### PR TITLE
Handle memory alignment

### DIFF
--- a/tests/test_aperture_turn_ele_and_monitor.py
+++ b/tests/test_aperture_turn_ele_and_monitor.py
@@ -1,19 +1,14 @@
 import numpy as np
 
 import xobjects as xo
-from xobjects.context import available
 import xtrack as xt
 import xline as xl
 
 
 def test_aperture_turn_ele_and_monitor():
 
-    for CTX in xo.ContextCpu, xo.ContextPyopencl, xo.ContextCupy:
-        if CTX not in available:
-            continue
-
-        print(f"Test {CTX}")
-        context = CTX()
+    for context in xo.context.get_test_contexts():
+        print(f"Test {context.__class__}")
 
         x_aper_min = -0.1
         x_aper_max = 0.2
@@ -117,12 +112,8 @@ def test_aperture_turn_ele_and_monitor():
 
 def test_custom_monitor():
 
-    for CTX in xo.ContextCpu, xo.ContextPyopencl, xo.ContextCupy:
-        if CTX not in available:
-            continue
-
-        print(f"Test {CTX}")
-        context = CTX()
+    for context in xo.context.get_test_contexts():
+        print(f"Test {context.__class__}")
 
         x_aper_min = -0.1
         x_aper_max = 0.2

--- a/tests/test_collective_tracker.py
+++ b/tests/test_collective_tracker.py
@@ -3,19 +3,14 @@ import json
 import numpy as np
 
 import xobjects as xo
-from xobjects.context import available
 import xline as xl
 import xtrack as xt
 import xfields as xf
 
 def test_collective_tracker():
 
-    for CTX in xo.ContextCpu, xo.ContextPyopencl, xo.ContextCupy:
-        if CTX not in available:
-            continue
-
-        print(f"Test {CTX}")
-        context = CTX()
+    for context in xo.context.get_test_contexts():
+        print(f"Test {context.__class__}")
 
         test_data_folder = pathlib.Path(
             __file__).parent.joinpath('../test_data').absolute()

--- a/tests/test_dress.py
+++ b/tests/test_dress.py
@@ -45,14 +45,16 @@ def test_explicit_buffer():
         def __init__(self, vv, **kwargs):
             self.xoinitialize(n=len(vv), b=np.sum(vv), vv=vv, **kwargs)
 
-    ele1 = Element([1,2,3])
-    ele2 = Element([7,8,9], _buffer=ele1._buffer)
+    for context in xo.context.get_test_contexts():
+        print(f"Test {context.__class__}")
+        ele1 = Element([1,2,3], _context=context)
+        ele2 = Element([7,8,9], _buffer=ele1._buffer)
 
-    assert ele1.vv[1] == ele1._xobject.vv[1] == 2
-    assert ele2.vv[1] == ele2._xobject.vv[1] == 8
-    for ee in [ele1, ele2]:
-        assert (ee._buffer is ee._xobject._buffer)
-        assert (ee._offset == ee._xobject._offset)
+        assert ele1.vv[1] == ele1._xobject.vv[1] == 2
+        assert ele2.vv[1] == ele2._xobject.vv[1] == 8
+        for ee in [ele1, ele2]:
+            assert (ee._buffer is ee._xobject._buffer)
+            assert (ee._offset == ee._xobject._offset)
 
-    assert ele1._buffer is ele2._buffer
-    assert ele1._offset != ele2._offset
+        assert ele1._buffer is ele2._buffer
+        assert ele1._offset != ele2._offset

--- a/tests/test_dress.py
+++ b/tests/test_dress.py
@@ -10,24 +10,28 @@ def test_dress():
 
     class Element(dress(ElementData)):
 
-        def __init__(self, vv):
-            self.xoinitialize(n=len(vv), b=np.sum(vv), vv=vv)
+        def __init__(self, vv, **kwargs):
+            self.xoinitialize(n=len(vv), b=np.sum(vv), vv=vv,
+                              **kwargs)
+    for context in xo.context.get_test_contexts():
+        print(f"Test {context.__class__}")
 
