### PR TITLE
Multiple kernels in tracker based on compile-time config

### DIFF
--- a/examples/full_ring/007_test_freeze_vars.py
+++ b/examples/full_ring/007_test_freeze_vars.py
@@ -53,24 +53,22 @@ line.particle_ref = xp.Particles(**input_data['particle'])
 print('Build tracker...')
 freeze_vars = xp.particles.part_energy_varnames() + ['zeta']
 tracker = xt.Tracker(_context=context,
-            line=line,
-            local_particle_src=xp.gen_local_particle_api(
-                                                freeze_vars=freeze_vars),
-            )
+            line=line)
+tracker.freeze_vars(freeze_vars)
 
 #########
 # Twiss #
 #########
 
-tw = tracker.twiss(method='4d') # <-- Need to choose 4d method when longitudinal
-                                #     variables are frozen
+tw = tracker.twiss(method='4d')  # <-- Need to choose 4d method when longitudinal
+                                 #     variables are frozen
 
 ##################################
 # Match a particles distribution #
 ##################################
 
 particles = xp.build_particles(_context=context, tracker=tracker,
-                               method = '4d', # <--- 4d
+                               method = '4d',  # <--- 4d
                                x_norm=np.linspace(0, 10, 11),
                                nemitt_x=3e-6, nemitt_y=3e-6)
 
@@ -81,6 +79,9 @@ particles_before_tracking = particles.copy()
 #########
 print('Track a few turns...')
 n_turns = 10
+tracker.track(particles, num_turns=n_turns)
+
+print('Track again (no compile)')
 tracker.track(particles, num_turns=n_turns)
 
 for vv in ['ptau', 'delta', 'rpp', 'rvv', 'zeta']:

--- a/tests/test_full_rings.py
+++ b/tests/test_full_rings.py
@@ -194,10 +194,9 @@ def test_freeze_vars():
         freeze_vars = xp.particles.part_energy_varnames() + ['zeta']
         tracker = xt.Tracker(_context=context,
                              line=line,
-                             local_particle_src=xp.gen_local_particle_api(
-                                 freeze_vars=freeze_vars),
-                             reset_s_at_end_turn=False
+                             reset_s_at_end_turn=False,
                              )
+        tracker.freeze_vars(freeze_vars)
 
         ######################
         # Get some particles #

--- a/tests/test_spacecharge_in_ring.py
+++ b/tests/test_spacecharge_in_ring.py
@@ -20,11 +20,11 @@ def test_ring_with_spacecharge():
                       'line_no_spacecharge_and_particle.json')
 
     # Test settings (fast but inaccurate)
-    bunch_intensity = 1e11/3 # Need short bunch to avoid bucket non-linearity
+    bunch_intensity = 1e11/3  # Need short bunch to avoid bucket non-linearity
     sigma_z = 22.5e-2/3
-    nemitt_x=2.5e-6
-    nemitt_y=2.5e-6
-    n_part=int(1e6/10)*10
+    nemitt_x = 2.5e-6
+    nemitt_y = 2.5e-6
+    n_part = int(1e6/10)*10
     nz_grid = 100//20
     z_range = (-3*sigma_z/40, 3*sigma_z/40)
 
@@ -46,18 +46,17 @@ def test_ring_with_spacecharge():
         z0=0.,
         q_parameter=1.)
 
-
     ##################
     # Make particles #
     ##################
