### PR TITLE
Fix behaviour of `particle_ref` in `Tracker` and `Line`

### DIFF
--- a/tests/test_spacecharge_in_ring.py
+++ b/tests/test_spacecharge_in_ring.py
@@ -20,11 +20,11 @@ def test_ring_with_spacecharge():
                       'line_no_spacecharge_and_particle.json')
 
     # Test settings (fast but inaccurate)
-    bunch_intensity = 1e11/3 # Need short bunch to avoid bucket non-linearity
+    bunch_intensity = 1e11/3  # Need short bunch to avoid bucket non-linearity
     sigma_z = 22.5e-2/3
-    nemitt_x=2.5e-6
-    nemitt_y=2.5e-6
-    n_part=int(1e6/10)*10
+    nemitt_x = 2.5e-6
+    nemitt_y = 2.5e-6
+    n_part = int(1e6/10)*10
     nz_grid = 100//20
     z_range = (-3*sigma_z/40, 3*sigma_z/40)
 
@@ -46,18 +46,17 @@ def test_ring_with_spacecharge():
         z0=0.,
         q_parameter=1.)
 
-
     ##################
     # Make particles #
     ##################
-    tracker_temp=xt.Tracker(# I make a temp tracker to gen. particles only once 
+    tracker_temp = xt.Tracker(  # I make a temp tracker to gen. particles only once
             line=line0_no_sc.filter_elements(exclude_types_starting_with='SpaceCh'))
     import warnings
     warnings.filterwarnings('ignore')
     particle_probe = xp.build_particles(
                 tracker=tracker_temp,
                 particle_ref=particle_ref,
-                weight=0, # pure probe particles
+                weight=0,  # pure probe particles
                 zeta=0, delta=0,
                 x_norm=2, px_norm=0,
                 y_norm=2, py_norm=0,
@@ -99,13 +98,14 @@ def test_ring_with_spacecharge():
 
             warnings.filterwarnings('ignore')
             line = line0_no_sc.copy()
-            xf.install_spacecharge_frozen(line=line,
-                           particle_ref=particle_ref,
-                           longitudinal_profile=lprofile,
-                           nemitt_x=nemitt_x, nemitt_y=nemitt_y,
-                           sigma_z=sigma_z,
-                           num_spacecharge_interactions=num_spacecharge_interactions,
-                           tol_spacecharge_position=tol_spacecharge_position)
+            xf.install_spacecharge_frozen(
+                    line=line,
+                    particle_ref=particle_ref,
+                    longitudinal_profile=lprofile,
+                    nemitt_x=nemitt_x, nemitt_y=nemitt_y,
+                    sigma_z=sigma_z,
+                    num_spacecharge_interactions=num_spacecharge_interactions,
+                    tol_spacecharge_position=tol_spacecharge_position)
             warnings.filterwarnings('default')
 
             ##########################
@@ -134,7 +134,7 @@ def test_ring_with_spacecharge():
             # Build Tracker #
             #################
             tracker = xt.Tracker(_context=context,
-                                line=line)
+                                 line=line)
 
             ###############################
             # Tune shift from single turn #
@@ -158,8 +158,8 @@ def test_ring_with_spacecharge():
             alfx = tw['alfx'][0]
             print(f'{alfx=} {betx=}')
             phasex_0 = np.angle(p_probe_before['x'] / np.sqrt(betx) -
-                               1j*(p_probe_before['x'] * alfx / np.sqrt(betx) +
-                                   p_probe_before['px'] * np.sqrt(betx)))[0]
+                                1j*(p_probe_before['x'] * alfx / np.sqrt(betx) +
+                                p_probe_before['px'] * np.sqrt(betx)))[0]
             phasex_1 = np.angle(p_probe_after['x'] / np.sqrt(betx) -
                                1j*(p_probe_after['x'] * alfx / np.sqrt(betx) +
                                    p_probe_after['px'] * np.sqrt(betx)))[0]
@@ -167,11 +167,11 @@ def test_ring_with_spacecharge():
             alfy = tw['alfy'][0]
             print(f'{alfy=} {bety=}')
             phasey_0 = np.angle(p_probe_before['y'] / np.sqrt(bety) -
-                               1j*(p_probe_before['y'] * alfy / np.sqrt(bety) +
-                                   p_probe_before['py'] * np.sqrt(bety)))[0]
+                                1j*(p_probe_before['y'] * alfy / np.sqrt(bety) +
+                                p_probe_before['py'] * np.sqrt(bety)))[0]
             phasey_1 = np.angle(p_probe_after['y'] / np.sqrt(bety) -
-                               1j*(p_probe_after['y'] * alfy / np.sqrt(bety) +
-                                   p_probe_after['py'] * np.sqrt(bety)))[0]
+                                1j*(p_probe_after['y'] * alfy / np.sqrt(bety) +
+                                p_probe_after['py'] * np.sqrt(bety)))[0]
             qx_probe = (phasex_1 - phasex_0)/(2*np.pi)
             qy_probe = (phasey_1 - phasey_0)/(2*np.pi)
 
