### PR TITLE
Refactor/remove dress element function

### DIFF
--- a/examples/element_internal_record/000_internal_record.py
+++ b/examples/element_internal_record/000_internal_record.py
@@ -20,7 +20,7 @@ import xobjects as xo
 # the index, the structure can contain an arbitrary number of other fields (which
 # need to be arrays) where the data will be stored.
 
-class TestElementRecord(xo.DressedStruct):
+class TestElementRecord(xo.HybridClass):
     _xofields = {
         '_index': xt.RecordIndex,
         'generated_rr': xo.Float64[:],

--- a/examples/element_internal_record/001_multirecord.py
+++ b/examples/element_internal_record/001_multirecord.py
@@ -13,7 +13,7 @@ import xobjects as xo
 # In this case the element internal record is made of two separate tables each
 # with its own record index.
 
-class Table1(xo.DressedStruct):
+class Table1(xo.HybridClass):
     _xofields = {
         '_index': xt.RecordIndex,
         'particle_x': xo.Float64[:],
@@ -23,7 +23,7 @@ class Table1(xo.DressedStruct):
         'particle_id': xo.Int64[:]
         }
 
-class Table2(xo.DressedStruct):
+class Table2(xo.HybridClass):
     _xofields = {
         '_index': xt.RecordIndex,
         'generated_rr': xo.Float64[:],
@@ -32,7 +32,7 @@ class Table2(xo.DressedStruct):
         'particle_id': xo.Int64[:]
         }
 
-class TestElementRecord(xo.DressedStruct):
+class TestElementRecord(xo.HybridClass):
     _xofields = {
         'table1': Table1.XoStruct,
         'table2': Table2.XoStruct

--- a/examples/element_internal_record/002_record_in_individual_element.py
+++ b/examples/element_internal_record/002_record_in_individual_element.py
@@ -12,7 +12,7 @@ import xobjects as xo
 # In this case the element internal record is made of two separate tables each
 # with its own record index.
 
-class Table1(xo.DressedStruct):
+class Table1(xo.HybridClass):
     _xofields = {
         '_index': xt.RecordIndex,
         'particle_x': xo.Float64[:],
@@ -22,7 +22,7 @@ class Table1(xo.DressedStruct):
         'particle_id': xo.Int64[:]
         }
 
-class Table2(xo.DressedStruct):
+class Table2(xo.HybridClass):
     _xofields = {
         '_index': xt.RecordIndex,
         'generated_rr': xo.Float64[:],
@@ -31,7 +31,7 @@ class Table2(xo.DressedStruct):
         'particle_id': xo.Int64[:]
         }
 
-class TestElementRecord(xo.DressedStruct):
+class TestElementRecord(xo.HybridClass):
     _xofields = {
         'table1': Table1.XoStruct,
         'table2': Table2.XoStruct

--- a/tests/test_element_internal_record.py
+++ b/tests/test_element_internal_record.py
@@ -3,6 +3,7 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
+from asyncio.format_helpers import extract_stack
 from tkinter import W
 import numpy as np
 
@@ -20,19 +21,13 @@ def test_record_single_table():
             'particle_id': xo.Int64[:]
             }
 
-    class TestElement(xt.BeamElement):
-        _xofields={
-            'n_kicks': xo.Int64,
-            }
-
-        _internal_record_class = TestElementRecord
-
-    TestElement.XoStruct.extra_sources.extend([
+    extra_src = []
+    extra_src.extend([
         xp._pkg_root.joinpath('random_number_generator/rng_src/base_rng.h'),
         xp._pkg_root.joinpath('random_number_generator/rng_src/local_particle_rng.h'),
         ])
 
-    TestElement.XoStruct.extra_sources.append(r'''
+    extra_src.append(r'''
         /*gpufun*/
         void TestElement_track_local_particle(TestElementData el, LocalParticle* part0){
 
@@ -73,6 +68,16 @@ def test_record_single_table():
             //end_per_particle_block
         }
         ''')
+
+    class TestElement(xt.BeamElement):
+        _xofields={
+            'n_kicks': xo.Int64,
+            }
+
+        _internal_record_class = TestElementRecord
+
+        extra_sources = extra_src
+
 
     for context in xo.context.get_test_contexts():
         print(f"Test {context.__class__}")
@@ -212,18 +217,13 @@ def test_record_multiple_tables():
             'table2': Table2.XoStruct
             }
 
-    class TestElement(xt.BeamElement):
-        _xofields={
-            'n_kicks': xo.Int64,
-            }
-        _internal_record_class = TestElementRecord
-
-    TestElement.XoStruct.extra_sources.extend([
+    extra_src = []
+    extra_src.extend([
         xp._pkg_root.joinpath('random_number_generator/rng_src/base_rng.h'),
         xp._pkg_root.joinpath('random_number_generator/rng_src/local_particle_rng.h'),
         ])
 
-    TestElement.XoStruct.extra_sources.append(r'''
+    extra_src.append(r'''
         /*gpufun*/
         void TestElement_track_local_particle(TestElementData el, LocalParticle* part0){
 
@@ -292,6 +292,15 @@ def test_record_multiple_tables():
             //end_per_particle_block
         }
         ''')
+
+    class TestElement(xt.BeamElement):
+        _xofields={
+            'n_kicks': xo.Int64,
+            }
+        _internal_record_class = TestElementRecord
+
+        extra_sources = extra_src
+
 
         # Checks
 
@@ -467,18 +476,13 @@ def test_record_standalone_mode():
             'table2': Table2.XoStruct
             }
 
-    class TestElement(xt.BeamElement):
-        _xofields={
-            'n_kicks': xo.Int64,
-            }
-        _internal_record_class = TestElementRecord
-
-    TestElement.XoStruct.extra_sources.extend([
+    extra_src = []
+    extra_src.extend([
         xp._pkg_root.joinpath('random_number_generator/rng_src/base_rng.h'),
         xp._pkg_root.joinpath('random_number_generator/rng_src/local_particle_rng.h'),
         ])
 
-    TestElement.XoStruct.extra_sources.append(r'''
+    extra_src.append(r'''
         /*gpufun*/
         void TestElement_track_local_particle(TestElementData el, LocalParticle* part0){
 
@@ -547,6 +551,15 @@ def test_record_standalone_mode():
             //end_per_particle_block
         }
         ''')
+
+    class TestElement(xt.BeamElement):
+        _xofields={
+            'n_kicks': xo.Int64,
+            }
+        _internal_record_class = TestElementRecord
+
+        extra_sources = extra_src
+
 
     # Checks
 

--- a/tests/test_element_internal_record.py
+++ b/tests/test_element_internal_record.py
@@ -10,7 +10,7 @@ import xpart as xp
 import xobjects as xo
 
 def test_record_single_table():
-    class TestElementRecord(xo.DressedStruct):
+    class TestElementRecord(xo.HybridClass):
         _xofields = {
             '_index': xt.RecordIndex,
             'generated_rr': xo.Float64[:],
@@ -190,7 +190,7 @@ def test_record_single_table():
 
 def test_record_multiple_tables():
 
-    class Table1(xo.DressedStruct):
+    class Table1(xo.HybridClass):
         _xofields = {
             '_index': xt.RecordIndex,
             'particle_x': xo.Float64[:],
@@ -200,7 +200,7 @@ def test_record_multiple_tables():
             'particle_id': xo.Int64[:]
             }
 
-    class Table2(xo.DressedStruct):
+    class Table2(xo.HybridClass):
         _xofields = {
             '_index': xt.RecordIndex,
             'generated_rr': xo.Float64[:],
@@ -209,7 +209,7 @@ def test_record_multiple_tables():
             'particle_id': xo.Int64[:]
             }
 
-    class TestElementRecord(xo.DressedStruct):
+    class TestElementRecord(xo.HybridClass):
         _xofields = {
             'table1': Table1.XoStruct,
             'table2': Table2.XoStruct
@@ -449,7 +449,7 @@ def test_record_multiple_tables():
 
 def test_record_standalone_mode():
 
-    class Table1(xo.DressedStruct):
+    class Table1(xo.HybridClass):
         _xofields = {
             '_index': xt.RecordIndex,
             'particle_x': xo.Float64[:],
@@ -459,7 +459,7 @@ def test_record_standalone_mode():
             'particle_id': xo.Int64[:]
             }
 
-    class Table2(xo.DressedStruct):
+    class Table2(xo.HybridClass):
         _xofields = {
             '_index': xt.RecordIndex,
             'generated_rr': xo.Float64[:],
@@ -468,7 +468,7 @@ def test_record_standalone_mode():
             'particle_id': xo.Int64[:]
             }
 
-    class TestElementRecord(xo.DressedStruct):
+    class TestElementRecord(xo.HybridClass):
         _xofields = {
             'table1': Table1.XoStruct,
             'table2': Table2.XoStruct

--- a/tests/test_element_internal_record.py
+++ b/tests/test_element_internal_record.py
@@ -3,8 +3,6 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
-from asyncio.format_helpers import extract_stack
-from tkinter import W
 import numpy as np
 
 import xtrack as xt

--- a/xtrack/__init__.py
+++ b/xtrack/__init__.py
@@ -5,7 +5,7 @@
 
 from .general import _pkg_root
 
-from .base_element import dress_element, BeamElement
+from .base_element import BeamElement
 from .beam_elements import *
 from .line_frozen import LineFrozen
 from .line import Line

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -111,13 +111,14 @@ class MetaBeamElement(xo.MetaDressedStruct):
 
     def __new__(cls, name, bases, data):
         XoStruct_name = name+'Data'
-        if '_xofields' in data.keys():
-            xofields = data['_xofields']
+
+        xofields = {}
+        if "_xofields" in data.keys():
+            xofields.update(data["_xofields"])
         else:
             for bb in bases:
-                if hasattr(bb,'_xofields'):
-                    xofields = bb._xofields
-                    break
+                if hasattr(bb, "_xofields"):
+                    xofields.update(bb._xofields)
 
         if '_internal_record_class' in data.keys():
             xofields['_internal_record_id'] = RecordIdentifier
@@ -178,9 +179,7 @@ class MetaBeamElement(xo.MetaDressedStruct):
 
 class BeamElement(metaclass=MetaBeamElement):
 
-    _xofields={}
     iscollective = None
-    extra_source = []
 
     def init_pipeline(self,pipeline_manager,name,partners_names=[]):
         self._pipeline_manager = pipeline_manager

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -9,7 +9,7 @@ import numpy as np
 import xobjects as xo
 import xpart as xp
 
-from xobjects.dressed_struct import DressedStruct, _build_xofields_dict
+from xobjects.dressed_struct import HybridClass, _build_xofields_dict
 
 from .general import _pkg_root
 from .interal_record import RecordIdentifier, RecordIndex, generate_get_record
@@ -108,7 +108,7 @@ def _generate_per_particle_kernel_from_local_particle_function(
 ''')
     return source
 
-class MetaBeamElement(xo.MetaDressedStruct):
+class MetaBeamElement(xo.MetaHybridClass):
 
     def __new__(cls, name, bases, data):
         XoStruct_name = name+'Data'
@@ -133,7 +133,7 @@ class MetaBeamElement(xo.MetaDressedStruct):
 
             data['extra_sources'] = sources_for_internal_record + data['extra_sources']
 
-        new_class = xo.MetaDressedStruct.__new__(cls, name, bases, data)
+        new_class = xo.MetaHybridClass.__new__(cls, name, bases, data)
         XoStruct = new_class.XoStruct
 
         new_class.per_particle_kernels_source = _generate_per_particle_kernel_from_local_particle_function(
@@ -174,7 +174,7 @@ class MetaBeamElement(xo.MetaDressedStruct):
 
         return new_class
 
-class BeamElement(xo.DressedStruct, metaclass=MetaBeamElement):
+class BeamElement(xo.HybridClass, metaclass=MetaBeamElement):
 
     iscollective = None
 

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -139,7 +139,6 @@ class MetaBeamElement(xo.MetaDressedStruct):
                         xo.Arg(xo.Int8, pointer=True, name="io_buffer")])}
 
         XoStruct._DressingClass = new_class
-        XoStruct.extra_sources = []
 
         if '_internal_record_class' in data.keys():
             new_class.XoStruct._internal_record_class = data['_internal_record_class']
@@ -151,8 +150,6 @@ class MetaBeamElement(xo.MetaDressedStruct):
                 generate_get_record(ele_classname=XoStruct_name,
                     record_classname=data['_internal_record_class'].XoStruct.__name__))
 
-        if 'extra_sources' in data.keys():
-            new_class.XoStruct.extra_sources.extend(data['extra_sources'])
 
         if 'per_particle_kernels' in data.keys():
             for nn, kk in data['per_particle_kernels'].items():

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -112,16 +112,15 @@ class MetaBeamElement(xo.MetaDressedStruct):
     def __new__(cls, name, bases, data):
         XoStruct_name = name+'Data'
 
-        xofields = {}
-        if "_xofields" in data.keys():
-            xofields.update(data["_xofields"])
-        else:
-            for bb in bases:
-                if hasattr(bb, "_xofields"):
-                    xofields.update(bb._xofields)
+        if '_xofields' not in data:
+            data['_xofields'] = {}
+
+        for bb in bases:
+            if hasattr(bb, "_xofields"):
+                data['_xofields'].update(bb._xofields)
 
         if '_internal_record_class' in data.keys():
-            xofields['_internal_record_id'] = RecordIdentifier
+            data['_xofields']['_internal_record_id'] = RecordIdentifier
             if '_skip_in_to_dict' not in data.keys():
                 data['_skip_in_to_dict'] = []
             data['_skip_in_to_dict'].append('_internal_record_id')

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -106,8 +106,7 @@ def _generate_per_particle_kernel_from_local_particle_function(
 ''')
     return source
 
-# TODO Duplicated code with xo.DressedStruct, can it be avoided?
-class MetaBeamElement(type):
+class MetaBeamElement(xo.MetaDressedStruct):
 
     def __new__(cls, name, bases, data):
         XoStruct_name = name+'Data'
@@ -125,10 +124,8 @@ class MetaBeamElement(type):
                 data['_skip_in_to_dict'] = []
             data['_skip_in_to_dict'].append('_internal_record_id')
 
-        XoStruct = type(XoStruct_name, (xo.Struct,), xofields)
-
-        bases = (xo.dress(XoStruct),) + bases
-        new_class = type.__new__(cls, name, bases, data)
+        new_class = xo.MetaDressedStruct.__new__(cls, name, bases, data)
+        XoStruct = new_class.XoStruct
 
         new_class.per_particle_kernels_source = _generate_per_particle_kernel_from_local_particle_function(
             element_name=name, kernel_name=name+'_track_particles',

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -9,7 +9,7 @@ import numpy as np
 import xobjects as xo
 import xpart as xp
 
-from xobjects.dressed_struct import HybridClass, _build_xofields_dict
+from xobjects.hybrid_class import HybridClass, _build_xofields_dict
 
 from .general import _pkg_root
 from .interal_record import RecordIdentifier, RecordIndex, generate_get_record

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -7,8 +7,9 @@ from pathlib import Path
 import numpy as np
 
 import xobjects as xo
-from xobjects.context import sources_from_classes
 import xpart as xp
+
+from xobjects.dressed_struct import _build_xofields_dict
 
 from .general import _pkg_root
 from .interal_record import RecordIdentifier, RecordIndex, generate_get_record
@@ -112,12 +113,9 @@ class MetaBeamElement(xo.MetaDressedStruct):
     def __new__(cls, name, bases, data):
         XoStruct_name = name+'Data'
 
-        if '_xofields' not in data:
-            data['_xofields'] = {}
-
-        for bb in bases:
-            if hasattr(bb, "_xofields"):
-                data['_xofields'].update(bb._xofields)
+        xofields = _build_xofields_dict(bases, data)
+        data = data.copy()
+        data['_xofields'] = xofields
 
         if '_internal_record_class' in data.keys():
             data['_xofields']['_internal_record_id'] = RecordIdentifier

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -9,7 +9,7 @@ import numpy as np
 import xobjects as xo
 import xpart as xp
 
-from xobjects.dressed_struct import _build_xofields_dict
+from xobjects.dressed_struct import DressedStruct, _build_xofields_dict
 
 from .general import _pkg_root
 from .interal_record import RecordIdentifier, RecordIndex, generate_get_record
@@ -174,7 +174,7 @@ class MetaBeamElement(xo.MetaDressedStruct):
 
         return new_class
 
-class BeamElement(metaclass=MetaBeamElement):
+class BeamElement(xo.DressedStruct, metaclass=MetaBeamElement):
 
     iscollective = None
 

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -180,6 +180,7 @@ class BeamElement(metaclass=MetaBeamElement):
 
     _xofields={}
     iscollective = None
+    extra_source = []
 
     def init_pipeline(self,pipeline_manager,name,partners_names=[]):
         self._pipeline_manager = pipeline_manager

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import numpy as np
 
 import xobjects as xo
+from xobjects.context import sources_from_classes
 import xpart as xp
 
 from .general import _pkg_root
@@ -124,6 +125,16 @@ class MetaBeamElement(xo.MetaDressedStruct):
                 data['_skip_in_to_dict'] = []
             data['_skip_in_to_dict'].append('_internal_record_id')
 
+            sources_for_internal_record = []
+            sources_for_internal_record.extend(
+                xo.context.sources_from_classes(xo.context.sort_classes(
+                                            [data['_internal_record_class'].XoStruct])))
+            sources_for_internal_record.append(
+                generate_get_record(ele_classname=XoStruct_name,
+                    record_classname=data['_internal_record_class'].XoStruct.__name__))
+
+            data['extra_sources'] = sources_for_internal_record + data['extra_sources']
+
         new_class = xo.MetaDressedStruct.__new__(cls, name, bases, data)
         XoStruct = new_class.XoStruct
 
@@ -143,12 +154,6 @@ class MetaBeamElement(xo.MetaDressedStruct):
         if '_internal_record_class' in data.keys():
             new_class.XoStruct._internal_record_class = data['_internal_record_class']
             new_class._internal_record_class = data['_internal_record_class']
-            new_class.XoStruct.extra_sources.extend(
-                xo.context.sources_from_classes(xo.context.sort_classes(
-                                            [data['_internal_record_class'].XoStruct])))
-            new_class.XoStruct.extra_sources.append(
-                generate_get_record(ele_classname=XoStruct_name,
-                    record_classname=data['_internal_record_class'].XoStruct.__name__))
 
 
         if 'per_particle_kernels' in data.keys():

--- a/xtrack/beam_elements/apertures.py
+++ b/xtrack/beam_elements/apertures.py
@@ -22,7 +22,7 @@ class LimitRect(BeamElement):
     def get_backtrack_element(self, _context=None, _buffer=None, _offset=None):
         return self.copy(_context=_context, _buffer=_buffer, _offset=_offset)
 
-LimitRect.XoStruct.extra_sources = [
+    extra_sources = [
         _pkg_root.joinpath('beam_elements/apertures_src/limitrect.h')]
 
 
@@ -93,7 +93,7 @@ class LimitEllipse(BeamElement):
     def get_backtrack_element(self, _context=None, _buffer=None, _offset=None):
         return self.copy(_context=_context, _buffer=_buffer, _offset=_offset)
 
-LimitEllipse.XoStruct.extra_sources = [
+    extra_sources = [
         _pkg_root.joinpath('beam_elements/apertures_src/limitellipse.h')]
 
 
@@ -206,7 +206,7 @@ class LimitPolygon(BeamElement):
         cy = 1/(6*self.area)*np.sum((y[:-1]+y[1:])*(y[:-1]*x[1:]-y[1:]*x[:-1]))
         return (cx,cy)
 
-LimitPolygon.XoStruct.extra_sources = [
+    extra_sources = [
         _pkg_root.joinpath('beam_elements/apertures_src/limitpolygon.h')]
 
 LimitPolygon.XoStruct.custom_kernels = {
@@ -289,6 +289,6 @@ class LimitRectEllipse(BeamElement):
         self.a_b_squ = a_squ * b_squ
         return self
 
-LimitRectEllipse.XoStruct.extra_sources = [
+    extra_sources = [
         _pkg_root.joinpath('beam_elements/apertures_src/limitrectellipse.h')]
 

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -222,7 +222,7 @@ class SRotation(BeamElement):
                               _context=_context, _buffer=_buffer, _offset=_offset)
 
 
-class SynchrotronRadiationRecord(xo.DressedStruct):
+class SynchrotronRadiationRecord(xo.HybridClass):
     _xofields = {
         '_index': RecordIndex,
         'photon_energy': xo.Float64[:],

--- a/xtrack/monitors.py
+++ b/xtrack/monitors.py
@@ -117,6 +117,7 @@ def generate_monitor_class(ParticlesClass):
         _pkg_root.joinpath("monitors_src/monitors.h")
     ]
 
+    import pdb; pdb.set_trace()
     ParticlesMonitorClass = type(
         "ParticlesMonitor",
         (BeamElement,),

--- a/xtrack/monitors.py
+++ b/xtrack/monitors.py
@@ -5,7 +5,7 @@
 
 import xobjects as xo
 
-from .base_element import dress_element
+from .base_element import BeamElement
 from .general import _pkg_root
 
 
@@ -101,30 +101,29 @@ class _FieldOfMonitor:
 
 def generate_monitor_class(ParticlesClass):
 
-    ParticlesMonitorDataClass = type(
-        "ParticlesMonitorData",
-        (xo.Struct,),
-        {
-            "start_at_turn": xo.Int64,
-            "stop_at_turn": xo.Int64,
-            'part_id_start': xo.Int64,
-            'part_id_end': xo.Int64,
-            'ebe_mode': xo.Int64,
-            "n_records": xo.Int64,
-            "n_repetitions": xo.Int64,
-            "repetition_period": xo.Int64,
-            "data": ParticlesClass.XoStruct,
-        },
-    )
+    _xofields = {
+        "start_at_turn": xo.Int64,
+        "stop_at_turn": xo.Int64,
+        'part_id_start': xo.Int64,
+        'part_id_end': xo.Int64,
+        'ebe_mode': xo.Int64,
+        "n_records": xo.Int64,
+        "n_repetitions": xo.Int64,
+        "repetition_period": xo.Int64,
+        "data": ParticlesClass.XoStruct,
+    }
 
-    ParticlesMonitorDataClass.extra_sources = [
+    extra_sources = [
         _pkg_root.joinpath("monitors_src/monitors.h")
     ]
 
     ParticlesMonitorClass = type(
         "ParticlesMonitor",
-        (dress_element(ParticlesMonitorDataClass),),
-        {"_ParticlesClass": ParticlesClass},
+        (BeamElement,),
+        {"_ParticlesClass": ParticlesClass,
+        '_xofields': _xofields,
+        'extra_sources': extra_sources,
+        },
     )
 
     ParticlesMonitorClass.__init__ = _monitor_init

--- a/xtrack/monitors.py
+++ b/xtrack/monitors.py
@@ -117,7 +117,6 @@ def generate_monitor_class(ParticlesClass):
         _pkg_root.joinpath("monitors_src/monitors.h")
     ]
 
-    import pdb; pdb.set_trace()
     ParticlesMonitorClass = type(
         "ParticlesMonitor",
         (BeamElement,),


### PR DESCRIPTION
**Changes:**
 - Removed ```dress_element``` function. Now there is only one mechanism to create beam elements which is to inherit from the ```BeamElement``` class.
 - Across the package ```xobjects.DressedStruct``` has been replaced with ```xobjects.HybridClass``` following update in xobjects.