-    tracker_temp=xt.Tracker(# I make a temp tracker to gen. particles only once 
+    tracker_temp = xt.Tracker(  # I make a temp tracker to gen. particles only once
             line=line0_no_sc.filter_elements(exclude_types_starting_with='SpaceCh'))
     import warnings
     warnings.filterwarnings('ignore')
     particle_probe = xp.build_particles(
                 tracker=tracker_temp,
                 particle_ref=particle_ref,
-                weight=0, # pure probe particles
+                weight=0,  # pure probe particles
                 zeta=0, delta=0,
                 x_norm=2, px_norm=0,
                 y_norm=2, py_norm=0,
@@ -99,13 +98,14 @@ def test_ring_with_spacecharge():
 
             warnings.filterwarnings('ignore')
             line = line0_no_sc.copy()
-            xf.install_spacecharge_frozen(line=line,
-                           particle_ref=particle_ref,
-                           longitudinal_profile=lprofile,
-                           nemitt_x=nemitt_x, nemitt_y=nemitt_y,
-                           sigma_z=sigma_z,
-                           num_spacecharge_interactions=num_spacecharge_interactions,
-                           tol_spacecharge_position=tol_spacecharge_position)
+            xf.install_spacecharge_frozen(
+                    line=line,
+                    particle_ref=particle_ref,
+                    longitudinal_profile=lprofile,
+                    nemitt_x=nemitt_x, nemitt_y=nemitt_y,
+                    sigma_z=sigma_z,
+                    num_spacecharge_interactions=num_spacecharge_interactions,
+                    tol_spacecharge_position=tol_spacecharge_position)
             warnings.filterwarnings('default')
 
             ##########################
@@ -134,7 +134,7 @@ def test_ring_with_spacecharge():
             # Build Tracker #
             #################
             tracker = xt.Tracker(_context=context,
-                                line=line)
+                                 line=line)
 
             ###############################
             # Tune shift from single turn #
@@ -158,8 +158,8 @@ def test_ring_with_spacecharge():
             alfx = tw['alfx'][0]
             print(f'{alfx=} {betx=}')
             phasex_0 = np.angle(p_probe_before['x'] / np.sqrt(betx) -
-                               1j*(p_probe_before['x'] * alfx / np.sqrt(betx) +
-                                   p_probe_before['px'] * np.sqrt(betx)))[0]
+                                1j*(p_probe_before['x'] * alfx / np.sqrt(betx) +
+                                p_probe_before['px'] * np.sqrt(betx)))[0]
             phasex_1 = np.angle(p_probe_after['x'] / np.sqrt(betx) -
                                1j*(p_probe_after['x'] * alfx / np.sqrt(betx) +
                                    p_probe_after['px'] * np.sqrt(betx)))[0]
@@ -167,11 +167,11 @@ def test_ring_with_spacecharge():
             alfy = tw['alfy'][0]
             print(f'{alfy=} {bety=}')
             phasey_0 = np.angle(p_probe_before['y'] / np.sqrt(bety) -
-                               1j*(p_probe_before['y'] * alfy / np.sqrt(bety) +
-                                   p_probe_before['py'] * np.sqrt(bety)))[0]
+                                1j*(p_probe_before['y'] * alfy / np.sqrt(bety) +
+                                p_probe_before['py'] * np.sqrt(bety)))[0]
             phasey_1 = np.angle(p_probe_after['y'] / np.sqrt(bety) -
-                               1j*(p_probe_after['y'] * alfy / np.sqrt(bety) +
-                                   p_probe_after['py'] * np.sqrt(bety)))[0]
+                                1j*(p_probe_after['y'] * alfy / np.sqrt(bety) +
+                                p_probe_after['py'] * np.sqrt(bety)))[0]
             qx_probe = (phasex_1 - phasex_0)/(2*np.pi)
             qy_probe = (phasey_1 - phasey_0)/(2*np.pi)
 
@@ -182,4 +182,3 @@ def test_ring_with_spacecharge():
                   f'ey={(qy_probe - qy_target)/1e-3:.6f}e-3')
             assert np.isclose(qx_probe, qx_target, atol=5e-4, rtol=0)
             assert np.isclose(qy_probe, qy_target, atol=5e-4, rtol=0)
-

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -266,7 +266,7 @@ class Line:
         if ((index_first_element is not None and name_first_element is not None)
                or (index_first_element is None and name_first_element is None)):
              raise ValueError(
-                "Plaese provide either `index_first_element` or `name_first_element`.")
+                "Please provide either `index_first_element` or `name_first_element`.")
 
         if name_first_element is not None:
             assert self.element_names.count(name_first_element) == 1, (
@@ -274,13 +274,14 @@ class Line:
             )
             index_first_element = self.element_names.index(name_first_element)
 
-        new_elements = (list(self.elements[index_first_element:])
-                        + list(self.elements[:index_first_element]))
         new_element_names = (list(self.element_names[index_first_element:])
-                        + list(self.element_names[:index_first_element]))
+                             + list(self.element_names[:index_first_element]))
 
         return self.__class__(
-                         elements=new_elements, element_names=new_element_names)
+            elements=self.element_dict,
+            element_names=new_element_names,
+            particle_ref=self.particle_ref,
+        )
 
     def configure_radiation(self, mode=None):
         assert mode in [None, 'mean', 'quantum']

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -3,36 +3,35 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
-import numpy as np
 import logging
 from functools import partial
 
