### PR TITLE
Adds DriftExact from pysixtrack / sixtracklib

### DIFF
--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -37,6 +37,21 @@ Drift.XoStruct.extra_sources = [
     _pkg_root.joinpath("beam_elements/elements_src/drift.h")
 ]
 
+
+class DriftExact(BeamElement):
+    """Beam element modeling a drift section without parabolic approximation. Parameters:
+
+    - length [m]: Length of the drift section. Default is ``0``.
+    """
+
+    _xofields = {"length": xo.Float64}
+
+
+DriftExact.XoStruct.extra_sources = [
+    _pkg_root.joinpath("beam_elements/elements_src/driftexact.h")
+]
+
+
 class Cavity(BeamElement):
     """Beam element modeling an RF cavity. Parameters:
 

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -8,149 +8,163 @@ from ..base_element import BeamElement
 from ..particles import ParticlesData
 from ..general import _pkg_root
 
+
 class ReferenceEnergyIncrease(BeamElement):
 
-    '''Beam element modeling a change of reference energy (acceleration, deceleration). Parameters:
+    """Beam element modeling a change of reference energy (acceleration, deceleration). Parameters:
 
-             - Delta_p0c [eV]: Change in reference energy. Default is ``0``.
-    '''
+    - Delta_p0c [eV]: Change in reference energy. Default is ``0``.
+    """
 
-    _xofields = {
-        'Delta_p0c': xo.Float64}
+    _xofields = {"Delta_p0c": xo.Float64}
+
 
 ReferenceEnergyIncrease.XoStruct.extra_sources = [
-        _pkg_root.joinpath('beam_elements/elements_src/referenceenergyincrease.h')]
+    _pkg_root.joinpath("beam_elements/elements_src/referenceenergyincrease.h")
+]
 
 
 class Drift(BeamElement):
-    '''Beam element modeling a drift section. Parameters:
+    """Beam element modeling a drift section. Parameters:
 
-             - length [m]: Length of the drift section. Default is ``0``.
-    '''
+    - length [m]: Length of the drift section. Default is ``0``.
+    """
 
-    _xofields = {
-        'length': xo.Float64}
+    _xofields = {"length": xo.Float64}
+
 
 Drift.XoStruct.extra_sources = [
-        _pkg_root.joinpath('beam_elements/elements_src/drift.h')]
+    _pkg_root.joinpath("beam_elements/elements_src/drift.h")
+]
 
 class Cavity(BeamElement):
-    '''Beam element modeling an RF cavity. Parameters:
+    """Beam element modeling an RF cavity. Parameters:
 
-             - voltage [V]: Voltage of the RF cavity. Default is ``0``.
-             - frequency [Hz]: Frequency of the RF cavity. Default is ``0``.
-             - lag [deg]: Phase seen by the reference particle. Default is ``0``.
-    '''
+    - voltage [V]: Voltage of the RF cavity. Default is ``0``.
+    - frequency [Hz]: Frequency of the RF cavity. Default is ``0``.
+    - lag [deg]: Phase seen by the reference particle. Default is ``0``.
+    """
 
     _xofields = {
-        'voltage': xo.Float64,
-        'frequency': xo.Float64,
-        'lag': xo.Float64,
-        }
+        "voltage": xo.Float64,
+        "frequency": xo.Float64,
+        "lag": xo.Float64,
+    }
+
 
 Cavity.XoStruct.extra_sources = [
-        _pkg_root.joinpath('headers/constants.h'),
-        _pkg_root.joinpath('beam_elements/elements_src/cavity.h')]
+    _pkg_root.joinpath("headers/constants.h"),
+    _pkg_root.joinpath("beam_elements/elements_src/cavity.h"),
+]
 
 
 class XYShift(BeamElement):
-    '''Beam element modeling an transverse shift of the reference system. Parameters:
+    """Beam element modeling an transverse shift of the reference system. Parameters:
 
-             - dx [m]: Horizontal shift. Default is ``0``.
-             - dy [m]: Vertical shift. Default is ``0``.
+    - dx [m]: Horizontal shift. Default is ``0``.
+    - dy [m]: Vertical shift. Default is ``0``.
 
