### PR TITLE
Fixed non-symplecticity bug in LinearTransferMatrix

### DIFF
--- a/ducktrack/elements.py
+++ b/ducktrack/elements.py
@@ -599,15 +599,19 @@ class LinearTransferMatrix(Element):
         ("alpha_x_0","","",0.0),
         ("beta_x_0","","",0.0),
         ("disp_x_0","","",0.0),
+        ("disp_px_0","","",0.0),
         ("alpha_x_1","","",0.0),
         ("beta_x_1","","",0.0),
         ("disp_x_1","","",0.0),
+        ("disp_px_1","","",0.0),
         ("alpha_y_0","","",0.0),
         ("beta_y_0","","",0.0),
         ("disp_y_0","","",0.0),
+        ("disp_py_0","","",0.0),
         ("alpha_y_1","","",0.0),
         ("beta_y_1","","",0.0),
         ("disp_y_1","","",0.0),
+        ("disp_py_1","","",0.0),
         ("Q_x","","",0.0),
         ("Q_y","","",0.0),
         ("beta_s","","",0.0),
@@ -653,10 +657,16 @@ class LinearTransferMatrix(Element):
         #Transverse linear uncoupled matrix
 
         # removing dispersion and close orbit
+        old_x=p.x
+        old_px=p.px
+        old_y=p.y
+        old_py=p.py
+
         p.x -= self.disp_x_0 * p.delta + self.x_ref_0
-        p.px -= self.px_ref_0
+        p.px -= self.disp_px_0 * p.delta + self.px_ref_0  
         p.y -= self.disp_y_0 * p.delta + self.y_ref_0
