### PR TITLE
Partial tracking with collective elements

### DIFF
--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -2,7 +2,6 @@ import numpy as np
 import xobjects as xo
 import xtrack as xt
 import xpart as xp
-import xcoll as xc
 
 
 def test_ebe_monitor():
@@ -65,14 +64,12 @@ def test_cycle():
                 assert ctracker.line.elements[3] is c0
 
 def test_partial_tracking():
-    line = xt.Line(elements=[xt.Multipole(knl=[0, 1.]),
-                                xt.Drift(length=0.5),
-                                xt.Multipole(knl=[0, -1]),
-                                xt.Cavity(frequency=400e7, voltage=6e6),
-                                xt.Drift(length=.5),
-                                xt.Drift(length=0)])
-    n_elem = len(line.element_names)
+    
+    n_elem = 9
+    elements = [ xt.Drift(length=1.) for _ in range(n_elem) ]
+    line = xt.Line(elements=elements)
     tracker = line.build_tracker()
+    assert not tracker.iscollective
     particles_init = xp.Particles(x=[1e-3, -2e-3, 5e-3], y=[2e-3, -4e-3, 3e-3],
                                 zeta=1e-2, p0c=7e12, mass0=xp.PROTON_MASS_EV,
                                 at_turn=0, at_element=0)
@@ -87,20 +84,15 @@ def test_partial_tracking():
 
 
 def test_partial_tracking_with_collective():
-    k2engine = xc.K2Engine(100)
-    line = xt.Line(elements=[xt.Multipole(knl=[0, 1.]),
-                                xt.Drift(length=0.5),
-                                xt.Drift(length=0.75),
-                                xc.K2Collimator(k2engine=k2engine, active_length=0.6, angle=90,
-                                               inactive_front=0, inactive_back=0, material='MoGR', is_active=False),
-                                xt.Multipole(knl=[0, -1]),
-                                xt.Cavity(frequency=400e7, voltage=6e6),
-                                xt.Drift(length=.5),
-                                xc.K2Collimator(k2engine=k2engine, active_length=0.6, angle=0,
-                                               inactive_front=0, inactive_back=0, material='MoGR', is_active=False),
-                                xt.Drift(length=0)])
-    n_elem = len(line.element_names)
+    n_elem = 9
+    elements = [ xt.Drift(length=1.) for _ in range(n_elem) ]
+    # Make some elements collective
+    elements[3].iscollective = True
+    elements[7].iscollective = True
+    line = xt.Line(elements=elements)
     tracker = line.build_tracker()
+    assert tracker.iscollective
+    assert len(tracker._parts) == 5
     particles_init = xp.Particles(x=[1e-3, -2e-3, 5e-3], y=[2e-3, -4e-3, 3e-3],
                                 zeta=1e-2, p0c=7e12, mass0=xp.PROTON_MASS_EV,
                                 at_turn=0, at_element=0)
@@ -123,8 +115,9 @@ def _default_track(tracker, particles_init):
 
         particles = particles_init.copy()
         tracker.track(particles, num_turns=turns)
-        check, end_turn, end_element = _get_at_turn_element(particles)
-        assert check and end_turn==expected_end_turn and end_element==expected_end_element
+        check, end_turn, end_element, end_s = _get_at_turn_element(particles)
+        assert (check and end_turn==expected_end_turn and end_element==expected_end_element
+                    and end_s==expected_end_element)
 
 # Track, from any ele_start, until the end of the first, second, and tenth turn
 def _ele_start_until_end(tracker, particles_init):
@@ -135,9 +128,12 @@ def _ele_start_until_end(tracker, particles_init):
             expected_end_element = 0
 
             particles = particles_init.copy()
+            particles.at_element = start
+            particles.s = start
             tracker.track(particles, num_turns=turns, ele_start=start)
-            check, end_turn, end_element = _get_at_turn_element(particles)
-            assert check and end_turn==expected_end_turn and end_element==expected_end_element
+            check, end_turn, end_element, end_s = _get_at_turn_element(particles)
+            assert (check and end_turn==expected_end_turn and end_element==expected_end_element
+                        and end_s==expected_end_element)
 
 # Track, from any ele_start, any shifts that stay within the first turn
 def _ele_start_with_shift(tracker, particles_init):
@@ -148,9 +144,12 @@ def _ele_start_with_shift(tracker, particles_init):
             expected_end_element = start+shift
 
             particles = particles_init.copy()
+            particles.at_element = start
+            particles.s = start
             tracker.track(particles, ele_start=start, num_elements=shift)
-            check, end_turn, end_element = _get_at_turn_element(particles)
-            assert check and end_turn==expected_end_turn and end_element==expected_end_element
+            check, end_turn, end_element, end_s = _get_at_turn_element(particles)
+            assert (check and end_turn==expected_end_turn and end_element==expected_end_element
+                        and end_s==expected_end_element)
 
 # Track, from any ele_start, any shifts that are larger than one turn (up to 3 turns)
 def _ele_start_with_shift_more_turns(tracker, particles_init):
@@ -161,9 +160,12 @@ def _ele_start_with_shift_more_turns(tracker, particles_init):
             expected_end_element = start + shift - n_elem*expected_end_turn
 
             particles = particles_init.copy()