-    '''
+    """
+
     _xofields = {
-        'dx': xo.Float64,
-        'dy': xo.Float64,
-        }
+        "dx": xo.Float64,
+        "dy": xo.Float64,
+    }
+
 
 XYShift.XoStruct.extra_sources = [
-        _pkg_root.joinpath('beam_elements/elements_src/xyshift.h')]
+    _pkg_root.joinpath("beam_elements/elements_src/xyshift.h")
+]
 
 
 ## ELECTRON LENS
 
-class Elens(BeamElement):
-# if array is needed we do it like this
-#    _xofields={'inner_radius': xo.Float64[:]}
-    _xofields={
-               'current':      xo.Float64,
-               'inner_radius': xo.Float64,
-               'outer_radius': xo.Float64,
-               'elens_length': xo.Float64,
-               'voltage':      xo.Float64
-              }
 
-    def __init__(self,  inner_radius = None,
-                        outer_radius = None,
-                        current      = None,
-                        elens_length = None,
-                        voltage      = None, **kwargs):
+class Elens(BeamElement):
+    # if array is needed we do it like this
+    #    _xofields={'inner_radius': xo.Float64[:]}
+    _xofields = {
+        "current": xo.Float64,
+        "inner_radius": xo.Float64,
+        "outer_radius": xo.Float64,
+        "elens_length": xo.Float64,
+        "voltage": xo.Float64,
+    }
+
+    def __init__(
+        self,
+        inner_radius=None,
+        outer_radius=None,
+        current=None,
+        elens_length=None,
+        voltage=None,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
-        self.inner_radius    = inner_radius
-        self.outer_radius    = outer_radius
-        self.current         = current
-        self.elens_length    = elens_length
-        self.voltage         = voltage
+        self.inner_radius = inner_radius
+        self.outer_radius = outer_radius
+        self.current = current
+        self.elens_length = elens_length
+        self.voltage = voltage
+
 
 Elens.XoStruct.extra_sources = [
-    _pkg_root.joinpath('beam_elements/elements_src/elens.h')]
-
-
+    _pkg_root.joinpath("beam_elements/elements_src/elens.h")
+]
 
 
 class SRotation(BeamElement):
-    '''Beam element modeling an rotation of the reference system around the s axis. Parameters:
+    """Beam element modeling an rotation of the reference system around the s axis. Parameters:
 
-                - angle [deg]: Rotation angle. Default is ``0``.
+    - angle [deg]: Rotation angle. Default is ``0``.
 
-    '''
+    """
 
-    _xofields={
-        'cos_z': xo.Float64,
-        'sin_z': xo.Float64,
-        }
+    _xofields = {
+        "cos_z": xo.Float64,
+        "sin_z": xo.Float64,
+    }
 
     def __init__(self, angle=0, **nargs):
         anglerad = angle / 180 * np.pi
-        nargs['cos_z']=np.cos(anglerad)
-        nargs['sin_z']=np.sin(anglerad)
+        nargs["cos_z"] = np.cos(anglerad)
+        nargs["sin_z"] = np.sin(anglerad)
         super().__init__(**nargs)
 
     @property
     def angle(self):
         return np.arctan2(self.sin_z, self.cos_z) * (180.0 / np.pi)
 
+
 SRotation.XoStruct.extra_sources = [
-        _pkg_root.joinpath('beam_elements/elements_src/srotation.h')]
+    _pkg_root.joinpath("beam_elements/elements_src/srotation.h")
+]
+
 
 class Multipole(BeamElement):
