### PR TITLE
allow prebuilding and loading prebuilt kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ examples/*/res/*
 *.egg-info
 __pycache__
 .pytest_cache
+xtrack/prebuilt_kernels
+!xtrack/prebuilt_kernels/_kernel_definitions.json

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
         'xdeps'
         ],
     extras_require={
-        'tests': ['cpymad', 'PyHEADTAIL', 'pytest'],
+        'tests': ['cpymad', 'PyHEADTAIL', 'pytest', 'pytest-mock'],
         },
     )

--- a/tests/test_prebuild_kernels.py
+++ b/tests/test_prebuild_kernels.py
@@ -1,0 +1,64 @@
+# copyright ################################# #
+# This file is part of the Xobjects Package.  #
+# Copyright (c) CERN, 2022.                   #
+# ########################################### #
+import json
+
+import cffi
+
+import xpart as xp
+import xtrack as xt
+from xtrack.prebuild_kernels import regenerate_kernels
+
+
+def test_prebuild_kernels(mocker, tmp_path):
+    # Set up the temporary kernels directory
+    metadata = {
+        "test_module": {
+            "config": {
+                "XTRACK_MULTIPOLE_NO_SYNRAD": True,
+                "XFIELDS_BB3D_NO_BEAMSTR": True,
+            },
+            "classes": [
+                "Drift",
+                "Cavity",
+                "XYShift",
+            ]
+        },
+    }
+
+    with (tmp_path /
+          xt.prebuild_kernels.XT_PREBUILT_KERNELS_METADATA).open('w+') as fp:
+        json.dump(metadata, fp)
+
+    mocker.patch('xtrack.prebuild_kernels.XT_PREBUILT_KERNELS_LOCATION',
+                 tmp_path)
+    mocker.patch('xtrack.tracker.XT_PREBUILT_KERNELS_LOCATION', tmp_path)
+
+    # Try regenerating the kernels
+    regenerate_kernels()
+
+    # Check if the expected files were created
+    so_file_exists = False
+    for path in tmp_path.iterdir():
+        if not path.name.startswith('test_module.'):
+            continue
+        if path.suffix not in ('.so', '.dll', '.dylib', '.pyd'):
+            continue
+        so_file_exists = True
+    assert so_file_exists
+
+    assert (tmp_path / 'test_module.c').exists()
+    assert (tmp_path / 'test_module.json').exists()
+
+    # Test that reloading the kernel works
+    cffi_compile = mocker.patch.object(cffi.FFI, 'compile')
+
+    tracker = xt.Tracker(line=xt.Line(elements=[xt.Drift(length=2.0)]))
+
+    p = xp.Particles(p0c=1e9, px=3e-6)
+    tracker.track(p)
+
+    assert p.x == 6e-6
+    assert p.y == 0.0
+    cffi_compile.assert_not_called()

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -354,6 +354,8 @@ class SimpleThinQuadrupole(BeamElement):
         _pkg_root.joinpath('beam_elements/elements_src/simplethinquadrupole.h')]
 
     def __init__(self, knl=None, **kwargs):
+        if knl is None:
+            knl = np.zeros(2)
 
         if '_xobject' in kwargs.keys() and kwargs['_xobject'] is not None:
             self.xoinitialize(**kwargs)
@@ -417,6 +419,8 @@ class SimpleThinBend(BeamElement):
         _pkg_root.joinpath('beam_elements/elements_src/simplethinbend.h')]
 
     def __init__(self, knl=None, **kwargs):
+        if knl is None:
+            knl = np.zeros(1)
 
         if '_xobject' in kwargs.keys() and kwargs['_xobject'] is not None:
             self.xoinitialize(**kwargs)

--- a/xtrack/prebuild_kernels.py
+++ b/xtrack/prebuild_kernels.py
@@ -1,0 +1,199 @@
+# copyright ################################# #
+# This file is part of the Xobjects Package.  #
+# Copyright (c) CERN, 2022.                   #
+# ########################################### #
+import json
+import logging
+from pathlib import Path
+from typing import Iterator, Optional, Tuple
+
+import numpy as np
+
+import xobjects as xo
+import xpart as xp
+import xtrack as xt
+
+LOGGER = logging.getLogger(__name__)
+
+XT_PREBUILT_KERNELS_LOCATION = Path(xt.__file__).parent / 'prebuilt_kernels'
+XT_PREBUILT_KERNELS_METADATA = '_kernel_definitions.json'
+
+BEAM_ELEMENTS_INIT_DEFAULTS = {
+    'BeamBeamBiGaussian2D': {
+        'other_beam_Sigma_11': 1.,
+        'other_beam_Sigma_33': 1.,
+        'other_beam_num_particles': 0.,
+        'other_beam_q0': 1.,
+        'other_beam_beta0': 1.,
+    },
+    'BeamBeamBiGaussian3D': {
+        'slices_other_beam_zeta_center': np.array([0]),
+        'slices_other_beam_num_particles': np.array([0]),
+        'phi': 0.,
+        'alpha': 0,
+        'other_beam_q0': 1.,
+        'slices_other_beam_Sigma_11': np.array([1]),
+        'slices_other_beam_Sigma_12': np.array([0]),
+        'slices_other_beam_Sigma_22': np.array([0]),
+        'slices_other_beam_Sigma_33': np.array([1]),
+        'slices_other_beam_Sigma_34': np.array([0]),
+        'slices_other_beam_Sigma_44': np.array([0]),
+    },
+}
+
+try:
+    from xfields import LongitudinalProfileQGaussian
+
+    BEAM_ELEMENTS_INIT_DEFAULTS['SpaceChargeBiGaussian'] = {
+        'longitudinal_profile': LongitudinalProfileQGaussian(
+            number_of_particles=0, sigma_z=1),
+    }
+except ModuleNotFoundError:
+    LOGGER.warning('Prebuilding kernels might fail, as xfields is not '
+                   'installed.')
+
+
+def get_element_class_by_name(name: str) -> type:
+    from xtrack.monitors import generate_monitor_class
+    monitor_cls = generate_monitor_class(xp.Particles)
+
+    try:
+        from xfields import element_classes as xf_element_classes
+    except ModuleNotFoundError:
+        xf_element_classes = ()
+
+    element_classes = xt.element_classes + xf_element_classes + (monitor_cls,)
+
+    for cls in element_classes:
+        if cls.__name__ == name:
+            return cls
+
+    raise ValueError(f'No element class with name {name} available.')
+
+
+def save_kernel_metadata(
+        module_name: str,
+        config: dict,
+        element_classes,
+):
+    out_file = XT_PREBUILT_KERNELS_LOCATION / f'{module_name}.json'
+
+    try:
+        import xfields
+        xf_version = xfields.__version__
+    except ModuleNotFoundError:
+        xf_version = None
+
+    kernel_metadata = {
+        'config': config,
+        'classes': [cls._DressingClass.__name__ for cls in element_classes],
+        'versions': {
+            'xtrack': xt.__version__,
+            'xfields': xf_version,
+            'xobjects': xo.__version__,
+        }
+    }
+
+    with out_file.open('w') as fd:
+        json.dump(kernel_metadata, fd, indent=4)
+
+
+def enumerate_kernels() -> Iterator[Tuple[str, dict]]:
+    """
+    Iterate over the prebuilt kernels compatible with the current version of
+    xsuite. The first element of the tuple is the name of the kernel module
+    and the second is a dictionary with the kernel metadata.
+    """
+    for metadata_file in XT_PREBUILT_KERNELS_LOCATION.glob('*.json'):
+        if metadata_file.stem.startswith('_'):
+            continue
+
+        with metadata_file.open('r') as fd:
+            kernel_metadata = json.load(fd)
+
+        try:
+            import xfields
+            xf_version = xfields.__version__
+        except ModuleNotFoundError:
+            xf_version = None
+
+        if kernel_metadata['versions']['xtrack'] != xt.__version__:
+            continue
+
+        if kernel_metadata['versions']['xobjects'] != xo.__version__:
+            continue
+
+        if (kernel_metadata['versions']['xfields'] != xf_version
+                and xf_version is not None):
+            continue
+
+        yield metadata_file.stem, kernel_metadata
+
+
+def get_suitable_kernel(
+        config: dict,
+        element_classes
+) -> Optional[Tuple[str, list]]:
+    """
+    Given a configuration and a list of element classes, return a tuple with
+    the name of a suitable prebuilt kernel module together with the list of
+    element classes that were used to build it.
+    """
+    requested_class_names = [
+        cls._DressingClass.__name__ for cls in element_classes
+    ]
+
+    for module_name, kernel_metadata in enumerate_kernels():
+        available_classes_names = kernel_metadata['classes']
+        if kernel_metadata['config'] != config:
+            continue
+
+        if set(requested_class_names) <= set(available_classes_names):
+            available_classes = [
+                get_element_class_by_name(class_name)
+                for class_name in available_classes_names
+            ]
+            return module_name, available_classes
+
+
+def regenerate_kernels():
+    """
+    Use the kernel definitions in the `_kernel_definitions.json` file to
+    regenerate kernel shared objects using the current version of xsuite.
+    """
+    metadata_file = XT_PREBUILT_KERNELS_LOCATION / XT_PREBUILT_KERNELS_METADATA
+
+    with metadata_file.open('r') as fd:
+        kernels_metadata = json.load(fd)
+
+    for module_name, metadata in kernels_metadata.items():
+        config = metadata['config']
+        element_class_names = metadata['classes']
+
+        element_classes = [
+            get_element_class_by_name(class_name)
+            for class_name in element_class_names
+        ]
+
+        elements = []
+        for cls in element_classes:
+            if cls.__name__ in BEAM_ELEMENTS_INIT_DEFAULTS:
+                element = cls(**BEAM_ELEMENTS_INIT_DEFAULTS[cls.__name__])
+            else:
+                element = cls()
+            elements.append(element)
+
+        line = xt.Line(elements=elements)
+        tracker = xt.Tracker(line=line, compile=False)
+        tracker.config.update(config)
+        tracker._build_kernel(module_name=module_name,
+                              containing_dir=XT_PREBUILT_KERNELS_LOCATION,
+                              compile='force')
+
+        save_kernel_metadata(module_name=module_name,
+                             config=tracker.config,
+                             element_classes=tracker.element_classes)
+
+
+if __name__ == '__main__':
+    regenerate_kernels()

--- a/xtrack/prebuilt_kernels/_kernel_definitions.json
+++ b/xtrack/prebuilt_kernels/_kernel_definitions.json
@@ -1,0 +1,69 @@
+{
+    "default_only_xtrack": {
+        "config": {
+            "XTRACK_MULTIPOLE_NO_SYNRAD": true,
+            "XFIELDS_BB3D_NO_BEAMSTR": true
+        },
+        "classes": [
+            "Drift",
+            "Multipole",
+            "ReferenceEnergyIncrease",
+            "Cavity",
+            "XYShift",
+            "Elens",
+            "Wire",
+            "SRotation",
+            "RFMultipole",
+            "DipoleEdge",
+            "LinearTransferMatrix",
+            "SimpleThinBend",
+            "SimpleThinQuadrupole"
+        ]
+    },
+    "default_bb3d": {
+        "config": {
+            "XTRACK_MULTIPOLE_NO_SYNRAD": true,
+            "XFIELDS_BB3D_NO_BEAMSTR": true
+        },
+        "classes": [
+            "Drift",
+            "Multipole",
+            "ReferenceEnergyIncrease",
+            "Cavity",
+            "XYShift",
+            "Elens",
+            "Wire",
+            "SRotation",
+            "RFMultipole",
+            "DipoleEdge",
+            "LinearTransferMatrix",
+            "SimpleThinBend",
+            "SimpleThinQuadrupole",
+            "BeamBeamBiGaussian2D",
+            "BeamBeamBiGaussian3D"
+        ]
+    },
+    "default_spacecharge": {
+        "config": {
+            "XTRACK_MULTIPOLE_NO_SYNRAD": true,
+            "XFIELDS_BB3D_NO_BEAMSTR": true
+        },
+        "classes": [
+            "Drift",
+            "Multipole",
+            "ReferenceEnergyIncrease",
+            "Cavity",
+            "XYShift",
+            "Elens",
+            "Wire",
+            "SRotation",
+            "RFMultipole",
+            "DipoleEdge",
+            "LinearTransferMatrix",
+            "SimpleThinBend",
+            "SimpleThinQuadrupole",
+            "BeamBeamBiGaussian2D",
+            "SpaceChargeBiGaussian"
+        ]
+    }
+}


### PR DESCRIPTION
## Description

Using a description of kernels located in `xtrack/prebuilt_kernels/_kernel_definitions.json` precompile `.so` files and their descriptions (+ C code) inside of xtrack, so that when a compatible tracker is encountered again, instead of compiling it again, the existing kernel will be used. In order to precompile the kernels, one must call the function `xtrack.prebuild_kernels:regenerate_kernels.py`.

If a tracker determines that it is compatible with a precompiled kernel, it might need to partially rebuild the line in memory: see the relevant code around `TrackerData`.

Needs xsuite/xobjects#85 and xsuite/xfields#68.

Closes xsuite/xsuite#224.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
