### PR TITLE
generate and reuse compiled track kernels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,10 @@ setup(
             "Source Code": "https://github.com/xsuite/xtrack",
         },
     packages=find_packages(),
-    ext_modules = extensions,
+    ext_modules=extensions,
     include_package_data=True,
     install_requires=[
+        'cffi>=1.0.0',
         'numpy>=1.0',
         'scipy',
         'xobjects',
@@ -47,6 +48,6 @@ setup(
         'xdeps'
         ],
     extras_require={
-        'tests': ['cpymad', 'PyHEADTAIL', 'pytest'],
+        'tests': ['cpymad', 'PyHEADTAIL', 'pytest', 'pytest-mock'],
         },
     )

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -12,28 +12,27 @@ import xtrack as xt
 import xpart as xp
 import xobjects as xo
 
-#context = xo.ContextPyopencl()
-context = xo.ContextCpu()
-
-test_data_folder = pathlib.Path(
-        __file__).parent.joinpath('../test_data').absolute()
-
-with open(test_data_folder.joinpath(
-        'hllhc15_noerrors_nobb/line_and_particle.json')) as f:
-    dct = json.load(f)
-line = xt.Line.from_dict(dct['line'])
-line.particle_ref = xp.Particles.from_dict(dct['particle'])
-
-tracker0 = line.build_tracker()
-
-num_particles = 50
-particles0 = xp.generate_matched_gaussian_bunch(tracker=tracker0,
-                                               num_particles=num_particles,
-                                               nemitt_x=2.5e-6,
-                                               nemitt_y=2.5e-6,
-                                               sigma_z=9e-2)
 
 def test_monitor():
+    context = xo.ContextCpu()
+
+    test_data_folder = pathlib.Path(
+            __file__).parent.joinpath('../test_data').absolute()
+
+    with open(test_data_folder.joinpath(
+            'hllhc15_noerrors_nobb/line_and_particle.json')) as f:
+        dct = json.load(f)
+    line = xt.Line.from_dict(dct['line'])
+    line.particle_ref = xp.Particles.from_dict(dct['particle'])
+
+    tracker0 = line.build_tracker()
+
+    num_particles = 50
+    particles0 = xp.generate_matched_gaussian_bunch(tracker=tracker0,
+                                                   num_particles=num_particles,
+                                                   nemitt_x=2.5e-6,
+                                                   nemitt_y=2.5e-6,
+                                                   sigma_z=9e-2)
 
     for context in xo.context.get_test_contexts():
         print(f"Test {context.__class__}")

--- a/tests/test_prebuild_kernels.py
+++ b/tests/test_prebuild_kernels.py
@@ -1,0 +1,48 @@
+# copyright ############################### #
+# This file is part of the Xtrack Package.  #
+# Copyright (c) CERN, 2022.                 #
+# ######################################### #
+
+import os
+from importlib.util import find_spec
+from itertools import chain
+
+import cffi
+import pytest
+import xpart as xp
+
+import xtrack as xt
+from xtrack.prebuild_kernels import PREBUILT_KERNELS as XT_KERNELS
+from xtrack.prebuild_kernels import precompile_kernels as xt_precompile
+
+try:
+    from xfields.prebuild_kernels import PREBUILT_KERNELS as XF_KERNELS
+    from xfields.prebuild_kernels import precompile_kernels as xf_precompile
+except ModuleNotFoundError:
+    def xf_precompile():
+        pass
+
+    XF_KERNELS = {}
+
+
+@pytest.fixture(scope='session')
+def with_precompiled_kernels():
+    xt_precompile()
+    xf_precompile()
+
+    yield
+
+    for precompiled_module in chain(XT_KERNELS.keys(), XF_KERNELS.keys()):
+        spec = find_spec(precompiled_module)
+        os.remove(spec.origin)
+
+
+def test_precompiled_kernels_avoid_compiling(with_precompiled_kernels, mocker):
+    cffi_compile = mocker.patch.object(cffi.FFI, 'compile')
+
+    line = xt.Line(elements=[xt.Drift()])
+    tracker = line.build_tracker()
+    particles = xp.Particles()
+    tracker.track(particles)
+
+    cffi_compile.assert_not_called()

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -385,6 +385,7 @@ def test_tracker_binary_serialisation_with_knobs(tmp_path):
 
 def test_tracker_hashable_config():
     tracker = xt.Tracker(line=xt.Line([]))
+
     tracker.config.TEST_FLAG_BOOL = True
     tracker.config.TEST_FLAG_INT = 42
     tracker.config.TEST_FLAG_FALSE = False

--- a/xtrack/prebuild_kernels.py
+++ b/xtrack/prebuild_kernels.py
@@ -1,0 +1,69 @@
+# copyright ############################### #
+# This file is part of the Xtrack Package.  #
+# Copyright (c) CERN, 2021.                 #
+# ######################################### #
+import os
+from importlib import import_module
+from importlib.util import find_spec
+from typing import Dict, Hashable, List, Tuple
+
+import xtrack as xt
+
+DEFAULT_CONFIG = {
+    'XTRACK_MULTIPOLE_NO_SYNRAD': True,
+}
+
+PREBUILT_KERNELS = {
+    'xtrack.lib.drifts_and_multipoles': (
+        ['Drift', 'Multipole', 'ParticlesMonitor'],
+        DEFAULT_CONFIG,
+    ),
+}
+
+
+class PrebuiltKernelNotFound(Exception):
+    pass
+
+
+def get_ffi_module_for_configuration(
+        desired_element_classes: List[str],
+        desired_config: Dict[str, Hashable],
+) -> Tuple[str, List[xt.BeamElement]]:
+    prebuilt_kernels = {}
+    prebuilt_kernels.update(PREBUILT_KERNELS)
+    try:
+        from xfields.prebuild_kernels import PREBUILT_KERNELS as XF_KERNELS
+        prebuilt_kernels.update(XF_KERNELS)
+    except ModuleNotFoundError:
+        pass
+
+    for module_name, (classes, config) in prebuilt_kernels.items():
+        if (set(desired_element_classes) < set(classes)
+                and desired_config == config):
+            if find_spec(module_name):
+                return module_name, classes
+
+    raise PrebuiltKernelNotFound(
+        f'There is no prebuilt kernel for classes {desired_element_classes} '
+        f'and config {desired_config}.'
+    )
+
+
+def precompile_single_kernel(name, elements, config):
+    dummy_tracker = xt.Tracker(
+        line=xt.Line(elements),
+        compile=False,
+    )
+    dummy_tracker.config.update(config)
+    dummy_tracker._build_kernel(
+        compile='force',
+        built_ffi_module_name=name,
+    )
+
+
+def precompile_kernels():
+    precompile_single_kernel(
+        'xtrack.lib.drifts_and_multipoles',
+        [xt.Drift(), xt.Multipole()],
+        {}
+    )


### PR DESCRIPTION
## Description

This adds a functionality of precompiling tracking kernels, so they can be reused between sessions.

The track kernels can be precompiled using `xtrack.prebuild_kernels.precompile_kernels`. Additionally the module contains the descriptions of the kernels to be generated. When building the tracker, in `xtrack.Tracker._build_tracker` an additional parameter `built_ffi_module_name` can be passed, which will try to load the kernel from the module of the given name, and failing that will compile the kernel and save it as that module.

A new value for the parameter `compile` in `Tracker._build_tracker` is introduced: it can now be either bool or 'force'. See the docstring of the method for more details.

Needs xsuite/xobjects#77.

Closes xsuite/xsuite#224.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