-    '''Beam element modeling a thin magnetic multipole. Parameters:
+    """Beam element modeling a thin magnetic multipole. Parameters:
 
-            - order [int]: Horizontal shift. Default is ``0``.
-            - knl [m^-n, array]: Normalized integrated strength of the normal components.
-            - ksl [m^-n, array]: Normalized integrated strength of the skew components.
-            - hxl [rad]: Rotation angle of the reference trajectoryin the horizzontal plane.
-            - hyl [rad]: Rotation angle of the reference trajectory in the vertical plane.
-            - length [m]: Length of the originating thick multipole.
+    - order [int]: Horizontal shift. Default is ``0``.
+    - knl [m^-n, array]: Normalized integrated strength of the normal components.
+    - ksl [m^-n, array]: Normalized integrated strength of the skew components.
+    - hxl [rad]: Rotation angle of the reference trajectoryin the horizzontal plane.
+    - hyl [rad]: Rotation angle of the reference trajectory in the vertical plane.
+    - length [m]: Length of the originating thick multipole.
 
-    '''
+    """
 
-    _xofields={
-        'order': xo.Int64,
-        'length': xo.Float64,
-        'hxl': xo.Float64,
-        'hyl': xo.Float64,
-        'radiation_flag': xo.Int64,
-        'bal': xo.Float64[:],
-        }
+    _xofields = {
+        "order": xo.Int64,
+        "length": xo.Float64,
+        "hxl": xo.Float64,
+        "hyl": xo.Float64,
+        "radiation_flag": xo.Int64,
+        "bal": xo.Float64[:],
+    }
 
     def __init__(self, order=None, knl=None, ksl=None, bal=None, **kwargs):
 
-        if bal is None and (
-            knl is not None or ksl is not None or order is not None
-        ):
+        if bal is None and (knl is not None or ksl is not None or order is not None):
             if knl is None:
                 knl = []
             if ksl is None:
@@ -190,10 +204,9 @@ class Multipole(BeamElement):
             kwargs["bal"] = bal
             kwargs["order"] = (len(bal) - 2) // 2
 
-
         # TODO: Remove when xobjects is fixed
-        kwargs["bal"] = list(kwargs['bal'])
-        self._temp_bal_length = len(kwargs['bal'])
+        kwargs["bal"] = list(kwargs["bal"])
+        self._temp_bal_length = len(kwargs["bal"])
 
         self.xoinitialize(**kwargs)
 
@@ -206,42 +219,44 @@ class Multipole(BeamElement):
     def ksl(self):
         idxes = np.array([ii for ii in range(0, self._temp_bal_length, 2)])
         return [self.bal[idx + 1] * factorial(idx // 2, exact=True) for idx in idxes]
-        #idx = np.array([ii for ii in range(0, len(self.bal), 2)])
-        #return self.bal[idx + 1] * factorial(idx // 2, exact=True)
+        # idx = np.array([ii for ii in range(0, len(self.bal), 2)])
+        # return self.bal[idx + 1] * factorial(idx // 2, exact=True)
+
 
 Multipole.XoStruct.extra_sources = [
-    _pkg_root.joinpath('random_number_generator/rng_src/base_rng.h'),
-    _pkg_root.joinpath('random_number_generator/rng_src/local_particle_rng.h'),
-    _pkg_root.joinpath('beam_elements/elements_src/multipole.h')]
+    _pkg_root.joinpath("random_number_generator/rng_src/base_rng.h"),
+    _pkg_root.joinpath("random_number_generator/rng_src/local_particle_rng.h"),
+    _pkg_root.joinpath("beam_elements/elements_src/multipole.h"),
+]
 
 
 class RFMultipole(BeamElement):
-    '''Beam element modeling a thin modulated multipole, with strengths dependent on the z coordinate:
+    """Beam element modeling a thin modulated multipole, with strengths dependent on the z coordinate:
 
-            kn(z) = k_n cos(2pi w tau + pn/180*pi)
+        kn(z) = k_n cos(2pi w tau + pn/180*pi)
 
-            ks[n](z) = k_n cos(2pi w tau + pn/180*pi)
+        ks[n](z) = k_n cos(2pi w tau + pn/180*pi)
 
-        Its parameters are:
+    Its parameters are:
 
-            - order [int]: Horizontal shift. Default is ``0``.
-            - frequency [Hz]: Frequency of the RF cavity. Default is ``0``.
-            - knl [m^-n, array]: Normalized integrated strength of the normal components.
-            - ksl [m^-n, array]: Normalized integrated strength of the skew components.
-            - pn [deg, array]: Phase of the normal components.
-            - ps [deg, array]: Phase of the skew components.
-            - voltage [V]: Longitudinal voltage. Default is ``0``.
-            - lag [deg]: Longitudinal phase seen by the reference particle. Default is ``0``.
+        - order [int]: Horizontal shift. Default is ``0``.
+        - frequency [Hz]: Frequency of the RF cavity. Default is ``0``.
+        - knl [m^-n, array]: Normalized integrated strength of the normal components.
+        - ksl [m^-n, array]: Normalized integrated strength of the skew components.
+        - pn [deg, array]: Phase of the normal components.
+        - ps [deg, array]: Phase of the skew components.
+        - voltage [V]: Longitudinal voltage. Default is ``0``.
+        - lag [deg]: Longitudinal phase seen by the reference particle. Default is ``0``.
 