+            particles.at_element = start
+            particles.s = start
             tracker.track(particles, ele_start=start, num_elements=shift)
-            check, end_turn, end_element = _get_at_turn_element(particles)
-            assert check and end_turn==expected_end_turn and end_element==expected_end_element
+            check, end_turn, end_element, end_s = _get_at_turn_element(particles)
+            assert (check and end_turn==expected_end_turn and end_element==expected_end_element
+                        and end_s==expected_end_element)
 
 # Track from the start until any ele_stop in the first, second, and tenth turn
 def _ele_stop_from_start(tracker, particles_init):
@@ -175,8 +177,9 @@ def _ele_stop_from_start(tracker, particles_init):
 
             particles = particles_init.copy()
             tracker.track(particles, num_turns=turns, ele_stop=stop)
-            check, end_turn, end_element = _get_at_turn_element(particles)
-            assert check and end_turn==expected_end_turn and end_element==expected_end_element
+            check, end_turn, end_element, end_s = _get_at_turn_element(particles)
+            assert (check and end_turn==expected_end_turn and end_element==expected_end_element
+                        and end_s==expected_end_element)
 
 # Track from any ele_start until any ele_stop that is larger than ele_start (so no overflow)
 # for one, two, and ten turns
@@ -189,9 +192,12 @@ def _ele_start_to_ele_stop(tracker, particles_init):
                 expected_end_element = stop
 
                 particles = particles_init.copy()
+                particles.at_element = start
+                particles.s = start
                 tracker.track(particles, num_turns=turns, ele_start=start, ele_stop=stop)
-                check, end_turn, end_element = _get_at_turn_element(particles)
-                assert check and end_turn==expected_end_turn and end_element==expected_end_element
+                check, end_turn, end_element, end_s = _get_at_turn_element(particles)
+                assert (check and end_turn==expected_end_turn and end_element==expected_end_element
+                            and end_s==expected_end_element)
 
 # Track from any ele_start until any ele_stop that is smaller than or equal to ele_start (turn overflow)
 # for one, two, and ten turns
@@ -204,9 +210,12 @@ def _ele_start_to_ele_stop_with_overflow(tracker, particles_init):
                 expected_end_element = stop
 
                 particles = particles_init.copy()
+                particles.at_element = start
+                particles.s = start
                 tracker.track(particles, num_turns=turns, ele_start=start, ele_stop=stop)
-                check, end_turn, end_element = _get_at_turn_element(particles)
-                assert check and end_turn==expected_end_turn and end_element==expected_end_element
+                check, end_turn, end_element, end_s = _get_at_turn_element(particles)
+                assert (check and end_turn==expected_end_turn and end_element==expected_end_element
+                            and end_s==expected_end_element)
 
 
 # Quick helper function to:
@@ -215,6 +224,7 @@ def _ele_start_to_ele_stop_with_overflow(tracker, particles_init):
 def _get_at_turn_element(particles):
     at_element = np.unique(particles.at_element[particles.state>0])
     at_turn = np.unique(particles.at_turn[particles.state>0])
-    all_together = len(at_turn)==1 and len(at_element)==1
-    return all_together, at_turn[0], at_element[0]
+    at_s = np.unique(particles.s[particles.state>0])
+    all_together = len(at_turn)==1 and len(at_element)==1 and len(at_s)==1
+    return all_together, at_turn[0], at_element[0], at_s[0]
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -113,6 +113,7 @@ def test_partial_tracking_with_collective():
     _ele_start_to_ele_stop(tracker, particles_init)
     _ele_start_to_ele_stop_with_overflow(tracker, particles_init)
 
+
 # Track, from any ele_start, until the end of the first, second, and tenth turn
 def _default_track(tracker, particles_init):
     n_elem = len(tracker.line.element_names)

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -2,7 +2,7 @@ import numpy as np
 import xobjects as xo
 import xtrack as xt
 import xpart as xp
-import xfields as xf
+import xcoll as xc
 
 
 def test_ebe_monitor():

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -61,3 +61,54 @@ def test_cycle():
                 assert ctracker.line.elements[1] is r0
                 assert ctracker.line.elements[2] is d0
                 assert ctracker.line.elements[3] is c0