-from .general import _pkg_root
-from .tracker_data import TrackerData
-from .base_element import _handle_per_particle_blocks
-from .twiss import (twiss_from_tracker,
-                                 compute_one_turn_matrix_finite_differences,
-                                 find_closed_orbit, match_tracker
-                                )
-from .survey import survey_from_tracker
-from .internal_record import (new_io_buffer,
-                             start_internal_logging_for_elements_of_type,
-                             stop_internal_logging_for_elements_of_type)
-from .pipeline import PipelineStatus
-
+import numpy as np
 import xobjects as xo
 import xpart as xp
-
-from .beam_elements import Drift
-from .line import Line
+from xdeps.utils import AttrDict
 
 from . import linear_normal_form as lnf
+from .base_element import _handle_per_particle_blocks
+from .beam_elements import Drift
+from .general import _pkg_root
+from .internal_record import (new_io_buffer,
+                              start_internal_logging_for_elements_of_type,
+                              stop_internal_logging_for_elements_of_type)
+from .line import Line
+from .pipeline import PipelineStatus
+from .survey import survey_from_tracker
+from .tracker_data import TrackerData
+from .twiss import (compute_one_turn_matrix_finite_differences,
+                    find_closed_orbit, match_tracker, twiss_from_tracker)
 
 logger = logging.getLogger(__name__)
+
 
 def _check_is_collective(ele):
     iscoll = not hasattr(ele, 'iscollective') or ele.iscollective
     return iscoll
+
 
 class Tracker:
 
@@ -58,6 +57,10 @@ class Tracker:
         enable_pipeline_hold=False,
         _element_ref_data=None,
     ):
+        self.config = AttrDict(
+            XTRACK_MULTIPOLE_NO_SYNRAD=False,
+            DISABLE_EBE_MONITOR=False,
+        )
 
         if sequence is not None:
             raise ValueError(
@@ -235,6 +238,7 @@ class Tracker:
                 save_source_as=save_source_as,
                 io_buffer=self.io_buffer
                 )
+        supertracker.config = self.config
 
         # Build trackers for non collective parts
         for ii, pp in enumerate(parts):
@@ -250,6 +254,7 @@ class Tracker:
                                 local_particle_src=local_particle_src,
                                 skip_end_turn_actions=True,
                                 io_buffer=self.io_buffer)
+                parts[ii].config = self.config
 
         # Make a "marker" element to increase at_element
         self._zerodrift = Drift(_context=_buffer.context, length=0)
@@ -291,9 +296,14 @@ class Tracker:
         compile=True,
         enable_pipeline_hold=False
     ):
+        if track_kernel == 'skip':
+            raise ValueError('Value `skip` for track kernel is deprecated for '
+                             'non-collective trackers, as all (re)compilation '
+                             'is done on demand.')
 
-        assert not(enable_pipeline_hold), (
-            "enable_pipeline_hold is not implemented in non collective mode")
+        if enable_pipeline_hold:
+            raise ValueError("`enable_pipeline_hold` is not implemented in "
+                             "non-collective mode")
         self._enable_pipeline_hold = False
 
         if particles_class is None:
@@ -320,13 +330,17 @@ class Tracker:
             io_buffer = new_io_buffer(_context=context)
         self.io_buffer = io_buffer
 
-        if track_kernel is None:
-            # Kernel relies on element_classes ordering
-            assert element_classes is None
+        if track_kernel is None and element_classes is not None:
+            raise ValueError('The kernel relies on `element_classes` ordering, '
+                             'so `element_classes` must be given if '
+                             '`track_kernel` is None.')
 
         if element_classes is None:
-            # Kernel relies on element_classes ordering
-            assert track_kernel == 'skip' or track_kernel is None
+            if track_kernel is not None:
+                raise ValueError(
+                    'The kernel relies on `element_classes` ordering, so '
+                    '`track_kernel` must be given if `element_classes` is None.'
+                )
             element_classes = tracker_data.element_classes
 
         line._freeze()