-    '''
+    """
 
-    _xofields={
-        'order': xo.Int64,
-        'voltage': xo.Float64,
-        'frequency': xo.Float64,
-        'lag': xo.Float64,
-        'bal': xo.Float64[:],
-        'phase': xo.Float64[:],
+    _xofields = {
+        "order": xo.Int64,
+        "voltage": xo.Float64,
+        "frequency": xo.Float64,
+        "lag": xo.Float64,
+        "bal": xo.Float64[:],
+        "phase": xo.Float64[:],
     }
 
     def __init__(
@@ -253,7 +268,7 @@ class RFMultipole(BeamElement):
         ps=None,
         bal=None,
         p=None,
-        **kwargs
+        **kwargs,
     ):
         if bal is None and (
             knl is not None
@@ -334,7 +349,6 @@ class RFMultipole(BeamElement):
             kwargs["phase"] = p
             kwargs["order"] = (len(bal) - 2) / 2
 
-
         temp_bal = kwargs["bal"]
         temp_phase = kwargs["phase"]
 
@@ -383,35 +397,30 @@ class RFMultipole(BeamElement):
         assert order <= self.order
         self.phase[order * 2 + 1] = value
 
+
 RFMultipole.XoStruct.extra_sources = [
-        _pkg_root.joinpath('headers/constants.h'),
-        _pkg_root.joinpath('beam_elements/elements_src/rfmultipole.h')]
+    _pkg_root.joinpath("headers/constants.h"),
+    _pkg_root.joinpath("beam_elements/elements_src/rfmultipole.h"),
+]
 
 
 class DipoleEdge(BeamElement):
-    '''Beam element modeling a dipole edge. Parameters:
+    """Beam element modeling a dipole edge. Parameters:
 
-            - h [1/m]: Curvature.
-            - e1 [rad]: Face angle.
-            - hgap [m]: Equivalent gap.
-            - fint []: Fringe integral.
+    - h [1/m]: Curvature.
+    - e1 [rad]: Face angle.
+    - hgap [m]: Equivalent gap.
+    - fint []: Fringe integral.
 
-    '''
+    """
 
     _xofields = {
-            'r21': xo.Float64,
-            'r43': xo.Float64,
-            }
+        "r21": xo.Float64,
+        "r43": xo.Float64,
+    }
 
     def __init__(
-        self,
-        r21=None,
-        r43=None,
-        h=None,
-        e1=None,
-        hgap=None,
-        fint=None,
-        **kwargs
+        self, r21=None, r43=None, h=None, e1=None, hgap=None, fint=None, **kwargs
     ):
         if r21 is None and r43 is None:
             ZERO = np.float64(0.0)
@@ -438,8 +447,8 @@ class DipoleEdge(BeamElement):
             r43 = -h * np.tan(e1 - temp)
 
         if r21 is not None and r43 is not None:
-            kwargs['r21'] = r21
-            kwargs['r43'] = r43
+            kwargs["r21"] = r21
+            kwargs["r43"] = r43
             super().__init__(**kwargs)
         else:
             raise ValueError(
@@ -449,134 +458,165 @@ class DipoleEdge(BeamElement):
 
 
 DipoleEdge.XoStruct.extra_sources = [
-        _pkg_root.joinpath('beam_elements/elements_src/dipoleedge.h')]
+    _pkg_root.joinpath("beam_elements/elements_src/dipoleedge.h")
+]
 
 
 class LinearTransferMatrix(BeamElement):
