### PR TITLE
v0.11.1

### DIFF
--- a/examples/collimation/003_all_together.py
+++ b/examples/collimation/003_all_together.py
@@ -93,7 +93,7 @@ line = xt.Line(elements=[
 # Build tracker #
 #################
 
-tracker = xt.Tracker(line=line)
+tracker = xt.Tracker(line=line, global_xy_limit=1e3)
 
 ##########################
 # Build particles object #

--- a/xtrack/beam_elements/beam_interaction.py
+++ b/xtrack/beam_elements/beam_interaction.py
@@ -34,6 +34,8 @@ class BeamInteraction:
             new_particles = xp.Particles(_context=particles._buffer.context,
                     p0c = particles.p0c[0], # TODO: Should we check that 
                                             #       they are all the same?
+                    mass0 = particles.mass0,
+                    q0 = particles.q0,
                     s = products['s'],
                     x = products['x'],
                     px = products['px'],

--- a/xtrack/loss_location_refinement/loss_location_refinement.py
+++ b/xtrack/loss_location_refinement/loss_location_refinement.py
@@ -41,7 +41,8 @@ class LossLocationRefinement:
         self._trk_gen = trk_gen
 
         if backtracker is None:
-            backtracker = self.tracker.get_backtracker(_context=self._context)
+            backtracker = self.tracker.get_backtracker(_context=self._context,
+                                                       global_xy_limit=None)
         self.backtracker = backtracker
 
         self.i_apertures, self.apertures = find_apertures(self.tracker)

--- a/xtrack/loss_location_refinement/loss_location_refinement.py
+++ b/xtrack/loss_location_refinement/loss_location_refinement.py
@@ -36,7 +36,8 @@ class LossLocationRefinement:
         # Build track kernel with all elements + polygon
         trk_gen = Tracker(_buffer=self.tracker._line_frozen._buffer,
                 line=Line(
-                    elements=self.tracker._line_frozen.elements + (temp_poly,)))
+                    elements=self.tracker._line_frozen.elements + (temp_poly,)),
+                    global_xy_limit=tracker.global_xy_limit)
         self._trk_gen = trk_gen
 
         if backtracker is None:
@@ -161,8 +162,11 @@ def refine_loss_location_single_aperture(particles, i_aper_1, i_start_thin_0,
                                          inplace=True):
 
     mask_part = (particles.state == 0) & (particles.at_element == i_aper_1)
+
     part_refine = xp.Particles(
                     p0c=particles.p0c[mask_part],
+                    mass0=particles.mass0,
+                    q0=particles.q0,
                     x=particles.x[mask_part],
                     px=particles.px[mask_part],
                     y=particles.y[mask_part],
@@ -336,7 +340,8 @@ def build_interp_tracker(_buffer, s0, s1, s_interp, aper_0, aper_1, aper_interp,
             line=Line(elements=ele_all),
             track_kernel=_trk_gen.track_kernel,
             element_classes=_trk_gen.element_classes,
-            reset_s_at_end_turn=0)
+            reset_s_at_end_turn=0,
+            global_xy_limit=_trk_gen.global_xy_limit)
 
     return interp_tracker
 

--- a/xtrack/tracker_src/tracker.h
+++ b/xtrack/tracker_src/tracker.h
@@ -19,7 +19,7 @@ void global_aperture_check(LocalParticle* part0){
 
 	// I assume that if I am in the function is because
     	if (!is_alive){
-           LocalParticle_set_state(part, 0);
+           LocalParticle_set_state(part, -1);
 	}
     //end_per_particle_block
 


### PR DESCRIPTION
**Changes:**
- Global aperture check can be disabled passing ```Tracker(..., global_xy_limit=None)```.
- Particles lost on the global aperture limit are identified by ```-1``` in the particle state.
- Fixes in ```LossLocationRefinement```: correct propagation of global aperture settings, correct charge and mass in refinement (and in ```BeamInteraction```. Global aperture check is disabled for backtracker.