@@ -345,18 +359,15 @@ class Tracker:
         self.element_classes = element_classes
         self._buffer = tracker_data._buffer
 
-        if track_kernel == 'skip':
-            self.track_kernel = None
-        elif track_kernel is None:
-            self._build_kernel(save_source_as, compile=compile)
-        else:
-            self.track_kernel = track_kernel
+        if track_kernel is None:
+            track_kernel = {}
+        self.track_kernel = track_kernel
 
         self.track = self._track_no_collective
 
     def _invalidate(self):
         if self.iscollective:
-            self._invalidated_parts  = self._parts
+            self._invalidated_parts = self._parts
             self._parts = None
         else:
             self._invalidated_tracker_data = self._tracker_data
@@ -726,7 +737,7 @@ class Tracker:
         context.add_kernels(
             [source_track],
             kernels,
-            extra_headers=headers,
+            extra_headers=self._config_to_headers() + headers,
             extra_classes=self.element_classes,
             apply_to_source=[
                 partial(_handle_per_particle_blocks,
@@ -736,7 +747,7 @@ class Tracker:
             compile=compile
         )
 
-        self.track_kernel = context.kernels.track_line
+        self._current_track_kernel = context.kernels.track_line
 
     def _prepare_collective_track_session(self, particles, ele_start, ele_stop,
                                        num_elements, num_turns, turn_by_turn_monitor):
@@ -745,10 +756,10 @@ class Tracker:
         if particles.start_tracking_at_element >= 0:
             if ele_start != 0:
                 raise ValueError("The argument ele_start is used, but particles.start_tracking_at_element is set as well. "
-                                + "Please use only one of those methods.")
+                                 "Please use only one of those methods.")
             ele_start = particles.start_tracking_at_element
             particles.start_tracking_at_element = -1
-        if isinstance(ele_start,str):
+        if isinstance(ele_start, str):
             ele_start = self.line.element_names.index(ele_start)
 
         # ele_start can only have values of existing element id's,
@@ -891,6 +902,13 @@ class Tracker:
     def resume(self, session):
         return self._track_with_collective(particles=None, _session_to_resume=session)
 
+    def freeze_vars(self, variable_names):
+        for name in variable_names:
+            self.config[f'FREEZE_VAR_{name}'] = True
+
+    def unfreeze_vars(self, variable_names):
+        for name in variable_names:
+            self.config[f'FREEZE_VAR_{name}'] = False
 
     def _track_with_collective(
         self,
@@ -1073,10 +1091,10 @@ class Tracker:
         if particles.start_tracking_at_element >= 0:
             if ele_start != 0:
                 raise ValueError("The argument ele_start is used, but particles.start_tracking_at_element is set as well. "
-                                + "Please use only one of those methods.")
+                                 "Please use only one of those methods.")
             ele_start = particles.start_tracking_at_element
             particles.start_tracking_at_element = -1
-        if isinstance(ele_start,str):
+        if isinstance(ele_start, str):
             ele_start = self.line.element_names.index(ele_start)
 
         assert ele_start >= 0
@@ -1169,10 +1187,10 @@ class Tracker:
         if self.line._needs_rng and not particles._has_valid_rng_state():
             particles._init_random_number_generator()
 
-        self.track_kernel.description.n_threads = particles._capacity
+        self._current_track_kernel.description.n_threads = particles._capacity
 
         # First turn
-        self.track_kernel(
+        self._current_track_kernel(
             buffer=self._tracker_data._buffer.buffer,
             tracker_data=self._tracker_data._element_ref_data,
             particles=particles._xobject,
@@ -1189,7 +1207,7 @@ class Tracker:
 
         # Middle turns
         if num_middle_turns > 0:
-            self.track_kernel(
+            self._current_track_kernel(
                 buffer=self._tracker_data._buffer.buffer,
                 tracker_data=self._tracker_data._element_ref_data,
                 particles=particles._xobject,
@@ -1206,7 +1224,7 @@ class Tracker:
 
         # Last turn, only if incomplete
         if num_elements_last_turn > 0:
-            self.track_kernel(
+            self._current_track_kernel(
                 buffer=self._tracker_data._buffer.buffer,
                 tracker_data=self._tracker_data._element_ref_data,
                 particles=particles._xobject,
@@ -1226,6 +1244,7 @@ class Tracker:
     @staticmethod
     def _get_default_monitor_class():
         import xtrack as xt  # I have to do it like this
+
         # to avoid circular import #TODO to be solved
         return xt.ParticlesMonitor
 
@@ -1335,3 +1354,30 @@ class Tracker:
             tracker.particle_ref = xp.Particles.from_dict(particle_ref)
 
         return tracker
+
+    def _hashable_config(self):
+        items = ((k, v) for k, v in self.config.items() if v is not False)
+        return tuple(sorted(items))
+
+    def _config_to_headers(self):
+        headers = []
+        for k, v in self.config.items():
+            if not isinstance(v, bool):
+                headers.append(f'#define {k} {v}')
+            elif v is True:
+                headers.append(f'#define {k}')
+            else:
+                headers.append(f'#undef {k}')
+        return headers
+
+    @property
+    def _current_track_kernel(self):
+        try:
+            return self.track_kernel[self._hashable_config()]
+        except KeyError:
+            self._build_kernel(save_source_as=None, compile=True)
+            return self._current_track_kernel
+
+    @_current_track_kernel.setter
+    def _current_track_kernel(self, value):
+        self.track_kernel[self._hashable_config()] = value

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -519,9 +519,13 @@ class Tracker:
                 )
 
     @property
-    def particle_ref(self):
+    def particle_ref(self) -> xp.Particles:
         self._check_invalidated()
         return self.line.particle_ref
+
+    @particle_ref.setter
+    def particle_ref(self, value: xp.Particles):
+        self.line.particle_ref = value
 
     @property
     def vars(self):
@@ -1274,6 +1278,7 @@ class Tracker:
         except AttributeError:
             raise TypeError("Only non-collective trackers can be binary serialized.")
 
+        # Serialise the tracker_data (line)
         if not isinstance(tracker_data._context, xo.ContextCpu):
             buffer = xo.ContextCpu().new_buffer(0)
         else:
@@ -1281,14 +1286,21 @@ class Tracker:
 
         buffer, header_offset = tracker_data.to_binary(buffer)
 
+        # Serialise the knobs
         var_management = {}
         if tracker_data.line._var_management:
             var_management = tracker_data.line._var_management_to_dict()
+
+        # Serialise the reference particle
+        particle_ref = None
+        if self.particle_ref:
+            particle_ref = self.particle_ref.to_dict()
 
         with open(path, 'wb') as f:
             np.save(f, header_offset)
             np.save(f, buffer.buffer)
             np.save(f, var_management, allow_pickle=True)
+            np.save(f, particle_ref, allow_pickle=True)
 
     @classmethod
     def from_binary_file(cls, path, particles_monitor_class=None) -> 'Tracker':
@@ -1299,6 +1311,7 @@ class Tracker:
             header_offset = np.load(f)
             np_buffer = np.load(f)
             var_management_dict = np.load(f, allow_pickle=True).item()
+            particle_ref = np.load(f, allow_pickle=True).item()
 
         xbuffer = xo.ContextCpu().new_buffer(np_buffer.nbytes)
         # make sure that if we carry on using the buffer we
@@ -1313,7 +1326,12 @@ class Tracker:
         if var_management_dict:
             tracker_data.line._init_var_management(var_management_dict)
 
-        return Tracker(
+        tracker = Tracker(
             line=tracker_data.line,
             _element_ref_data=tracker_data._element_ref_data,
         )
+
+        if particle_ref is not None:
+            tracker.particle_ref = xp.Particles.from_dict(particle_ref)
+
+        return tracker


### PR DESCRIPTION
## Description

Add an instance variable `Tracker.config: xdeps.utils.AttrDict` where each field is used to define a C flag at tracker compile time.

Each track kernel is cached with the corresponding config, so that when the user changes the config to a previously seen one, the tracker will not be recompiled again. The above changes imply that trackers will be built on-demand, instead of in the constructor. As a result the `skip` option for `track_kernel` has been removed from the non-collective tracker.

Add new methods `Tracker.freeze_vars` and `Tracker.unfreeze` using the above functionality and thanks to 

On top of #232.
Needs xsuite/xpart#47.

Part of the solution for xsuite/xsuite#206

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
