### PR TITLE
Initialize the _beamstrahlung_model

### DIFF
--- a/xtrack/tapering.py
+++ b/xtrack/tapering.py
@@ -81,16 +81,16 @@ def compensate_radiation_energy_loss(tracker, delta0=0, rtot_eneloss=1e-10, max_
     i_multipoles = multipoles.index.values
     delta_taper_multipoles = ((mon.delta[0,:][i_multipoles+1] + mon.delta[0,:][i_multipoles]) / 2)
     for nn, dd in zip(multipoles['name'].values, delta_taper_multipoles):
-        line[nn].knl *= (1 + dd)
-        line[nn].ksl *= (1 + dd)
+        line.element_dict[nn].knl *= (1 + dd)
+        line.element_dict[nn].ksl *= (1 + dd)
 
     print("  - Adjust dipole edge strengths")
     i_dipole_edges = dipole_edges.index.values
     delta_taper_dipole_edges = ((mon.delta[0,:][i_dipole_edges+1] + mon.delta[0,:][i_dipole_edges]) / 2)
     for nn, dd in zip(dipole_edges['name'].values, delta_taper_dipole_edges):
-        line[nn].r21 *= (1 + dd)
-        line[nn].r43 *= (1 + dd)
-        line[nn].h *= (1 + dd)
+        line.element_dict[nn].r21 *= (1 + dd)
+        line.element_dict[nn].r43 *= (1 + dd)
+        line.element_dict[nn].h *= (1 + dd)
 
 
     print("  - Restore cavity voltage and frequency. Set cavity lag")

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -285,6 +285,7 @@ class Tracker:
         self._element_part = _element_part
         self._element_index_in_part = _element_index_in_part
         self._radiation_model = None
+        self._beamstrahlung_model = None
 
     def _init_track_no_collective(
         self,
@@ -373,6 +374,7 @@ class Tracker:
 
         self.track = self._track_no_collective
         self._radiation_model = None
+        self._beamstrahlung_model = None
         self.use_prebuilt_kernels = use_prebuilt_kernels
 
         if compile:


### PR DESCRIPTION
Initialize the _beamstrahlung_model variable to avoid situations where it is used/modified without being initialized via tracker.configure_radiation

## Description
Following the fixes in 0.25.1, this variable beamstrahlung_model is copied in _build_auxiliary_tracker_with_extra_markers, but this can be used without running tracker.configure_radiation() first, for example in the build_particles method. 

Closes [Xsuite issue #269](https://github.com/xsuite/xsuite/issues/269)

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
