### PR TITLE
include the prebuilt kernel descriptions in the MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,7 @@ include *.md
 # Include the license file
 include LICENSE.txt
 
+# Include the prebuilt kernel descriptions
+include xtrack/prebuilt_kernels/_kernel_definitions.json
+
 recursive-include xtrack *.h


### PR DESCRIPTION
Include the file `xtrack/prebuilt_kernels/_kernel_definitions.json` in the manifest, so that kernels can be prebuilt when xtrack is installed to site-packages.

This fixes the issue described in https://github.com/xsuite/xsuite/issues/273.
