### PR TITLE
v0.9.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extensions = []
 
 setup(
     name='xtrack',
-    version='0.9.1',
+    version='0.9.2',
     description='Tracking library for particle accelerators',
     url='https://github.com/xsuite/xtrack',
     author='Riccard De Maria, Giovanni Iadarola',

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -54,6 +54,17 @@ def test_insert():
                 ['e0_part0', 'inserted_drift', 'e1', 'e2', 'e3', 'e4']))])
     assert line.get_length() == line.get_s_elements(mode='downstream')[-1] == 5
 
+    line = line0.copy()
+    line.insert_element(element=xt.LimitEllipse(a=1, b=1), at_s=2.1, name='aper')
+    assert line.get_s_position('aper') == 2.1
+    assert line.get_length() == line.get_s_elements(mode='downstream')[-1] == 5
+    assert np.all([nn==nnref for nn, nnref in list(zip(line.element_names,
+                ['e0', 'e1', 'e2_part0', 'aper', 'e2_part1', 'e3', 'e4']))])
+    line.insert_element(element=xt.Drift(length=0.8), at_s=1.9, name="newdrift")
+    assert line.get_s_position('newdrift') == 1.9
+    assert np.all([nn==nnref for nn, nnref in list(zip(line.element_names,
+                ['e0', 'e1_part0', 'newdrift', 'e2_part1_part1', 'e3', 'e4']))])
+
     # Check preservation of markers
     elements = []
     enames = []