+
+def test_partial_tracking():
+    line = xt.Line(elements=[xt.Multipole(knl=[0, 1.]),
+                                xt.Drift(length=0.5),
+                                xt.Multipole(knl=[0, -1]),
+                                xt.Cavity(frequency=400e7, voltage=6e6),
+                                xt.Drift(length=.5),
+                                xt.Drift(length=0)])
+ 
+    tracker = line.build_tracker()
+    particles_init = xp.Particles(x=[1e-3, -2e-3, 5e-3], y=[2e-3, -4e-3, 3e-3],
+                                zeta=1e-2, p0c=7e12, mass0=xp.PROTON_MASS_EV,
+                                at_turn=0, at_element=0)
+
+    # Track two elements from lattice start
+    particles = particles_init.copy()
+    tracker.track(particles, num_turns=1, num_elements=2)
+    at_element = np.unique(particles.at_element[particles.state>0])
+    at_turn = np.unique(particles.at_turn[particles.state>0])
+    assert len(at_turn)==1 and at_turn[0]==0 and \
+            len(at_element)==1 and at_element[0]==2
+
+    # Track two elements, starting from first element
+    particles = particles_init.copy()
+    tracker.track(particles, num_turns=1, ele_start=0, num_elements=2)
+    at_element = np.unique(particles.at_element[particles.state>0])
+    at_turn = np.unique(particles.at_turn[particles.state>0])
+    assert len(at_turn)==1 and at_turn[0]==0 and \
+            len(at_element)==1 and at_element[0]==2
+
+    # Track two elements, starting from third element
+    particles = particles_init.copy()
+    tracker.track(particles, num_turns=1, ele_start=2, num_elements=2)
+    at_element = np.unique(particles.at_element[particles.state>0])
+    at_turn = np.unique(particles.at_turn[particles.state>0])
+    return at_element, at_turn
+    assert len(at_turn)==1 and at_turn[0]==0 and \
+            len(at_element)==1 and at_element[0]==4
+
+    # Track from lattice start until third element
+    particles = particles_init.copy()
+    tracker.track(particles, num_turns=1, ele_stop=2)
+    at_element = np.unique(particles.at_element[particles.state>0])
+    at_turn = np.unique(particles.at_turn[particles.state>0])
+    assert len(at_turn)==1 and at_turn[0]==0 and \
+            len(at_element)==1 and at_element[0]==2
+    
+    
+    
+    
+    

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -136,7 +136,6 @@ def _ele_start_until_end(tracker, particles_init):
             particles = particles_init.copy()
             tracker.track(particles, num_turns=turns, ele_start=start)
             check, end_turn, end_element = _get_at_turn_element(particles)
-            print("Expected: ",expected_end_turn,expected_end_element,"Got: ",end_turn,end_element)
             assert check and end_turn==expected_end_turn and end_element==expected_end_element
 
 # Track, from any ele_start, any shifts that stay within the first turn
@@ -146,11 +145,10 @@ def _ele_start_with_shift(tracker, particles_init):
         for shift in range(1,n_elem-start):
             expected_end_turn = 0
             expected_end_element = start+shift
-            print("Test start: ",start, "shift: ", shift)
+
             particles = particles_init.copy()
             tracker.track(particles, ele_start=start, num_elements=shift)
             check, end_turn, end_element = _get_at_turn_element(particles)
-            print("Expected: ",expected_end_turn,expected_end_element,"Got: ",end_turn,end_element)
             assert check and end_turn==expected_end_turn and end_element==expected_end_element
 
 # Track, from any ele_start, any shifts that are larger than one turn (up to 3 turns)
@@ -160,11 +158,10 @@ def _ele_start_with_shift_more_turns(tracker, particles_init):
         for shift in range(n_elem-start, 3*n_elem+1):
             expected_end_turn = round(np.floor( (start+shift)/n_elem ))
             expected_end_element = start + shift - n_elem*expected_end_turn
-            print("Test start: ",start, "shift: ", shift)
+
             particles = particles_init.copy()
             tracker.track(particles, ele_start=start, num_elements=shift)
             check, end_turn, end_element = _get_at_turn_element(particles)
-            print("Expected: ",expected_end_turn,expected_end_element,"Got: ",end_turn,end_element)
             assert check and end_turn==expected_end_turn and end_element==expected_end_element
 
 # Track from the start until any ele_stop in the first, second, and tenth turn
@@ -178,7 +175,6 @@ def _ele_stop_from_start(tracker, particles_init):
             particles = particles_init.copy()
             tracker.track(particles, num_turns=turns, ele_stop=stop)
             check, end_turn, end_element = _get_at_turn_element(particles)
-            print("Expected: ",expected_end_turn,expected_end_element,"Got: ",end_turn,end_element)
             assert check and end_turn==expected_end_turn and end_element==expected_end_element
 
 # Track from any ele_start until any ele_stop that is larger than ele_start (so no overflow)
@@ -190,11 +186,10 @@ def _ele_start_to_ele_stop(tracker, particles_init):
             for stop in range(start+1,n_elem):
                 expected_end_turn = turns-1
                 expected_end_element = stop
-                print("Test start: ",start, "stop: ", stop, turns)
+
                 particles = particles_init.copy()
                 tracker.track(particles, num_turns=turns, ele_start=start, ele_stop=stop)
                 check, end_turn, end_element = _get_at_turn_element(particles)
-                print("Expected: ",expected_end_turn,expected_end_element,"Got: ",end_turn,end_element)
                 assert check and end_turn==expected_end_turn and end_element==expected_end_element
 
 # Track from any ele_start until any ele_stop that is smaller than or equal to ele_start (turn overflow)
@@ -206,11 +201,10 @@ def _ele_start_to_ele_stop_with_overflow(tracker, particles_init):
             for stop in range(start+1):
                 expected_end_turn = turns
                 expected_end_element = stop