-    _xofields={
-        'no_detuning': xo.Int64,
-        'q_x': xo.Float64,
-        'q_y': xo.Float64,
-        'cos_s': xo.Float64,
-        'sin_s': xo.Float64,
-        'beta_x_0': xo.Float64,
-        'beta_y_0': xo.Float64,
-        'beta_ratio_x': xo.Float64,
-        'beta_prod_x': xo.Float64,
-        'beta_ratio_y': xo.Float64,
-        'beta_prod_y': xo.Float64,
-        'alpha_x_0': xo.Float64,
-        'alpha_x_1': xo.Float64,
-        'alpha_y_0': xo.Float64,
-        'alpha_y_1': xo.Float64,
-        'disp_x_0': xo.Float64,
-        'disp_x_1': xo.Float64,
-        'disp_y_0': xo.Float64,
-        'disp_y_1': xo.Float64,
-        'beta_s': xo.Float64,
-        'energy_ref_increment': xo.Float64,
-        'energy_increment': xo.Float64,
-        'chroma_x': xo.Float64,
-        'chroma_y': xo.Float64,
-        'detx_x': xo.Float64,
-        'detx_y': xo.Float64,
-        'dety_y': xo.Float64,
-        'dety_x': xo.Float64
-        }
+    _xofields = {
+        "no_detuning": xo.Int64,
+        "q_x": xo.Float64,
+        "q_y": xo.Float64,
+        "cos_s": xo.Float64,
+        "sin_s": xo.Float64,
+        "beta_x_0": xo.Float64,
+        "beta_y_0": xo.Float64,
+        "beta_ratio_x": xo.Float64,
+        "beta_prod_x": xo.Float64,
+        "beta_ratio_y": xo.Float64,
+        "beta_prod_y": xo.Float64,
+        "alpha_x_0": xo.Float64,
+        "alpha_x_1": xo.Float64,
+        "alpha_y_0": xo.Float64,
+        "alpha_y_1": xo.Float64,
+        "disp_x_0": xo.Float64,
+        "disp_x_1": xo.Float64,
+        "disp_y_0": xo.Float64,
+        "disp_y_1": xo.Float64,
+        "beta_s": xo.Float64,
+        "energy_ref_increment": xo.Float64,
+        "energy_increment": xo.Float64,
+        "chroma_x": xo.Float64,
+        "chroma_y": xo.Float64,
+        "detx_x": xo.Float64,
+        "detx_y": xo.Float64,
+        "dety_y": xo.Float64,
+        "dety_x": xo.Float64,
+    }
 
-    def __init__(self, Q_x=0, Q_y=0,
-                     beta_x_0=1.0, beta_x_1=1.0, beta_y_0=1.0, beta_y_1=1.0,
-                     alpha_x_0=0.0, alpha_x_1=0.0, alpha_y_0=0.0, alpha_y_1=0.0,
-                     disp_x_0=0.0, disp_x_1=0.0, disp_y_0=0.0, disp_y_1=0.0,
-                     Q_s=0.0, beta_s=1.0,
-                     chroma_x=0.0, chroma_y=0.0,
-                     detx_x=0.0, detx_y=0.0, dety_y=0.0, dety_x=0.0,
-                     energy_increment=0.0, energy_ref_increment=0.0, **nargs):
+    def __init__(
+        self,
+        Q_x=0,
+        Q_y=0,
+        beta_x_0=1.0,
+        beta_x_1=1.0,
+        beta_y_0=1.0,
+        beta_y_1=1.0,
+        alpha_x_0=0.0,
+        alpha_x_1=0.0,
+        alpha_y_0=0.0,
+        alpha_y_1=0.0,
+        disp_x_0=0.0,
+        disp_x_1=0.0,
+        disp_y_0=0.0,
+        disp_y_1=0.0,
+        Q_s=0.0,
+        beta_s=1.0,
+        chroma_x=0.0,
+        chroma_y=0.0,
+        detx_x=0.0,
+        detx_y=0.0,
+        dety_y=0.0,
+        dety_x=0.0,
+        energy_increment=0.0,
+        energy_ref_increment=0.0,
+        **nargs,
+    ):
 
-        if (chroma_x==0 and chroma_y==0
-            and detx_x==0 and detx_y==0 and dety_y==0 and dety_x==0):
+        if (
+            chroma_x == 0
+            and chroma_y == 0
+            and detx_x == 0
+            and detx_y == 0
+            and dety_y == 0
+            and dety_x == 0
+        ):
 
