### PR TITLE
Fixe MetaBeamElement for inheritance

### DIFF
--- a/xtrack/dress_element.py
+++ b/xtrack/dress_element.py
@@ -88,7 +88,13 @@ class MetaBeamElement(type):
 
     def __new__(cls, name, bases, data):
         XoStruct_name = name+'Data'
-        xofields = data['_xofields']
+        if '_xofields' in data.keys():
+            xofields = data['_xofields']
+        else:
+            for bb in bases:
+                if hasattr(bb,'_xofields'):
+                    xofields = bb._xofields
+                    break
         XoStruct = type(XoStruct_name, (xo.Struct,), xofields)
 
         bases = (dress_element(XoStruct),) + bases


### PR DESCRIPTION
In case of inheritance the meta class goes through the bases to find an attribute _xofields