-                print("Test start: ",start, "stop: ", stop, turns)
+
                 particles = particles_init.copy()
                 tracker.track(particles, num_turns=turns, ele_start=start, ele_stop=stop)
                 check, end_turn, end_element = _get_at_turn_element(particles)
-                print("Expected: ",expected_end_turn,expected_end_element,"Got: ",end_turn,end_element)
                 assert check and end_turn==expected_end_turn and end_element==expected_end_element
 
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -74,39 +74,72 @@ def test_partial_tracking():
     particles_init = xp.Particles(x=[1e-3, -2e-3, 5e-3], y=[2e-3, -4e-3, 3e-3],
                                 zeta=1e-2, p0c=7e12, mass0=xp.PROTON_MASS_EV,
                                 at_turn=0, at_element=0)
+    
+    def _get_at_turn_element(particles):
+        at_element = np.unique(particles.at_element[particles.state>0])
+        at_turn = np.unique(particles.at_turn[particles.state>0])
+        all_together = len(at_turn)==1 and len(at_element)==1
+        return all_together, at_turn[0], at_element[0]
 
-    # Track two elements from lattice start
+    # Test P0: Track two elements from lattice start
     particles = particles_init.copy()
     tracker.track(particles, num_turns=1, num_elements=2)
-    at_element = np.unique(particles.at_element[particles.state>0])
-    at_turn = np.unique(particles.at_turn[particles.state>0])
-    assert len(at_turn)==1 and at_turn[0]==0 and \
-            len(at_element)==1 and at_element[0]==2
+    check, turn_stop, ele_stop = _get_at_turn_element(particles)
+    assert check and turn_stop==0 and ele_stop==2    # Test P0
 
-    # Track two elements, starting from first element
-    particles = particles_init.copy()
-    tracker.track(particles, num_turns=1, ele_start=0, num_elements=2)
-    at_element = np.unique(particles.at_element[particles.state>0])
-    at_turn = np.unique(particles.at_turn[particles.state>0])
-    assert len(at_turn)==1 and at_turn[0]==0 and \
-            len(at_element)==1 and at_element[0]==2
-
-    # Track two elements, starting from third element
+    # Test P1: Track two elements, starting from third element
     particles = particles_init.copy()
     tracker.track(particles, num_turns=1, ele_start=2, num_elements=2)
-    at_element = np.unique(particles.at_element[particles.state>0])
-    at_turn = np.unique(particles.at_turn[particles.state>0])
-    return at_element, at_turn
-    assert len(at_turn)==1 and at_turn[0]==0 and \
-            len(at_element)==1 and at_element[0]==4
+    check, turn_stop, ele_stop = _get_at_turn_element(particles)
+    assert check and turn_stop==0 and ele_stop==4    # Test P1
 
-    # Track from lattice start until third element
+    # Test P2: Track from third element until end
+    particles = particles_init.copy()
+    tracker.track(particles, num_turns=1, ele_start=2)
+    check, turn_stop, ele_stop = _get_at_turn_element(particles)
+    assert check and turn_stop==1 and ele_stop==0    # Test P2
+
+    # Test P3: Track from third element until end + 1 turn
+    particles = particles_init.copy()
+    tracker.track(particles, num_turns=2, ele_start=2)
+    check, turn_stop, ele_stop = _get_at_turn_element(particles)
+    assert check and turn_stop==2 and ele_stop==0    # Test P3
+
+    # Test P4: Track from lattice start until third element
     particles = particles_init.copy()
     tracker.track(particles, num_turns=1, ele_stop=2)
-    at_element = np.unique(particles.at_element[particles.state>0])
-    at_turn = np.unique(particles.at_turn[particles.state>0])
-    assert len(at_turn)==1 and at_turn[0]==0 and \
-            len(at_element)==1 and at_element[0]==2
+    check, turn_stop, ele_stop = _get_at_turn_element(particles)
+    assert check and turn_stop==0 and ele_stop==2    # Test P4
+
+    # Test P5: Track from lattice start until third element + 1 turn
+    particles = particles_init.copy()
+    tracker.track(particles, num_turns=2, ele_stop=2)
+    check, turn_stop, ele_stop = _get_at_turn_element(particles)
+    assert check and turn_stop==1 and ele_stop==2    # Test P5
+
+    # Test P6: Track from third element until fifth element
+    particles = particles_init.copy()
+    tracker.track(particles, num_turns=1, ele_start=2, ele_stop=4)
+    check, turn_stop, ele_stop = _get_at_turn_element(particles)
+    assert check and turn_stop==0 and ele_stop==4    # Test P6
+
+    # Test P7: Track from third element until fifth element + 1 turn
+    particles = particles_init.copy()
+    tracker.track(particles, num_turns=2, ele_start=2, ele_stop=4)
+    check, turn_stop, ele_stop = _get_at_turn_element(particles)
+    assert check and turn_stop==1 and ele_stop==4    # Test P7
+
+    # Test P8: Track from third element until second element (turn overflow)
+    particles = particles_init.copy()
+    tracker.track(particles, num_turns=1, ele_start=2, ele_stop=1)
+    check, turn_stop, ele_stop = _get_at_turn_element(particles)
+    assert check and turn_stop==1 and ele_stop==1    # Test P8
+
+    # Test P8: Track from third element until second element (turn overflow) + 1 turn
+    particles = particles_init.copy()
+    tracker.track(particles, num_turns=2, ele_start=2, ele_stop=1)
+    check, turn_stop, ele_stop = _get_at_turn_element(particles)
+    assert check and turn_stop==2 and ele_stop==1    # Test P8
     
     
     

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -2,6 +2,8 @@ import numpy as np
 import xobjects as xo
 import xtrack as xt
 import xpart as xp