@@ -76,7 +87,7 @@ def test_insert():
     line.insert_element(element=xt.Cavity(), at_s=3.0, name='cav1')
     assert len(line.elements) == 12
     assert np.all([nn==nnref for nn, nnref in list(zip(line.element_names,
-        ['d0', 'm0', 'inserted_drift', 'm1', 'd2', 'm2', 'cav0', 'cav1', 'd3',
+        ['d0', 'm0', 'inserted_drift', 'm1', 'd2', 'cav1', 'cav0', 'm2', 'd3',
         'm3', 'd4', 'm4']))])
     assert line.get_length() == line.get_s_elements(mode='downstream')[-1] == 5
     assert line.get_s_position('cav0') == 3.

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -1,7 +1,7 @@
 import numpy as np
 import xtrack as xt
 
-def test_merge_consecutive_drifts():
+def test_simplification_methods():
 
     line = xt.Line(
         elements = [xt.Drift(length=1) for _ in range(5)]
@@ -12,6 +12,26 @@ def test_merge_consecutive_drifts():
     assert np.isclose(line[0].length, 3.3, rtol=0, atol=1e-12)
     assert isinstance(line[1], xt.Cavity)
     assert np.isclose(line[2].length, 1.7, rtol=0, atol=1e-12)
+
+    line.insert_element(element=xt.Drift(length=0), name="marker", at_s=3.3)
+    assert len(line.element_names) == 4
+    line.remove_zero_length_drifts(inplace=True)
+    assert len(line.element_names) == 3
+
+    line.insert_element(element=xt.Multipole(knl=[1, 0, 3], ksl=[0, 20, 0]), name="m1", at_s=3.3)
+    line.insert_element(element=xt.Multipole(knl=[4, 2], ksl=[10, 40]), name="m2", at_s=3.3)
+    assert len(line.element_names) == 5
+    line.merge_consecutive_multipoles(inplace=True)
+    assert len(line.element_names) == 4
+    assert np.allclose(line[1].knl, [5,2,3], rtol=0, atol=1e-15)
+    assert np.allclose(line[1].ksl, [10,60,0], rtol=0, atol=1e-15)
+
+    line.remove_inactive_multipoles(inplace=True)
+    assert len(line.element_names) == 4
+    line[1].knl[:] = 0
+    line[1].ksl[:] = 0
+    line.remove_inactive_multipoles(inplace=True)
+    assert len(line.element_names) == 3
 
 def test_insert():
 

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -1,6 +1,18 @@
 import numpy as np
 import xtrack as xt
 
+def test_merge_consecutive_drifts():
+
+    line = xt.Line(
+        elements = [xt.Drift(length=1) for _ in range(5)]
+    )
+    line.insert_element(element=xt.Cavity(), name="cav", at_s=3.3)
+    line.merge_consecutive_drifts(inplace=True)
+    assert line.get_length() == line.get_s_elements(mode='downstream')[-1] == 5
+    assert np.isclose(line[0].length, 3.3, rtol=0, atol=1e-12)
+    assert isinstance(line[1], xt.Cavity)
+    assert np.isclose(line[2].length, 1.7, rtol=0, atol=1e-12)
+
 def test_insert():
 
     line0 = xt.Line(

--- a/tests/test_vs_madx.py
+++ b/tests/test_vs_madx.py
@@ -96,6 +96,21 @@ def test_twiss():
                               atol=1e-7, rtol=0)
             assert np.isclose(twxt['py'][ixt], twmad['py'][imad],
                               atol=1e-7, rtol=0)
+
+        # Test custom s locations
+        s_test = [2e3, 1e3, 3e3, 10e3]
+        twats = tracker.twiss(at_s = s_test)
+        for ii, ss in enumerate(s_test):
+            assert np.isclose(twats['s'][ii], ss, rtol=0, atol=1e-14)
+            assert np.isclose(twats['alfx'][ii], np.interp(ss, twxt['s'], twxt['alfx']),
+                            rtol=1e-5, atol=0)
+            assert np.isclose(twats['alfy'][ii], np.interp(ss, twxt['s'], twxt['alfy']),
+                            rtol=1e-5, atol=0)
+            assert np.isclose(twats['dpx'][ii], np.interp(ss, twxt['s'], twxt['dpx']),
+                            rtol=1e-5, atol=0)
+            assert np.isclose(twats['dpy'][ii], np.interp(ss, twxt['s'], twxt['dpy']),
+                            rtol=1e-5, atol=0)
+
 def norm(x):
     return np.sqrt(np.sum(np.array(x) ** 2))
 

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -296,7 +296,6 @@ class Line:
     def copy(self):
         return self.__class__.from_dict(self.to_dict())
 
-    @profile
     def insert_element(self, index=None, element=None, name=None, at_s=None):
 
         assert name is not None

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -206,7 +206,14 @@ class Line:
         return tuple([self.element_dict[nn] for nn in self.element_names])
 
     def __getitem__(self, ii):
-        return self.element_dict.__getitem__(ii)
+        if isinstance(ii, str):
+            return self.element_dict.__getitem__(ii)
+        else:
+            names = self.element_names.__getitem__(ii)
+            if isinstance(names, str):
+                return self.element_dict.__getitem__(names)
+            else:
+                return [self.element_dict[nn] for nn in names]
 
     def filter_elements(self, mask=None, exclude_types_starting_with=None):
 

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -347,7 +347,9 @@ class Line:
             assert _is_drift(last_drift_to_cut)
 
             for ii in range(i_first_drift_to_cut, i_last_drift_to_cut+1):
-                if not _is_drift(self.element_dict[self.element_names[ii]]):
+                e_to_replace = self.element_dict[self.element_names[ii]]
+                if (not _is_drift(e_to_replace) and
+                    not e_to_replace.__class__.__name__.startswith('Limit')):
                     raise ValueError('Cannot replace active element '
                                         f'{self.element_names[ii]}')
 

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -388,7 +388,7 @@ class Line:
                     self.element_names.insert(i_insert, nn)
 
         else:
-            if _is_thick(element) and np.abs(element.length):
+            if _is_thick(element) and np.abs(element.length)>0:
                 raise NotImplementedError('use `at_s` to insert thick elements')
             assert name not in self.element_dict.keys()
             self.element_dict[name] = element

--- a/xtrack/loader_mad.py
+++ b/xtrack/loader_mad.py
@@ -198,10 +198,10 @@ def madx_sequence_to_xtrack_line(
                         _lref[eename].ksl[ii] = madeval(eepar.ksl.expr[ii])
                 for ii, _ in enumerate(ee.pnl):
                     if eepar.pn.expr[ii] is not None:
-                        _lref[eename].pn[ii] = madeval(eepar.pn.expr[ii]) * 360
+                        _lref[eename].pn[ii] = madeval(eepar.pnl.expr[ii]) * 360
                 for ii, _ in enumerate(ee.psl):
                     if eepar.ps.expr[ii] is not None:
-                        _lref[eename].ps[ii] = madeval(eepar.ps.expr[ii]) * 360
+                        _lref[eename].ps[ii] = madeval(eepar.psl.expr[ii]) * 360
 
 
         elif mad_etype == "wire":

--- a/xtrack/loader_mad.py
+++ b/xtrack/loader_mad.py
@@ -51,6 +51,7 @@ def madx_sequence_to_xtrack_line(
 
     old_pp = 0.0
     i_drift = 0
+    counters = {}
     for pp, ee in sorted(zip(ele_pos,elements),key=lambda x:x[0]):
         skiptilt=False
 
@@ -59,8 +60,15 @@ def madx_sequence_to_xtrack_line(
             old_pp = pp
             i_drift += 1
 
-        eename = ee.name
+        eename_mad = ee.name
         mad_etype = ee.base_type.name
+
+        if eename_mad not in counters.keys():
+            eename = eename_mad
+            counters[eename_mad] = 0
+        else:
+            counters[eename_mad] += 1
+            eename = eename_mad + f'_{counters[eename_mad]}'
 
         if mad_etype in [
             "marker",

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -16,6 +16,8 @@ import xpart as xp
 from .beam_elements import Drift
 from .line import Line
 
+from . import linear_normal_form as lnf
+
 logger = logging.getLogger(__name__)
 
 def _check_is_collective(ele):
@@ -308,6 +310,8 @@ class Tracker:
         particle_co_guess=None, steps_r_matrix=None,
         co_search_settings=None, at_elements=None, at_s=None,
         eneloss_and_damping=False,
+        matrix_responsiveness_tol=lnf.DEFAULT_MATRIX_RESPONSIVENESS_TOL,
+        matrix_stability_tol=lnf.DEFAULT_MATRIX_STABILITY_TOL,
         symplectify=False
         ):
 
@@ -336,6 +340,8 @@ class Tracker:
             co_search_settings=co_search_settings,
             at_elements=at_elements, at_s=at_s,
             eneloss_and_damping=eneloss_and_damping,
+            matrix_responsiveness_tol=matrix_responsiveness_tol,
+            matrix_stability_tol=matrix_stability_tol,
             symplectify=symplectify)
 
 

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -86,6 +86,9 @@ class Tracker:
                 local_particle_src=local_particle_src,
                 save_source_as=save_source_as)
 
+        self.matrix_responsiveness_tol = lnf.DEFAULT_MATRIX_RESPONSIVENESS_TOL
+        self.matrix_stability_tol = lnf.DEFAULT_MATRIX_STABILITY_TOL
+
     def _init_track_with_collective(
         self,
         _context=None,
@@ -310,10 +313,15 @@ class Tracker:
         particle_co_guess=None, steps_r_matrix=None,
         co_search_settings=None, at_elements=None, at_s=None,
         eneloss_and_damping=False,
-        matrix_responsiveness_tol=lnf.DEFAULT_MATRIX_RESPONSIVENESS_TOL,
-        matrix_stability_tol=lnf.DEFAULT_MATRIX_STABILITY_TOL,
+        matrix_responsiveness_tol=None,
+        matrix_stability_tol=None,
         symplectify=False
         ):
+
+        if matrix_responsiveness_tol is None:
+            matrix_responsiveness_tol = self.matrix_responsiveness_tol
+        if matrix_stability_tol is None:
+            matrix_stability_tol = self.matrix_stability_tol
 
         if self.iscollective:
             logger.warning(

--- a/xtrack/twiss_from_tracker.py
+++ b/xtrack/twiss_from_tracker.py
@@ -66,6 +66,8 @@ def find_closed_orbit(tracker, particle_co_guess=None, particle_ref=None,
                 **co_search_settings)
         fsolve_info = {
             'res': res, 'info': infodict, 'ier': ier, 'mesg': mesg}
+        if ier == 1:
+            break
 
     if ier != 1:
         raise ClosedOrbitSearchError
@@ -167,9 +169,11 @@ def _build_auxiliary_tracker_with_extra_markers(tracker, at_s, marker_prefix,
         markers.append(xt.Drift(length=0))
 
     if algorithm == 'insert':
-        for nn, mm in zip(names_inserted_markers, markers):
+        print('Here')
+        for nn, mm, ss in zip(names_inserted_markers, markers, at_s):
             auxline.insert_element(element=mm, name=nn, at_s=ss)
     elif algorithm == 'regen_all_drifts':
+        prrrr
         s_elems = auxline.get_s_elements()
         s_keep = []
         enames_keep = []
@@ -462,6 +466,7 @@ def twiss_from_tracker(tracker, particle_ref, r_sigma=0.01,
         'R_matrix': RR,
         'particle_on_co':part_on_co.copy(_context=xo.context_default)
     }
+    twiss_res['particle_on_co']._fsolve_info = part_on_co._fsolve_info
 
     if eneloss_and_damping:
         twiss_res.update(eneloss_damp_res)

--- a/xtrack/twiss_from_tracker.py
+++ b/xtrack/twiss_from_tracker.py
@@ -151,7 +151,6 @@ def _build_auxiliary_tracker_with_extra_markers(tracker, at_s, marker_prefix):
     auxline = xt.Line(elements=list(tracker.line.elements).copy(),
                       element_names=list(tracker.line.element_names).copy())
 
-    import pdb; pdb.set_trace()
     names_inserted_markers = []
     for ii, ss in enumerate(at_s):
         nn = marker_prefix + f'{ii}'

--- a/xtrack/twiss_from_tracker.py
+++ b/xtrack/twiss_from_tracker.py
@@ -169,11 +169,9 @@ def _build_auxiliary_tracker_with_extra_markers(tracker, at_s, marker_prefix,
         markers.append(xt.Drift(length=0))
 
     if algorithm == 'insert':
-        print('Here')
         for nn, mm, ss in zip(names_inserted_markers, markers, at_s):
             auxline.insert_element(element=mm, name=nn, at_s=ss)
     elif algorithm == 'regen_all_drifts':
-        prrrr
         s_elems = auxline.get_s_elements()
         s_keep = []
         enames_keep = []
@@ -196,7 +194,7 @@ def _build_auxiliary_tracker_with_extra_markers(tracker, at_s, marker_prefix,
         new_ele_dict.update({nn: ee for nn, ee in zip(names_inserted_markers, markers)})
         s_curr = 0
         for ss, nn in zip(s_keep, enames_keep):
-            if ss > s_curr + 1e-4:
+            if ss > s_curr + 1e-6:
                 new_drift = xt.Drift(length=ss-s_curr)
                 new_dname = f'_auxrift_{i_new_drift}'
                 new_ele_dict[new_dname] = new_drift

--- a/xtrack/twiss_from_tracker.py
+++ b/xtrack/twiss_from_tracker.py
@@ -297,6 +297,8 @@ def twiss_from_tracker(tracker, particle_ref, r_sigma=0.01,
         particle_on_co=part_on_co,
         scale_with_transverse_norm_emitt=(nemitt_x, nemitt_y),
         R_matrix=RR,
+        matrix_responsiveness_tol=matrix_responsiveness_tol,
+        matrix_stability_tol=matrix_stability_tol,
         symplectify=symplectify)
 
     part_for_twiss = xp.Particles.merge([part_for_twiss, part_disp])
@@ -356,13 +358,18 @@ def twiss_from_tracker(tracker, particle_ref, r_sigma=0.01,
                 zeta=part_on_co._xobject.zeta[0], delta=delta_chrom,
                 particle_on_co=part_on_co,
                 scale_with_transverse_norm_emitt=(nemitt_x, nemitt_y),
-                R_matrix=RR, symplectify=symplectify)
+                R_matrix=RR,
+                matrix_stability_tol=matrix_stability_tol,
+                matrix_responsiveness_tol=matrix_responsiveness_tol,
+                symplectify=symplectify)
     RR_chrom_plus = tracker.compute_one_turn_matrix_finite_differences(
                                             particle_on_co=part_chrom_plus.copy(),
                                             steps_r_matrix=steps_r_matrix)
     (WW_chrom_plus, WWinv_chrom_plus, Rot_chrom_plus
-        ) = compute_linear_normal_form(RR_chrom_plus,
-                                          symplectify=symplectify)
+        ) = lnf.compute_linear_normal_form(RR_chrom_plus,
+                                        responsiveness_tol=matrix_responsiveness_tol,
+                                        stability_tol=matrix_stability_tol,
+                                        symplectify=symplectify)
     qx_chrom_plus = np.angle(np.linalg.eig(Rot_chrom_plus)[0][0])/(2*np.pi)
     qy_chrom_plus = np.angle(np.linalg.eig(Rot_chrom_plus)[0][2])/(2*np.pi)
 
@@ -372,13 +379,18 @@ def twiss_from_tracker(tracker, particle_ref, r_sigma=0.01,
                 zeta=part_on_co._xobject.zeta[0], delta=-delta_chrom,
                 particle_on_co=part_on_co,
                 scale_with_transverse_norm_emitt=(nemitt_x, nemitt_y),
-                R_matrix=RR, symplectify=symplectify)
+                R_matrix=RR,
+                matrix_responsiveness_tol=matrix_responsiveness_tol,
+                matrix_stability_tol=matrix_stability_tol,
+                symplectify=symplectify)
     RR_chrom_minus = tracker.compute_one_turn_matrix_finite_differences(
                                         particle_on_co=part_chrom_minus.copy(),
                                         steps_r_matrix=steps_r_matrix)
     (WW_chrom_minus, WWinv_chrom_minus, Rot_chrom_minus
-        ) = compute_linear_normal_form(RR_chrom_minus,
-                                          symplectify=symplectify)
+        ) = lnf.compute_linear_normal_form(RR_chrom_minus,
+                                          symplectify=symplectify,
+                                          stability_tol=matrix_stability_tol,
+                                          responsiveness_tol=matrix_responsiveness_tol)
     qx_chrom_minus = np.angle(np.linalg.eig(Rot_chrom_minus)[0][0])/(2*np.pi)
     qy_chrom_minus = np.angle(np.linalg.eig(Rot_chrom_minus)[0][2])/(2*np.pi)
 

--- a/xtrack/twiss_from_tracker.py
+++ b/xtrack/twiss_from_tracker.py
@@ -7,7 +7,7 @@ import xpart as xp
 from scipy.optimize import fsolve
 from scipy.constants import c as clight
 
-from .linear_normal_form import compute_linear_normal_form
+from . import linear_normal_form as lnf
 
 import xtrack as xt # To avoid circular imports
 
@@ -225,6 +225,8 @@ def twiss_from_tracker(tracker, particle_ref, r_sigma=0.01,
         particle_co_guess=None, steps_r_matrix=None,
         co_search_settings=None, at_elements=None, at_s=None,
         eneloss_and_damping=False,
+        matrix_responsiveness_tol=lnf.DEFAULT_MATRIX_RESPONSIVENESS_TOL,
+        matrix_stability_tol=lnf.DEFAULT_MATRIX_STABILITY_TOL,
         symplectify=False):
 
     if at_s is not None:
@@ -269,7 +271,9 @@ def twiss_from_tracker(tracker, particle_ref, r_sigma=0.01,
     gemitt_x = nemitt_x/part_on_co._xobject.beta0[0]/part_on_co._xobject.gamma0[0]
     gemitt_y = nemitt_y/part_on_co._xobject.beta0[0]/part_on_co._xobject.gamma0[0]
 
-    W, Winv, Rot = compute_linear_normal_form(RR, symplectify=symplectify)
+    W, Winv, Rot = lnf.compute_linear_normal_form(RR, symplectify=symplectify,
+                                responsiveness_tol=matrix_responsiveness_tol,
+                                stability_tol=matrix_stability_tol)
 
     s = np.array(tracker.line.get_s_elements())
 


### PR DESCRIPTION
**Changes:**
 - ```Line.insert_element``` allows replacement of aperture elements.
 - Introduced getitem capability for ```Line``` providing object associated to a given index or name.
 - Thresholds for checking one-turn matrix validity can now be modified at runtime.
 - Import of MAD-X sequence can handle repeated elements.
 - More robust algorithm for closed-orbit search, exception raised if solution is not found.
 - Faster algorithm for marker insertion in ```Tracker.twiss(at_s=...)```
 - Fix in introduction of multipole errors in the presence of deferred expressions.