-            cos_x = np.cos(2.0*np.pi*Q_x)
-            sin_x = np.sin(2.0*np.pi*Q_x)
-            cos_y = np.cos(2.0*np.pi*Q_y)
-            sin_y = np.sin(2.0*np.pi*Q_y)
+            cos_x = np.cos(2.0 * np.pi * Q_x)
+            sin_x = np.sin(2.0 * np.pi * Q_x)
+            cos_y = np.cos(2.0 * np.pi * Q_y)
+            sin_y = np.sin(2.0 * np.pi * Q_y)
 
-            nargs['no_detuning']  =  True
-            nargs['q_x'] = sin_x
-            nargs['q_y'] = sin_y
-            nargs['chroma_x'] = cos_x
-            nargs['chroma_y'] = cos_y
-            nargs['detx_x'] = 0.
-            nargs['detx_y'] = 0.
-            nargs['dety_y'] = 0.
-            nargs['dety_x'] = 0.
+            nargs["no_detuning"] = True
+            nargs["q_x"] = sin_x
+            nargs["q_y"] = sin_y
+            nargs["chroma_x"] = cos_x
+            nargs["chroma_y"] = cos_y
+            nargs["detx_x"] = 0.0
+            nargs["detx_y"] = 0.0
+            nargs["dety_y"] = 0.0
+            nargs["dety_x"] = 0.0
         else:
-            nargs['no_detuning']  =  False
-            nargs['q_x'] = Q_x
-            nargs['q_y'] = Q_y
-            nargs['chroma_x'] = chroma_x
-            nargs['chroma_y'] = chroma_y
-            nargs['detx_x'] = detx_x
-            nargs['detx_y'] = detx_y
-            nargs['dety_y'] = dety_y
-            nargs['dety_x'] = dety_x
+            nargs["no_detuning"] = False
+            nargs["q_x"] = Q_x
+            nargs["q_y"] = Q_y
+            nargs["chroma_x"] = chroma_x
+            nargs["chroma_y"] = chroma_y
+            nargs["detx_x"] = detx_x
+            nargs["detx_y"] = detx_y
+            nargs["dety_y"] = dety_y
+            nargs["dety_x"] = dety_x
 
         if Q_s is not None:
-            nargs['cos_s'] = np.cos(2.0*np.pi*Q_s)
-            nargs['sin_s'] = np.sin(2.0*np.pi*Q_s)
+            nargs["cos_s"] = np.cos(2.0 * np.pi * Q_s)
+            nargs["sin_s"] = np.sin(2.0 * np.pi * Q_s)
         else:
-            nargs['cos_s'] = 999
-            nargs['sin_s'] = 0.
+            nargs["cos_s"] = 999
+            nargs["sin_s"] = 0.0
 
-        nargs['beta_x_0'] = beta_x_0
-        nargs['beta_y_0'] = beta_y_0
-        nargs['beta_ratio_x'] = np.sqrt(beta_x_1/beta_x_0)
-        nargs['beta_prod_x'] = np.sqrt(beta_x_1*beta_x_0)
-        nargs['beta_ratio_y'] = np.sqrt(beta_y_1/beta_y_0)
-        nargs['beta_prod_y'] = np.sqrt(beta_y_1*beta_y_0)
-        nargs['alpha_x_0'] = alpha_x_0
-        nargs['alpha_x_1'] = alpha_x_1
-        nargs['alpha_y_0'] = alpha_y_0
-        nargs['alpha_y_1'] = alpha_y_1
-        nargs['disp_x_0'] = disp_x_0
-        nargs['disp_x_1'] = disp_x_1
-        nargs['disp_y_0'] = disp_y_0
-        nargs['disp_y_1'] = disp_y_1
-        nargs['beta_s'] = beta_s
+        nargs["beta_x_0"] = beta_x_0
+        nargs["beta_y_0"] = beta_y_0
+        nargs["beta_ratio_x"] = np.sqrt(beta_x_1 / beta_x_0)
+        nargs["beta_prod_x"] = np.sqrt(beta_x_1 * beta_x_0)
+        nargs["beta_ratio_y"] = np.sqrt(beta_y_1 / beta_y_0)
+        nargs["beta_prod_y"] = np.sqrt(beta_y_1 * beta_y_0)
+        nargs["alpha_x_0"] = alpha_x_0
+        nargs["alpha_x_1"] = alpha_x_1
+        nargs["alpha_y_0"] = alpha_y_0
+        nargs["alpha_y_1"] = alpha_y_1
+        nargs["disp_x_0"] = disp_x_0
+        nargs["disp_x_1"] = disp_x_1
+        nargs["disp_y_0"] = disp_y_0
+        nargs["disp_y_1"] = disp_y_1
+        nargs["beta_s"] = beta_s
         # acceleration with change of reference momentum
