### PR TITLE
exact drift calculation enabled with config flag

### DIFF
--- a/ducktrack/elements.py
+++ b/ducktrack/elements.py
@@ -74,7 +74,7 @@ class DriftExact(Drift):
         lpzi = length / sqrt(opd ** 2 - p.px ** 2 - p.py ** 2)
         p.x += p.px * lpzi
         p.y += p.py * lpzi
-        p.zeta +=  length - 1 / p.rvv * opd * lpzi
+        p.zeta += length - 1 / p.rvv * opd * lpzi
         p.s += length
 
 

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -66,6 +66,7 @@ def test_arr2ctx():
         assert type(d._arr2ctx(a)) is ctx.nplike_array_type
         assert type(d._arr2ctx(a[1])) is float
 
+
 def test_drift():
 
     for ctx in xo.context.get_test_contexts():
@@ -97,6 +98,43 @@ def test_drift():
                           dtk_particle.zeta,
                           rtol=1e-14, atol=1e-14)
 
+
+def test_drift_exact():
+
+    for ctx in xo.context.get_test_contexts():
+        print(f"Test {ctx.__class__}")
+
+        dtk_particle = dtk.TestParticles(
+                p0c=25.92e9,
+                x=1e-3,
+                px=1e-5,
+                y=-2e-3,
+                py=-1.5e-5,
+                delta=1e-2,
+                zeta=1.)
+
+        particles = xp.Particles.from_dict(dtk_particle.to_dict(),
+                                           _context=ctx)
+
+        drift = xt.Drift(_context=ctx, length=10.)
+        tracker = xt.Tracker(
+            line=xt.Line(elements=[drift]),
+            compile=False,
+            _context=ctx,
+        )
+        tracker.config.XTRACK_USE_EXACT_DRIFTS = True
+        tracker.track(particles)
+
+        dtk_drift = dtk.elements.DriftExact(length=10.)
+        dtk_drift.track(dtk_particle)
+
+        assert np.isclose(ctx.nparray_from_context_array(particles.x)[0],
+                          dtk_particle.x, rtol=1e-14, atol=1e-14)
+        assert np.isclose(ctx.nparray_from_context_array(particles.y)[0],
+                          dtk_particle.y, rtol=1e-14, atol=1e-14)
+        assert np.isclose(ctx.nparray_from_context_array(particles.zeta)[0],
+                          dtk_particle.zeta,
+                          rtol=1e-14, atol=1e-14)
 
 
 def test_elens():

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -49,7 +49,6 @@ class Drift(BeamElement):
                               _context=_context, _buffer=_buffer, _offset=_offset)
 
 
-
 class Cavity(BeamElement):
     '''Beam element modeling an RF cavity. Parameters:
 

--- a/xtrack/beam_elements/elements_src/drift.h
+++ b/xtrack/beam_elements/elements_src/drift.h
@@ -13,6 +13,8 @@ void Drift_track_local_particle(DriftData el, LocalParticle* part0){
 
     //start_per_particle_block (part0->part)
 
+    #ifndef XTRACK_USE_EXACT_DRIFTS
+
         double const rpp    = LocalParticle_get_rpp(part);
         double const rv0v    = 1./LocalParticle_get_rvv(part);
         double const xp     = LocalParticle_get_px(part) * rpp;
@@ -23,6 +25,21 @@ void Drift_track_local_particle(DriftData el, LocalParticle* part0){
         LocalParticle_add_to_y(part, yp * length );
         LocalParticle_add_to_s(part, length);
         LocalParticle_add_to_zeta(part, length * dzeta );
+
+    #else
+
+        double const px = LocalParticle_get_px(part);
+        double const py = LocalParticle_get_py(part);
+        double const rvv = LocalParticle_get_rvv(part);
+
+        double const opd = 1 + LocalParticle_get_delta(part);
+        double const lpzi = length / sqrt(opd * opd - px * px - py * py);
+        LocalParticle_add_to_x(part, px * lpzi);
+        LocalParticle_add_to_y(part, py * lpzi);
+        LocalParticle_add_to_zeta(part, length - 1 / rvv * opd * lpzi);
+        LocalParticle_add_to_s(part, length);
+
+    #endif
     //end_per_particle_block
 
 }


### PR DESCRIPTION
## Description

Introduce an exact drift element.

Closes xsuite/xsuite#218.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
