### PR TITLE
fix prebuilt kernel behaviour when False flags set explicitly

### DIFF
--- a/xtrack/prebuild_kernels.py
+++ b/xtrack/prebuild_kernels.py
@@ -153,6 +153,7 @@ def get_suitable_kernel(
                 get_element_class_by_name(class_name)
                 for class_name in available_classes_names
             ]
+            print(f'Found suitable prebuilt kernel `{module_name}`.')
             return module_name, available_classes
 
 
@@ -197,10 +198,12 @@ def regenerate_kernels():
 
 
 def clear_kernels():
-    for metadata_file in XT_PREBUILT_KERNELS_LOCATION.glob('*.json'):
-        if metadata_file.name.startswith('_'):
+    for file in XT_PREBUILT_KERNELS_LOCATION.iterdir():
+        if file.name.startswith('_'):
             continue
-        metadata_file.unlink()
+        if file.suffix not in ('.c', '.so', '.json'):
+            continue
+        file.unlink()
 
 
 if __name__ == '__main__':

--- a/xtrack/prebuilt_kernels/_kernel_definitions.json
+++ b/xtrack/prebuilt_kernels/_kernel_definitions.json
@@ -73,7 +73,8 @@
         "config": {
             "XFIELDS_BB3D_NO_BEAMSTR": true,
             "XTRACK_DIPOLEEDGE_TAPER": true,
-            "XTRACK_MULTIPOLE_TAPER": true
+            "XTRACK_MULTIPOLE_TAPER": true,
+            "XTRACK_MULTIPOLE_NO_SYNRAD": false
         },
         "classes": [
             "Drift",
@@ -89,6 +90,27 @@
             "LinearTransferMatrix",
             "SimpleThinBend",
             "SimpleThinQuadrupole"
+        ]
+    },
+    "only_xtrack_with_synrad": {
+        "config": {
+            "XFIELDS_BB3D_NO_BEAMSTR": true,
+            "XTRACK_MULTIPOLE_NO_SYNRAD": false
+        },
+        "classes": [
+            "Cavity",
+            "DipoleEdge",
+            "Drift",
+            "Elens",
+            "LinearTransferMatrix",
+            "Multipole",
+            "RFMultipole",
+            "ReferenceEnergyIncrease",
+            "SRotation",
+            "SimpleThinBend",
+            "SimpleThinQuadrupole",
+            "Wire",
+            "XYShift"
         ]
     }
 }

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -1626,4 +1626,13 @@ class TrackerConfig(dict):
             super(TrackerConfig, self).__setitem__(idx, val)
 
     def __setattr__(self, idx, val):
-        self[idx] = val
+        if val is not False:
+            self[idx] = val
+        elif idx in self:
+            del(self[idx])
+
+    def update(self, other, **kwargs):
+        super().update(other, **kwargs)
+        keys_for_none_vals = [k for k, v in self.items() if v is False]
+        for k in keys_for_none_vals:
+            del self[k]


### PR DESCRIPTION
There was a bug that some flags set to False would be retained in the kernel metadata. This fixes that.