### PR TITLE
Pzeta in monitor

### DIFF
--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -49,7 +49,7 @@ def test_monitor():
         assert np.all(mon.at_turn[3, :] == np.arange(0, num_turns))
         assert np.all(mon.particle_id[:, 3] == np.arange(0, num_particles))
         assert np.all(mon.at_element[:, :] == 0)
-        assert np.all(mon.pzeta[:, 0] == particles0.pzeta) #new
+        assert np.all(mon.pzeta[:, 0] == particles0.pzeta)
 
         # Test explicit monitor passed to track
         monitor = xt.ParticlesMonitor(_context=context,

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -49,6 +49,7 @@ def test_monitor():
         assert np.all(mon.at_turn[3, :] == np.arange(0, num_turns))
         assert np.all(mon.particle_id[:, 3] == np.arange(0, num_particles))
         assert np.all(mon.at_element[:, :] == 0)
+        assert np.all(mon.pzeta[:, 0] == particles0.pzeta) #new
 
         # Test explicit monitor passed to track
         monitor = xt.ParticlesMonitor(_context=context,
@@ -61,6 +62,7 @@ def test_monitor():
         assert np.all(monitor.at_turn[3, :] == np.arange(5, 15))
         assert np.all(monitor.particle_id[:, 3] == np.arange(0, num_particles))
         assert np.all(monitor.at_element[:, :] == 0)
+        assert np.all(monitor.pzeta[:, 0] == mon.pzeta[:, 5]) #5 in mon because the 0th entry of monitor is the 5th turn (5th entry in mon)
 
 
         # Test explicit monitor used in in stand-alone mode
@@ -76,6 +78,7 @@ def test_monitor():
         assert np.all(mon2.at_turn[3, :] == np.arange(5, 15))
         assert np.all(mon2.particle_id[:, 3] == np.arange(0, num_particles))
         assert np.all(mon2.at_element[:, :] == 0)
+        assert np.all(mon2.pzeta[:, 0] == mon.pzeta[:, 5]) #5 in mon because the 0th entry of monitor is the 5th turn (5th entry in mon)
 
         # Test monitors with multiple frames
         monitor_multiframe = xt.ParticlesMonitor(_context=context,
@@ -92,6 +95,7 @@ def test_monitor():
         assert np.all(monitor_multiframe.particle_id[2, :, 3] == np.arange(0,
                                                                  num_particles))
         assert np.all(monitor_multiframe.at_element[:, :, :] == 0)
+        assert np.all(monitor_multiframe.pzeta[0, :, 0] == mon.pzeta[:, 5]) #5 in mon because the 0th entry of monitor is the 5th turn (5th entry in mon)
 
         # Test monitors installed in a line
         monitor_ip5 = xt.ParticlesMonitor(start_at_turn=5, stop_at_turn=15,

--- a/xtrack/monitors.py
+++ b/xtrack/monitors.py
@@ -132,7 +132,7 @@ def generate_monitor_class(ParticlesClass):
     for tt, nn in per_particle_vars:
         setattr(ParticlesMonitorClass, nn, _FieldOfMonitor(name=nn))
 
-    for nn in ['pzeta', 'energy']:
+    for nn in ['pzeta']:
         setattr(ParticlesMonitorClass, nn, _FieldOfMonitor(name=nn))
 
     return ParticlesMonitorClass

--- a/xtrack/monitors.py
+++ b/xtrack/monitors.py
@@ -132,4 +132,7 @@ def generate_monitor_class(ParticlesClass):
     for tt, nn in per_particle_vars:
         setattr(ParticlesMonitorClass, nn, _FieldOfMonitor(name=nn))
 
+    for nn in ['pzeta', 'energy']:
+        setattr(ParticlesMonitorClass, nn, _FieldOfMonitor(name=nn))
+
     return ParticlesMonitorClass


### PR DESCRIPTION
## Description
pzeta variable was not accessible in monitor. Included it to be.

To note that there is a problem if the same is attempted for the energy0 variable. It becomes equal to p0c in the monitor, as if it cannot read mass0 and makes it equal to 0. Very subtle difference of 9e-7%.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
