### PR TITLE
Qs in twiss and particle_ref attached to line

### DIFF
--- a/examples/twiss/000_twiss.py
+++ b/examples/twiss/000_twiss.py
@@ -15,7 +15,7 @@ fname_line_particles = '../../test_data/hllhc15_noerrors_nobb/line_and_particle.
 with open(fname_line_particles, 'r') as fid:
     input_data = json.load(fid)
 line = xt.Line.from_dict(input_data['line'])
-particle_ref = xp.Particles.from_dict(input_data['particle'])
+line.particle_ref = xp.Particles.from_dict(input_data['particle'])
 
 #################
 # Build tracker #
@@ -27,7 +27,7 @@ tracker = xt.Tracker(line=line)
 # Twiss #
 #########
 
-tw = tracker.twiss(particle_ref=particle_ref)
+tw = tracker.twiss()
 
 #!end-doc-part
 

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -28,7 +28,7 @@ def test_twiss():
     line = xt.Line.from_madx_sequence(
             mad.sequence['lhcb1'], apply_madx_errors=True)
     line.elements[10].iscollective = True # we make it artificially collective to test this option
-    part_ref = xp.Particles(mass0=xp.PROTON_MASS_EV, q0=1,
+    line.particle_ref = xp.Particles(mass0=xp.PROTON_MASS_EV, q0=1,
                             gamma0=mad.sequence.lhcb1.beam.gamma)
 
     for context in xo.context.get_test_contexts():
@@ -37,7 +37,7 @@ def test_twiss():
         tracker = xt.Tracker(_context=context, line=line)
         assert tracker.iscollective
 
-        twxt = tracker.twiss(particle_ref=part_ref)
+        twxt = tracker.twiss()
         assert np.isclose(mad.table.summ.q1[0], twxt['qx'], rtol=1e-4, atol=0)
         assert np.isclose(mad.table.summ.q2[0], twxt['qy'], rtol=1e-4, atol=0)
         assert np.isclose(mad.table.summ.dq1, twxt['dqx'], atol=0.1, rtol=0)
@@ -45,6 +45,7 @@ def test_twiss():
         assert np.isclose(mad.table.summ.alfa[0],
             twxt['momentum_compaction_factor'],
             atol=2e-10, rtol=0)
+        assert np.isclose(twxt['qs'], 0.0021, atol=1e-4, rtol=0)
 
         for name in ['mb.b19r5.b1', 'mb.b19r1.b1',
                     'ip1', 'ip2', 'ip5', 'ip8',

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -2,6 +2,7 @@ import json
 import numpy as np
 
 import xobjects as xo
+import xpart as xp
 
 from .loader_sixtrack import _expand_struct
 from .loader_mad import iter_from_madx_sequence
@@ -67,6 +68,9 @@ class Line:
                newel = eltype.from_dict(eldct)
             self.elements.append(newel)
         self.element_names = dct["element_names"]
+        if 'particle_ref' in dct.keys():
+            line.particle_ref = xp.Particles.from_dict(dct['particle_ref'],
+                                    _buffer=_buffer.context)
         return self
 
 
@@ -120,7 +124,7 @@ class Line:
 
         return line
 
-    def __init__(self, elements=(), element_names=None):
+    def __init__(self, elements=(), element_names=None, particle_ref=None):
         if isinstance(elements,dict):
             element_dict=elements
             if element_names is None:
@@ -141,6 +145,8 @@ class Line:
 
         self._vars={} #TODO xdeps
         self._manager=None # TODO xdeps
+
+        self.particle_ref = particle_ref
 
     def filter_elements(self, mask=None, exclude_types_starting_with=None):
 
@@ -203,6 +209,8 @@ class Line:
         out = {}
         out["elements"] = [el.to_dict() for el in self.elements]
         out["element_names"] = self.element_names[:]
+        if self.particle_ref is not None:
+            out['particle_ref'] = particle_ref.to_dict()
         return out
 
 

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -266,6 +266,10 @@ class Tracker:
 
     def find_closed_orbit(self, particle_co_guess=None, particle_ref=None,
                           co_search_settings={}):
+
+        if particle_ref is None:
+            particle_ref = self.particle_ref
+
         return find_closed_orbit(self, particle_co_guess=particle_co_guess,
                                  particle_ref=particle_ref,
                                  co_search_settings=co_search_settings)
@@ -276,7 +280,7 @@ class Tracker:
         return compute_one_turn_matrix_finite_differences(self, particle_on_co,
                                                    steps_r_matrix)
 
-    def twiss(self, particle_ref, r_sigma=0.01,
+    def twiss(self, particle_ref=None, r_sigma=0.01,
         nemitt_x=1e-6, nemitt_y=1e-6,
         n_theta=1000, delta_disp=1e-5, delta_chrom=1e-4,
         particle_co_guess=None, steps_r_matrix=None,
@@ -292,6 +296,8 @@ class Tracker:
         else:
             tracker = self
 
+        if particle_ref is None:
+            particle_ref = self.particle_ref
 
         return twiss_from_tracker(tracker, particle_ref, r_sigma=r_sigma,
             nemitt_x=nemitt_x, nemitt_y=nemitt_y,
@@ -364,6 +370,10 @@ class Tracker:
                     global_xy_limit=self.global_xy_limit,
                     local_particle_src=self.local_particle_src,
                 )
+
+    @property
+    def particle_ref(self):
+        return self.line.particle_ref
 
     def _build_kernel(self, save_source_as):
 

--- a/xtrack/twiss_from_tracker.py
+++ b/xtrack/twiss_from_tracker.py
@@ -226,6 +226,8 @@ def twiss_from_tracker(tracker, particle_ref, r_sigma=0.01,
     dqx = (qx_chrom_plus - qx_chrom_minus)/delta_chrom/2
     dqy = (qy_chrom_plus - qy_chrom_minus)/delta_chrom/2
 
+    qs = np.angle(np.linalg.eig(Rot)[0][4])/(2*np.pi)
+
     twiss_res = {
         'name': tracker.line.element_names,
         's': s,
@@ -247,6 +249,7 @@ def twiss_from_tracker(tracker, particle_ref, r_sigma=0.01,
         'muy': muy,
         'qx': mux[-1],
         'qy': muy[-1],
+        'qs': qs,
         'dqx': dqx,
         'dqy': dqy,
         'slip_factor': eta,


### PR DESCRIPTION
**New features**
 - Qs added to results of ```Tracker.twiss```.
 - ```particle_ref``` can be optionally attached to the line. In that case it can be omitted when calling ```Tracker.twiss``` and ```Tracker.find_closed_orbit```.