+import xfields as xf
+
 
 def test_ebe_monitor():
 
@@ -69,79 +71,155 @@ def test_partial_tracking():
                                 xt.Cavity(frequency=400e7, voltage=6e6),
                                 xt.Drift(length=.5),
                                 xt.Drift(length=0)])
- 
+    n_elem = len(line.element_names)
     tracker = line.build_tracker()
     particles_init = xp.Particles(x=[1e-3, -2e-3, 5e-3], y=[2e-3, -4e-3, 3e-3],
                                 zeta=1e-2, p0c=7e12, mass0=xp.PROTON_MASS_EV,
                                 at_turn=0, at_element=0)
-    
-    def _get_at_turn_element(particles):
-        at_element = np.unique(particles.at_element[particles.state>0])
-        at_turn = np.unique(particles.at_turn[particles.state>0])
-        all_together = len(at_turn)==1 and len(at_element)==1
-        return all_together, at_turn[0], at_element[0]
 
-    # Test P0: Track two elements from lattice start
-    particles = particles_init.copy()
-    tracker.track(particles, num_turns=1, num_elements=2)
-    check, turn_stop, ele_stop = _get_at_turn_element(particles)
-    assert check and turn_stop==0 and ele_stop==2    # Test P0
+    _default_track(tracker, particles_init)
+    _ele_start_until_end(tracker, particles_init)
+    _ele_start_with_shift(tracker, particles_init)
+    _ele_start_with_shift_more_turns(tracker, particles_init)
+    _ele_stop_from_start(tracker, particles_init)
+    _ele_start_to_ele_stop(tracker, particles_init)
+    _ele_start_to_ele_stop_with_overflow(tracker, particles_init)
 
-    # Test P1: Track two elements, starting from third element
-    particles = particles_init.copy()
-    tracker.track(particles, num_turns=1, ele_start=2, num_elements=2)
-    check, turn_stop, ele_stop = _get_at_turn_element(particles)
-    assert check and turn_stop==0 and ele_stop==4    # Test P1
 
-    # Test P2: Track from third element until end
-    particles = particles_init.copy()
-    tracker.track(particles, num_turns=1, ele_start=2)
-    check, turn_stop, ele_stop = _get_at_turn_element(particles)
-    assert check and turn_stop==1 and ele_stop==0    # Test P2
+def test_partial_tracking_with_collective():
+    k2engine = xc.K2Engine(100)
+    line = xt.Line(elements=[xt.Multipole(knl=[0, 1.]),
+                                xt.Drift(length=0.5),
+                                xt.Drift(length=0.75),
+                                xc.K2Collimator(k2engine=k2engine, active_length=0.6, angle=90,
+                                               inactive_front=0, inactive_back=0, material='MoGR', is_active=False),
+                                xt.Multipole(knl=[0, -1]),
+                                xt.Cavity(frequency=400e7, voltage=6e6),
+                                xt.Drift(length=.5),
+                                xc.K2Collimator(k2engine=k2engine, active_length=0.6, angle=0,
+                                               inactive_front=0, inactive_back=0, material='MoGR', is_active=False),
+                                xt.Drift(length=0)])
+    n_elem = len(line.element_names)
+    tracker = line.build_tracker()
+    particles_init = xp.Particles(x=[1e-3, -2e-3, 5e-3], y=[2e-3, -4e-3, 3e-3],
+                                zeta=1e-2, p0c=7e12, mass0=xp.PROTON_MASS_EV,
+                                at_turn=0, at_element=0)
 
-    # Test P3: Track from third element until end + 1 turn
-    particles = particles_init.copy()
-    tracker.track(particles, num_turns=2, ele_start=2)
-    check, turn_stop, ele_stop = _get_at_turn_element(particles)
-    assert check and turn_stop==2 and ele_stop==0    # Test P3
+    _default_track(tracker, particles_init)
+    _ele_start_until_end(tracker, particles_init)
+    _ele_start_with_shift(tracker, particles_init)
+    _ele_start_with_shift_more_turns(tracker, particles_init)
+    _ele_stop_from_start(tracker, particles_init)
+    _ele_start_to_ele_stop(tracker, particles_init)
+    _ele_start_to_ele_stop_with_overflow(tracker, particles_init)
 
-    # Test P4: Track from lattice start until third element
-    particles = particles_init.copy()
-    tracker.track(particles, num_turns=1, ele_stop=2)
-    check, turn_stop, ele_stop = _get_at_turn_element(particles)
-    assert check and turn_stop==0 and ele_stop==2    # Test P4
+# Track, from any ele_start, until the end of the first, second, and tenth turn
+def _default_track(tracker, particles_init):
+    n_elem = len(tracker.line.element_names)
+    for turns in [1, 2, 10]:
+        expected_end_turn = turns
+        expected_end_element = 0
 