-    ele = Element([1,2,3])
-    assert ele.n == ele._xobject.n == 3
-    assert ele.b == ele._xobject.b == 6
-    assert ele.vv[1] == ele._xobject.vv[1] == 2
+        ele = Element([1,2,3], _context=context)
+        assert ele.n == ele._xobject.n == 3
+        assert ele.b == ele._xobject.b == 6
+        assert ele.vv[1] == ele._xobject.vv[1] == 2
 
-    ele.vv = [7,8,9]
-    assert ele.n == ele._xobject.n == 3
-    assert ele.b == ele._xobject.b == 6
-    assert ele.vv[1] == ele._xobject.vv[1] == 8
+        new_vv = context.nparray_to_context_array(np.array([7,8,9]))
+        ele.vv = new_vv
+        assert ele.n == ele._xobject.n == 3
+        assert ele.b == ele._xobject.b == 6
+        assert ele.vv[1] == ele._xobject.vv[1] == 8
 
-    ele.n = 5.
-    assert ele.n == ele._xobject.n == 5
+        ele.n = 5.
+        assert ele.n == ele._xobject.n == 5
 
-    ele.b = 50
-    assert ele.b == ele._xobject.b == 50.
+        ele.b = 50
+        assert ele.b == ele._xobject.b == 50.
 
 
 def test_explicit_buffer():

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -7,12 +7,8 @@ from xobjects.context import available
 
 def test_drift():
 
-    for CTX in xo.ContextCpu, xo.ContextPyopencl, xo.ContextCupy:
-        if CTX not in available:
-            continue
-
-        print(f"Test {CTX}")
-        ctx = CTX()
+    for ctx in xo.context.get_test_contexts():
+        print(f"Test {ctx.__class__}")
 
         pyst_particle = xl.Particles(
                 p0c=25.92e9,
@@ -40,12 +36,8 @@ def test_drift():
 
 def test_elens():
 
-   for CTX in xo.ContextCpu, xo.ContextPyopencl, xo.ContextCupy:
-        if CTX not in available:
-            continue
-
-        print(f"Test {CTX}")
-        ctx = CTX()
+    for ctx in xo.context.get_test_contexts():
+        print(f"Test {ctx.__class__}")
 
         pyst_particle = xl.Particles(
                 p0c=np.array([7000e9]),

--- a/tests/test_full_rings.py
+++ b/tests/test_full_rings.py
@@ -32,12 +32,8 @@ def test_full_rings(element_by_element=False):
         rtol_10turns, atol_10turns = tolerances_10_turns[icase]
 
         print('Case:', fname_line_particles)
-        for CTX in xo.ContextCpu, xo.ContextPyopencl, xo.ContextCupy:
-            if CTX not in available:
-                continue
-
-            print(f"Test {CTX}")
-            context = CTX()
+        for context in xo.context.get_test_contexts():
+            print(f"Test {context.__class__}")
 
             #############
             # Load file #

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -72,9 +72,11 @@ class Line():
             else: # needs to be converted
                 XtClass = seq_typename_to_xtclass(ee.__class__.__name__, external_elements)
                 if hasattr(XtClass, 'from_xline'):
-                    xt_ee = XtClass.from_xline(ee, _buffer=line_data._buffer)
+                    xt_ee = XtClass.from_xline(ee, _buffer=line_data._buffer,
+                                               _offset='packed')
                 else:
-                    xt_ee = XtClass(_buffer=line_data._buffer, **ee.to_dict())
+                    xt_ee = XtClass(_buffer=line_data._buffer, **ee.to_dict(),
+                                    _offset='packed')
             elements.append(xt_ee)
             line_data[ii] = xt_ee._xobject
 


### PR DESCRIPTION
New features:
 - Use ```get_test_contexts``` from xobjects
 - Use non-aligned objects in tracker instances, aligned objects elsewhere
