### PR TITLE
Update synrad_spectrum.h

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extensions = []
 
 setup(
     name='xtrack',
-    version='0.11.4',
+    version='0.12.0',
     description='Tracking library for particle accelerators',
     url='https://github.com/xsuite/xtrack',
     author='Riccard De Maria, Giovanni Iadarola',

--- a/xtrack/headers/synrad_spectrum.h
+++ b/xtrack/headers/synrad_spectrum.h
@@ -13,10 +13,10 @@ void synrad_average_kick(LocalParticle* part, double curv, double lpath){
 
     double const delta  = LocalParticle_get_delta(part);
 
-    double const r = 1/(6*PI*EPSILON_0)
-                        * QELEM / (mass0*q0*q0)
-                        * curv*curv
+    double const r = QELEM/(6*PI*EPSILON_0)
+                        * q0*q0 / mass0
                         * (beta0*gamma0)*(beta0*gamma0)*(beta0*gamma0)
+	                * curv*curv
                         * lpath * (1 + delta);
 
     double const beta = beta0 * LocalParticle_get_rvv(part);


### PR DESCRIPTION
q0^2 goes to the numerator

![image](https://user-images.githubusercontent.com/54369/167172635-df969961-a794-493e-8621-3539d36ebcc4.png)

![image](https://user-images.githubusercontent.com/54369/167172506-81c348fd-2f94-4f25-a185-89739f02ac23.png)

![image](https://user-images.githubusercontent.com/54369/167172385-e51d401f-ed76-49d5-9a8e-7558da2048e3.png)

Needs to be update using `mratio` and `qratio`