-    # Test P5: Track from lattice start until third element + 1 turn
-    particles = particles_init.copy()
-    tracker.track(particles, num_turns=2, ele_stop=2)
-    check, turn_stop, ele_stop = _get_at_turn_element(particles)
-    assert check and turn_stop==1 and ele_stop==2    # Test P5
+        particles = particles_init.copy()
+        tracker.track(particles, num_turns=turns)
+        check, end_turn, end_element = _get_at_turn_element(particles)
+        assert check and end_turn==expected_end_turn and end_element==expected_end_element
 
-    # Test P6: Track from third element until fifth element
-    particles = particles_init.copy()
-    tracker.track(particles, num_turns=1, ele_start=2, ele_stop=4)
-    check, turn_stop, ele_stop = _get_at_turn_element(particles)
-    assert check and turn_stop==0 and ele_stop==4    # Test P6
+# Track, from any ele_start, until the end of the first, second, and tenth turn
+def _ele_start_until_end(tracker, particles_init):
+    n_elem = len(tracker.line.element_names)
+    for turns in [1, 2, 10]:
+        for start in range(n_elem):
+            expected_end_turn = turns
+            expected_end_element = 0
 
-    # Test P7: Track from third element until fifth element + 1 turn
-    particles = particles_init.copy()
-    tracker.track(particles, num_turns=2, ele_start=2, ele_stop=4)
-    check, turn_stop, ele_stop = _get_at_turn_element(particles)
-    assert check and turn_stop==1 and ele_stop==4    # Test P7
+            particles = particles_init.copy()
+            tracker.track(particles, num_turns=turns, ele_start=start)
+            check, end_turn, end_element = _get_at_turn_element(particles)
+            print("Expected: ",expected_end_turn,expected_end_element,"Got: ",end_turn,end_element)
+            assert check and end_turn==expected_end_turn and end_element==expected_end_element
 
-    # Test P8: Track from third element until second element (turn overflow)
-    particles = particles_init.copy()
-    tracker.track(particles, num_turns=1, ele_start=2, ele_stop=1)
-    check, turn_stop, ele_stop = _get_at_turn_element(particles)
-    assert check and turn_stop==1 and ele_stop==1    # Test P8
+# Track, from any ele_start, any shifts that stay within the first turn
+def _ele_start_with_shift(tracker, particles_init):
+    n_elem = len(tracker.line.element_names)
+    for start in range(n_elem):
+        for shift in range(1,n_elem-start):
+            expected_end_turn = 0
+            expected_end_element = start+shift
+            print("Test start: ",start, "shift: ", shift)
+            particles = particles_init.copy()
+            tracker.track(particles, ele_start=start, num_elements=shift)
+            check, end_turn, end_element = _get_at_turn_element(particles)
+            print("Expected: ",expected_end_turn,expected_end_element,"Got: ",end_turn,end_element)
+            assert check and end_turn==expected_end_turn and end_element==expected_end_element
 
-    # Test P8: Track from third element until second element (turn overflow) + 1 turn
-    particles = particles_init.copy()
-    tracker.track(particles, num_turns=2, ele_start=2, ele_stop=1)
-    check, turn_stop, ele_stop = _get_at_turn_element(particles)
-    assert check and turn_stop==2 and ele_stop==1    # Test P8
-    
-    
-    
-    
-    
+# Track, from any ele_start, any shifts that are larger than one turn (up to 3 turns)
+def _ele_start_with_shift_more_turns(tracker, particles_init):
+    n_elem = len(tracker.line.element_names)
+    for start in range(n_elem):
+        for shift in range(n_elem-start, 3*n_elem+1):
+            expected_end_turn = round(np.floor( (start+shift)/n_elem ))
+            expected_end_element = start + shift - n_elem*expected_end_turn
+            print("Test start: ",start, "shift: ", shift)
+            particles = particles_init.copy()
+            tracker.track(particles, ele_start=start, num_elements=shift)
+            check, end_turn, end_element = _get_at_turn_element(particles)
+            print("Expected: ",expected_end_turn,expected_end_element,"Got: ",end_turn,end_element)
+            assert check and end_turn==expected_end_turn and end_element==expected_end_element
+
+# Track from the start until any ele_stop in the first, second, and tenth turn
+def _ele_stop_from_start(tracker, particles_init):
+    n_elem = len(tracker.line.element_names)
+    for turns in [1, 2, 10]:
+        for stop in range(1, n_elem):
+            expected_end_turn = turns-1
+            expected_end_element = stop
+
+            particles = particles_init.copy()
+            tracker.track(particles, num_turns=turns, ele_stop=stop)
+            check, end_turn, end_element = _get_at_turn_element(particles)
+            print("Expected: ",expected_end_turn,expected_end_element,"Got: ",end_turn,end_element)
+            assert check and end_turn==expected_end_turn and end_element==expected_end_element
+
+# Track from any ele_start until any ele_stop that is larger than ele_start (so no overflow)
+# for one, two, and ten turns
+def _ele_start_to_ele_stop(tracker, particles_init): 
+    n_elem = len(tracker.line.element_names)
+    for turns in [1, 2, 10]:
+        for start in range(n_elem):
+            for stop in range(start+1,n_elem):
+                expected_end_turn = turns-1
+                expected_end_element = stop
+                print("Test start: ",start, "stop: ", stop, turns)
+                particles = particles_init.copy()
+                tracker.track(particles, num_turns=turns, ele_start=start, ele_stop=stop)
+                check, end_turn, end_element = _get_at_turn_element(particles)
+                print("Expected: ",expected_end_turn,expected_end_element,"Got: ",end_turn,end_element)
+                assert check and end_turn==expected_end_turn and end_element==expected_end_element
+
+# Track from any ele_start until any ele_stop that is smaller than or equal to ele_start (turn overflow)
+# for one, two, and ten turns
+def _ele_start_to_ele_stop_with_overflow(tracker, particles_init):
+    n_elem = len(tracker.line.element_names)
+    for turns in [1, 2, 10]:
+        for start in range(n_elem):
+            for stop in range(start+1):
+                expected_end_turn = turns
+                expected_end_element = stop
+                print("Test start: ",start, "stop: ", stop, turns)
+                particles = particles_init.copy()
+                tracker.track(particles, num_turns=turns, ele_start=start, ele_stop=stop)
+                check, end_turn, end_element = _get_at_turn_element(particles)
+                print("Expected: ",expected_end_turn,expected_end_element,"Got: ",end_turn,end_element)
+                assert check and end_turn==expected_end_turn and end_element==expected_end_element
+
+
+# Quick helper function to:
+#   1) check that all survived particles are at the same element and turn
+#   2) return that element and turn
+def _get_at_turn_element(particles):
+    at_element = np.unique(particles.at_element[particles.state>0])
+    at_turn = np.unique(particles.at_turn[particles.state>0])
+    all_together = len(at_turn)==1 and len(at_element)==1
+    return all_together, at_turn[0], at_element[0]
+

