### PR TITLE
Release v0.20.3

### DIFF
--- a/xtrack/linear_normal_form.py
+++ b/xtrack/linear_normal_form.py
@@ -57,7 +57,7 @@ def Rot2D(mu):
     return np.array([[ np.cos(mu), np.sin(mu)],
                      [-np.sin(mu), np.cos(mu)]])
 
-def compute_linear_normal_form(M, symplectify=True, only_4d_block=False,
+def compute_linear_normal_form(M, symplectify=False, only_4d_block=False,
                         responsiveness_tol=DEFAULT_MATRIX_RESPONSIVENESS_TOL,
                         stability_tol=DEFAULT_MATRIX_STABILITY_TOL):
 

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -231,7 +231,11 @@ def twiss_from_tracker(tracker, particle_ref=None, method='6d',
             'circumference': circumference, 'T_rev': T_rev,
             'particle_on_co':part_on_co.copy(_context=xo.context_default)
         })
-        twiss_res['particle_on_co']._fsolve_info = part_on_co._fsolve_info
+        if hasattr(part_on_co, '_fsolve_info'):
+            twiss_res['particle_on_co']._fsolve_info = part_on_co._fsolve_info
+        else:
+            twiss_res['particle_on_co']._fsolve_info = None
+
         twiss_res['R_matrix'] = RR
 
         if method == '4d':


### PR DESCRIPTION
**Changes:**
 - Change a default value ```compute_linear_normal_form(M, symplectify=True, ...)```
 - Handle missing fsolve_info in closed orbit search when fsolve is skipped