-        p.py -= self.py_ref_0
+        p.py -= self.disp_py_0 * p.delta + self.py_ref_0
+        p.zeta-= self.disp_px_0*old_x - self.disp_x_0*old_px + self.disp_py_0*old_y - self.disp_y_0*old_py
 
         J_x = 0.5 * (
                 (1.0 + self.alpha_x_0*self.alpha_x_0)/self.beta_x_0 * p.x*p.x
@@ -749,10 +759,17 @@ class LinearTransferMatrix(Element):
             p.delta += self.gauss_noise_ampl_s*np.random.randn(len(p.delta))
 
         # re-adding dispersion and closed orbit
+        old_x=p.x
+        old_px=p.px
+        old_y=p.y
+        old_py=p.py
+
         p.x += self.disp_x_1 * p.delta + self.x_ref_1
-        p.px += self.px_ref_1
+        p.px += self.disp_px_1 * p.delta + self.px_ref_1 
         p.y += self.disp_y_1 * p.delta + self.y_ref_1
-        p.py += self.py_ref_1
+        p.py += self.disp_py_1 * p.delta + self.py_ref_1
+        p.zeta+= self.disp_px_1*old_x - self.disp_x_1*old_px + self.disp_py_1*old_y - self.disp_y_1*old_py
+
 
 class FirstOrderTaylorMap(Element):
     _description = [

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -262,21 +262,25 @@ def test_linear_transfer():
         alpha_x_0 = -0.5
         beta_x_0 = 100.0
         disp_x_0 = 1.8
+        disp_px_0 = 2.2
         alpha_x_1 = 2.1
         beta_x_1 = 2.0
         disp_x_1 = 3.3
+        disp_px_1 = 3.7
         alpha_y_0 = -0.4
         beta_y_0 = 8.0
         disp_y_0 = -0.2
+        disp_py_0 = -0.4
         alpha_y_1 = 0.7
         beta_y_1 = 0.3
         disp_y_1 = -1.9
+        disp_py_1 = -2.9
         Q_x = 0.27
         Q_y = 0.34
         beta_s = 856.9
         Q_s = 0.001
-        energy_ref_increment = 1.2E9
-        energy_increment = 4.8E8
+        energy_ref_increment = 0.0
+        energy_increment = 0.0
         x_ref_0 = -5E-3
         px_ref_0 = 6E-4
         x_ref_1 = 2E-2
@@ -287,10 +291,10 @@ def test_linear_transfer():
         py_ref_1 = 5E-4
 
         arc = xt.LinearTransferMatrix(_context=ctx,
-        alpha_x_0=alpha_x_0, beta_x_0=beta_x_0, disp_x_0=disp_x_0,
-        alpha_x_1=alpha_x_1, beta_x_1=beta_x_1, disp_x_1=disp_x_1,
-        alpha_y_0=alpha_y_0, beta_y_0=beta_y_0, disp_y_0=disp_y_0,
-        alpha_y_1=alpha_y_1, beta_y_1=beta_y_1, disp_y_1=disp_y_1,
+        alpha_x_0=alpha_x_0, beta_x_0=beta_x_0, disp_x_0=disp_x_0, disp_px_0=disp_px_0,
+        alpha_x_1=alpha_x_1, beta_x_1=beta_x_1, disp_x_1=disp_x_1, disp_px_1=disp_px_1,
+        alpha_y_0=alpha_y_0, beta_y_0=beta_y_0, disp_y_0=disp_y_0, disp_py_0=disp_py_0,
+        alpha_y_1=alpha_y_1, beta_y_1=beta_y_1, disp_y_1=disp_y_1, disp_py_1=disp_py_1,
         Q_x=Q_x, Q_y=Q_y,
         beta_s=beta_s, Q_s=Q_s,
         chroma_x=0.0, chroma_y=0.0,
@@ -300,10 +304,11 @@ def test_linear_transfer():
         y_ref_0 = y_ref_0, py_ref_0 = py_ref_0, y_ref_1 = y_ref_1, py_ref_1 = py_ref_1)
         arc.track(particles)
 
-        dtk_arc = dtk.elements.LinearTransferMatrix(alpha_x_0=alpha_x_0, beta_x_0=beta_x_0, disp_x_0=disp_x_0,
-        alpha_x_1=alpha_x_1, beta_x_1=beta_x_1, disp_x_1=disp_x_1,
-        alpha_y_0=alpha_y_0, beta_y_0=beta_y_0, disp_y_0=disp_y_0,
-        alpha_y_1=alpha_y_1, beta_y_1=beta_y_1, disp_y_1=disp_y_1,
+        dtk_arc = dtk.elements.LinearTransferMatrix(
+        alpha_x_0=alpha_x_0, beta_x_0=beta_x_0, disp_x_0=disp_x_0, disp_px_0=disp_px_0,
+        alpha_x_1=alpha_x_1, beta_x_1=beta_x_1, disp_x_1=disp_x_1, disp_px_1=disp_px_1,
+        alpha_y_0=alpha_y_0, beta_y_0=beta_y_0, disp_y_0=disp_y_0, disp_py_0=disp_py_0,
+        alpha_y_1=alpha_y_1, beta_y_1=beta_y_1, disp_y_1=disp_y_1, disp_py_1=disp_py_1,
         Q_x=Q_x, Q_y=Q_y,
         beta_s=beta_s, Q_s=Q_s,
         chroma_x=0.0, chroma_y=0.0,

--- a/xtrack/beam_elements/elements_src/lineartransfermatrix.h
+++ b/xtrack/beam_elements/elements_src/lineartransfermatrix.h
@@ -6,6 +6,8 @@
 #ifndef XTRACK_LINEARTRANSFERMATRIX_H
 #define XTRACK_LINEARTRANSFERMATRIX_H
 
+
+
 /*gpufun*/
 void LinearTransferMatrix_track_local_particle(LinearTransferMatrixData el, LocalParticle* part0){
 
@@ -31,10 +33,14 @@ void LinearTransferMatrix_track_local_particle(LinearTransferMatrixData el, Loca
     double const beta_prod_y = LinearTransferMatrixData_get_beta_prod_y(el);
     double const disp_x_0 = LinearTransferMatrixData_get_disp_x_0(el);
     double const disp_y_0 = LinearTransferMatrixData_get_disp_y_0(el);
+    double const disp_px_0 = LinearTransferMatrixData_get_disp_px_0(el);
+    double const disp_py_0 = LinearTransferMatrixData_get_disp_py_0(el);
     double const alpha_x_0 = LinearTransferMatrixData_get_alpha_x_0(el);
     double const alpha_y_0 = LinearTransferMatrixData_get_alpha_y_0(el);
     double const disp_x_1 = LinearTransferMatrixData_get_disp_x_1(el);
     double const disp_y_1 = LinearTransferMatrixData_get_disp_y_1(el);
+    double const disp_px_1 = LinearTransferMatrixData_get_disp_px_1(el);
+    double const disp_py_1 = LinearTransferMatrixData_get_disp_py_1(el);
     double const alpha_x_1 = LinearTransferMatrixData_get_alpha_x_1(el);
     double const alpha_y_1 = LinearTransferMatrixData_get_alpha_y_1(el);
 
@@ -61,12 +67,15 @@ void LinearTransferMatrix_track_local_particle(LinearTransferMatrixData el, Loca
     double new_px = LocalParticle_get_px(part);
     double new_py = LocalParticle_get_py(part);
     double delta = LocalParticle_get_delta(part);
+    double zeta_no_disp = LocalParticle_get_zeta(part);
 
     // removing dispersion and close orbit
     new_x -= disp_x_0 * delta + x_ref_0;
-    new_px -= px_ref_0;
+    new_px -= disp_px_0 * delta + px_ref_0;
     new_y -= disp_y_0 * delta + y_ref_0;
-    new_py -= py_ref_0;
+    new_py -= disp_py_0 * delta + py_ref_0;
+
+    zeta_no_disp -= disp_px_0*LocalParticle_get_x(part) - disp_x_0*LocalParticle_get_px(part) + disp_py_0*LocalParticle_get_y(part) - disp_y_0*LocalParticle_get_py(part);    
 
     double sin_x, cos_x, sin_y, cos_y;
 
@@ -116,10 +125,9 @@ void LinearTransferMatrix_track_local_particle(LinearTransferMatrixData el, Loca
 
     if (cos_s < 2){
         // We set cos_s = 999 if long map is to be skipped
-        double const old_zeta = LocalParticle_get_zeta(part);
         double const old_pzeta = LocalParticle_get_pzeta(part); // Use canonically conjugate variables
-        double const new_zeta = cos_s*old_zeta+beta_s*sin_s*old_pzeta;
-        double const new_pzeta = -sin_s*old_zeta/beta_s+cos_s*old_pzeta;
+        double const new_zeta = cos_s*zeta_no_disp+beta_s*sin_s*old_pzeta;
+        double const new_pzeta = -sin_s*zeta_no_disp/beta_s+cos_s*old_pzeta;
 
         LocalParticle_set_zeta(part, new_zeta);
         LocalParticle_update_pzeta(part, new_pzeta);
@@ -195,16 +203,16 @@ void LinearTransferMatrix_track_local_particle(LinearTransferMatrixData el, Loca
         delta += r*gauss_noise_ampl_delta;
         LocalParticle_update_delta(part,delta);
     }
-
-
         
     // re-adding dispersion and closed orbit
     delta = LocalParticle_get_delta(part);
+    LocalParticle_add_to_zeta(part,disp_px_1*LocalParticle_get_x(part) - disp_x_1*LocalParticle_get_px(part) + disp_py_1*LocalParticle_get_y(part) - disp_y_1*LocalParticle_get_py(part));
     LocalParticle_add_to_x(part,disp_x_1 * delta + x_ref_1);
-    LocalParticle_add_to_px(part,px_ref_1);
+    LocalParticle_add_to_px(part,px_ref_1 +disp_px_1 * delta);
     LocalParticle_add_to_y(part,disp_y_1 * delta + y_ref_1);
-    LocalParticle_add_to_py(part,py_ref_1);
-
+    LocalParticle_add_to_py(part,py_ref_1+disp_py_1 * delta);
+    
+    
     //end_per_particle_block
 }
 


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

1. Added momentum dispersion
2. Fixed symplecticity by including transformation as described by Eq 3.41 of 
https://www.sciencedirect.com/science/article/pii/S0168900215008098
3. Added the relevant tests
Closes # .

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