--- a/xtrack/loader_sixtrack.py
+++ b/xtrack/loader_sixtrack.py
@@ -98,11 +98,16 @@ def _expand_struct(sixinput, convert):
                 ksl[0] = hyl
             elem = Multipole(knl=knl, ksl=ksl, hxl=hxl, hyl=hyl, length=length)
         elif etype == 12:
-            e0=sixinput.initialconditions[-1]
+            e0=sixinput.e0
+            # Use proton mass from SYNC (pma) instead of that from SIMU (m0c2), as the settings
+            # in SYNC will have been calculated based on pma (in case the two are different)
             p0c=np.sqrt(e0**2-sixinput.pma**2)
             beta0=p0c/e0
             v = d1 * 1e6
-            freq = d2 * clight * beta0 / sixinput.tlen
+            if d2 != 0:
+                freq = d2 * clight * beta0 / sixinput.tlen
+            else:
+                freq = sixinput.harm * clight * beta0 / sixinput.tlen
             #print(v,freq)
             elem = Cavity(voltage=v, frequency=freq, lag=180 - d3)
         elif etype == 20:
@@ -111,7 +116,7 @@ def _expand_struct(sixinput, convert):
             if hasattr(thisbb, "sigma_x"):
                 from scipy.constants import e as qe
                 dct['n_particles'] = thisbb.charge/qe # ducktrack has it in coulumb
-                dct['q0'] = qe # TODO change implementation
+                dct['q0'] = sixinput.q0 # TODO change implementation
                 dct['beta0'] = thisbb.beta_r
                 dct['mean_x'] = thisbb.x_bb
                 dct['mean_y'] = thisbb.y_bb
@@ -129,7 +134,7 @@ def _expand_struct(sixinput, convert):
             voltage_V = d1 *1e6
             freq_Hz = d2 * 1e6
             phase_rad = d3