-        nargs['energy_ref_increment'] = energy_ref_increment
+        nargs["energy_ref_increment"] = energy_ref_increment
         # acceleration without change of reference momentum
-        nargs['energy_increment'] = energy_increment
+        nargs["energy_increment"] = energy_increment
 
         super().__init__(**nargs)
 
     @property
     def Q_s(self):
-        return np.arccos(self.cos_s) / (2*np.pi)
+        return np.arccos(self.cos_s) / (2 * np.pi)
 
     @property
     def beta_x_1(self):
-        return self.beta_prod_x*self.beta_ratio_x
+        return self.beta_prod_x * self.beta_ratio_x
 
     @property
     def beta_y_1(self):
-        return self.beta_prod_y*self.beta_ratio_y
+        return self.beta_prod_y * self.beta_ratio_y
+
 
 LinearTransferMatrix.XoStruct.extra_sources = [
-        _pkg_root.joinpath('beam_elements/elements_src/lineartransfermatrix.h')]
+    _pkg_root.joinpath("beam_elements/elements_src/lineartransfermatrix.h")
+]
+
 
 class EnergyChange(BeamElement):
-    _xofields={
-        'energy_ref_increment': xo.Float64,
-        'energy_increment': xo.Float64
-        }
+    _xofields = {"energy_ref_increment": xo.Float64, "energy_increment": xo.Float64}
 
-    def __init__(self, energy_increment=0.0,energy_ref_increment=0.0, **nargs):
-        nargs['energy_ref_increment']=energy_ref_increment # acceleration with change of reference momentum (e.g. ramp)
-        nargs['energy_increment']=energy_increment # acceleration without change of reference momentum (e.g. compensation of energy loss)
+    def __init__(self, energy_increment=0.0, energy_ref_increment=0.0, **nargs):
+        nargs[
+            "energy_ref_increment"
+        ] = energy_ref_increment  # acceleration with change of reference momentum (e.g. ramp)
+        nargs[
+            "energy_increment"
+        ] = energy_increment  # acceleration without change of reference momentum (e.g. compensation of energy loss)
         super().__init__(**nargs)
 
+
 EnergyChange.XoStruct.extra_sources = [
-        _pkg_root.joinpath('beam_elements/elements_src/energychange.h')]
-
-
+    _pkg_root.joinpath("beam_elements/elements_src/energychange.h")
+]

--- a/xtrack/beam_elements/elements_src/driftexact.h
+++ b/xtrack/beam_elements/elements_src/driftexact.h
@@ -1,0 +1,28 @@
+#ifndef XTRACK_DRIFT_EXACT_H
+#define XTRACK_DRIFT_EXACT_H
+
+/*gpufun*/
+void Drift_track_local_particle(DriftData el, LocalParticle* part0){
+
+    double const length = DriftExactData_get_length( el );
+
+    //start_per_particle_block (part0->part)
+
+        double const px = LocalParticle_get_px( part );
+        double const py = LocalParticle_get_py( part );
+        double const delta_plus_1 = LocalParticle_get_delta( part )
+                                  + ( double )1.0;
+
+        double const lpzi = length / sqrt(
+            ( delta_plus_1 * delta_plus_1 ) - ( px * px ) - ( py * py ) );
+
+        LocalParticle_add_to_s(part, length);
+        LocalParticle_add_to_x(part, px * lpzi );
+        LocalParticle_add_to_y(part, py * lpzi );
+        LocalParticle_add_to_zeta( part,
+            LocalParticle_get_rvv( part ) * length - delta_plus_1 * lpzi; );
+
+    //end_per_particle_block
+}
+
+#endif /* XTRACK_DRIFT_EXACT_H */


### PR DESCRIPTION
Adds a DriftExact beam-element. This is required to perform simulations with lattices where the parabolic approximation is not upheld (e.g., SIS100 at GSI, for example). 