### PR TITLE
add extras_require for installing test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,8 @@ setup(
         'xobjects',
         'xpart',
         'xdeps'
-        ]
+        ],
+    extras_require={
+        'tests': ['cpymad', 'PyHEADTAIL'],
+        },
     )


### PR DESCRIPTION
With this, one can install xtrack for testing as following:
```bash
cd /path/to/xtrack
pip install -e .[tests]  # will install cpymad and pyHEADTAIL if unavailable
```