-            p0c_eV = sixinput.initialconditions[12]*1e6
+            p0c_eV = np.sqrt(sixinput.e0**2 - sixinput.m0c2**2)*1e6
             elem = RFMultipole(
                 frequency = freq_Hz,
                 knl= [voltage_V / p0c_eV],
@@ -139,7 +144,7 @@ def _expand_struct(sixinput, convert):
             voltage_V = d1 *1e6
             freq_Hz = d2 * 1e6
             phase_rad = d3
-            p0c_eV = sixinput.initialconditions[12]*1e6
+            p0c_eV = np.sqrt(sixinput.e0**2 - sixinput.m0c2**2)*1e6
             print(nnn, sixinput.single[nnn])
             print(f'p0c_eV: {p0c_eV}')
             elem = RFMultipole(

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -518,7 +518,6 @@ class Tracker:
             Particles_to_LocalParticle(particles, &lpart, part_id);
 
             int64_t isactive = check_is_active(&lpart);
-            crosscheck_at_element(&lpart, (int64_t)ele_start);
 
             for (int64_t iturn=0; iturn<num_turns; iturn++){
 

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -870,10 +870,11 @@ class Tracker:
                 # Track only the first (potentially partial) turn
                 num_elements_first_turn = num_elements
             else:
+                # Track the first turn until the end of the lattice
                 num_elements_first_turn = self.num_elements - ele_start
+                # Middle turns and potential last turn
                 num_middle_turns, ele_stop = np.divmod(ele_start + num_elements, self.num_elements)
                 num_elements_last_turn = ele_stop
-#                 if ele_stop == 0:
                 num_middle_turns -= 1              
 
         else:
@@ -906,7 +907,6 @@ class Tracker:
                     # Track the last turn until ele_stop
                     num_elements_last_turn = ele_stop
 
-        print(ele_start, num_elements_first_turn, num_middle_turns, num_elements_last_turn)
         assert len(particles.state) > 0
 
         if self.skip_end_turn_actions:

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -648,6 +648,8 @@ class Tracker:
                 ele_start = 0
         if isinstance(ele_start,str):
             ele_start = self.line.element_names.index(ele_start)
+        # Need to manually set particles starting positions, as we will
+        # skip tracking until ele_start
         particles.start_tracking_at_element = -1
         particles.at_element = ele_start
         particles.s = self.line.get_s_position(ele_start)

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -793,12 +793,15 @@ class Tracker:
         if particles.start_tracking_at_element >= 0:
             assert ele_start is None
             ele_start = particles.start_tracking_at_element
-            particles.start_tracking_at_element = -1
         else:
             if ele_start is None:
                 ele_start = 0
         if isinstance(ele_start,str):
             ele_start = self.line.element_names.index(ele_start)
+        # Need to manually set particles starting positions
+        particles.start_tracking_at_element = -1
+        particles.at_element = ele_start
+        particles.s = self.line.get_s_position(ele_start)
 
         assert ele_start >= 0
         assert ele_start <= self.num_elements
@@ -849,7 +852,6 @@ class Tracker:
 
         self.track_kernel.description.n_threads = particles._capacity
 
-        print(ele_start, ele_stop, num_elements, num_elements_first_turn, num_middle_turns, num_elements_last_turn)
         # First turn
         self.track_kernel(
             buffer=self._line_frozen._buffer.buffer,

--- a/xtrack/tracker_src/tracker.h
+++ b/xtrack/tracker_src/tracker.h
@@ -28,6 +28,19 @@ void global_aperture_check(LocalParticle* part0){
 #endif
 
 /*gpufun*/
+void crosscheck_at_element(LocalParticle* part0, int64_t i_ele){
+
+   //start_per_particle_block (part0->part)
+        int64_t const part_ele = LocalParticle_get_at_element(part);
+        if (part_ele != i_ele){
+          LocalParticle_set_state(part, -555);
+        }
+   //end_per_particle_block
+
+
+}
+
+/*gpufun*/
 void increment_at_element(LocalParticle* part0){
 
    //start_per_particle_block (part0->part)

--- a/xtrack/tracker_src/tracker.h
+++ b/xtrack/tracker_src/tracker.h
@@ -28,19 +28,6 @@ void global_aperture_check(LocalParticle* part0){
 #endif
 
 /*gpufun*/
-void crosscheck_at_element(LocalParticle* part0, int64_t i_ele){
-
-   //start_per_particle_block (part0->part)
-        int64_t const part_ele = LocalParticle_get_at_element(part);
-        if (part_ele != i_ele){
-          LocalParticle_set_state(part, -555);
-        }
-   //end_per_particle_block
-
-
-}
-
-/*gpufun*/
 void increment_at_element(LocalParticle* part0){
 
    //start_per_particle_block (part0->part)


### PR DESCRIPTION
The following new features are implemented:

1) A stop element can be specified with `ele_stop` (in which case `num_elements` has to be `None`).
Tracking will then go from `ele_start` (defaulting to 0) until `ele_stop`, potentially over several turns.
If `ele_stop` is before `ele_start` we pass `s=0`. This counts as one turn (though inside the `particles`
object the `at_turn` will be at 1 already).

The logic is hence that, when `ele_stop` is used, the last turn will be incomplete.

Examples:
  a) `ele_start=IP8`, `ele_stop=IP2`, `num_turns=1`
  This means we start at IP8, cross `s=0`, and continue until IP2.
  This is less than a full turn.
  Particles that died between IP8 and IP1 will be `at_turn=0`.
  Particles that died between IP1 and IP2 will be `at_turn=1`.

  b) `ele_start=IP8`, `ele_stop=IP2`, `num_turns=2`
  This means we start at IP8, make a full turn back to IP8, and then continue until IP2.
  This is more than one turn, but less than two.
  Particles that died between IP8 and IP1 will be `at_turn=0`.
  Particles that died between IP1 and IP1 (next turn) will be `at_turn=1`.
  Particles that died between IP1 (next turn) and IP2 (next turn) will be `at_turn=2`.


2) Both `ele_start` and `ele_stop` can be given by either the element index, or the element name.


3) Partial tracking is fully implemented for tracking with collective elements as well.


4) Small fix of an existing typo inside `_track_with_collective` (line 722-723):

  if _need_clean_active_lost_state:
    particles._num_active_particle = -1

is replaced with

  if _need_clean_active_lost_state:
    particles._num_active_particles = -1