@@ -182,4 +182,3 @@ def test_ring_with_spacecharge():
                   f'ey={(qy_probe - qy_target)/1e-3:.6f}e-3')
             assert np.isclose(qx_probe, qx_target, atol=5e-4, rtol=0)
             assert np.isclose(qy_probe, qy_target, atol=5e-4, rtol=0)
-

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -266,7 +266,7 @@ class Line:
         if ((index_first_element is not None and name_first_element is not None)
                or (index_first_element is None and name_first_element is None)):
              raise ValueError(
-                "Plaese provide either `index_first_element` or `name_first_element`.")
+                "Please provide either `index_first_element` or `name_first_element`.")
 
         if name_first_element is not None:
             assert self.element_names.count(name_first_element) == 1, (
@@ -274,13 +274,14 @@ class Line:
             )
             index_first_element = self.element_names.index(name_first_element)
 
-        new_elements = (list(self.elements[index_first_element:])
-                        + list(self.elements[:index_first_element]))
         new_element_names = (list(self.element_names[index_first_element:])
-                        + list(self.element_names[:index_first_element]))
+                             + list(self.element_names[:index_first_element]))
 
         return self.__class__(
-                         elements=new_elements, element_names=new_element_names)
+            elements=self.element_dict,
+            element_names=new_element_names,
+            particle_ref=self.particle_ref,
+        )
 
     def configure_radiation(self, mode=None):
         assert mode in [None, 'mean', 'quantum']

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -519,9 +519,13 @@ class Tracker:
                 )
 
     @property
-    def particle_ref(self):
+    def particle_ref(self) -> xp.Particles:
         self._check_invalidated()
         return self.line.particle_ref
+
+    @particle_ref.setter
+    def particle_ref(self, value: xp.Particles):
+        self.line.particle_ref = value
 
     @property
     def vars(self):
@@ -1274,6 +1278,7 @@ class Tracker:
         except AttributeError:
             raise TypeError("Only non-collective trackers can be binary serialized.")
 
+        # Serialise the tracker_data (line)
         if not isinstance(tracker_data._context, xo.ContextCpu):
             buffer = xo.ContextCpu().new_buffer(0)
         else:
@@ -1281,14 +1286,21 @@ class Tracker:
 
         buffer, header_offset = tracker_data.to_binary(buffer)
 
+        # Serialise the knobs
         var_management = {}
         if tracker_data.line._var_management:
             var_management = tracker_data.line._var_management_to_dict()
+
+        # Serialise the reference particle
+        particle_ref = None
+        if self.particle_ref:
+            particle_ref = self.particle_ref.to_dict()
 
         with open(path, 'wb') as f:
             np.save(f, header_offset)
             np.save(f, buffer.buffer)
             np.save(f, var_management, allow_pickle=True)
+            np.save(f, particle_ref, allow_pickle=True)
 
     @classmethod
     def from_binary_file(cls, path, particles_monitor_class=None) -> 'Tracker':
@@ -1299,6 +1311,7 @@ class Tracker:
             header_offset = np.load(f)
             np_buffer = np.load(f)
             var_management_dict = np.load(f, allow_pickle=True).item()
+            particle_ref = np.load(f, allow_pickle=True).item()
 
         xbuffer = xo.ContextCpu().new_buffer(np_buffer.nbytes)
         # make sure that if we carry on using the buffer we
@@ -1313,7 +1326,12 @@ class Tracker:
         if var_management_dict:
             tracker_data.line._init_var_management(var_management_dict)
 
-        return Tracker(
+        tracker = Tracker(
             line=tracker_data.line,
             _element_ref_data=tracker_data._element_ref_data,
         )
+
+        if particle_ref is not None:
+            tracker.particle_ref = xp.Particles.from_dict(particle_ref)
+
+        return tracker


### PR DESCRIPTION
## Description

Improve the handling of {`Tracker`, `Line`}`.particle_ref`:
- add a setter to `Tracker`,
- propagate `particle_ref` on `Line.cycle`,
- serialise `Tracker.particle_ref` in `Tracker.to_binary_file`.

Also done a little reformatting.

Closes xsuite/xsuite#212.
Closes xsuite/xsuite#213.
Closes xsuite/xsuite#215.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
