### PR TITLE
increase tolerance in test_twiss.py:test_get_normalized_coordinates

### DIFF
--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -200,7 +200,7 @@ def test_get_normalized_coordinates(test_context):
     assert np.allclose(norm_coord23['y_norm'][:3], [0.3, -0.2, 0.2], atol=5e-12, rtol=0)
     assert np.allclose(norm_coord23['y_norm'][3:6], [0.3, -0.2, 0.2], atol=5e-12, rtol=0)
     assert np.allclose(norm_coord23['y_norm'][6:], xp.particles.LAST_INVALID_STATE)
-    assert np.allclose(norm_coord23['px_norm'][:3], [0.1, 0.2, 0.3], atol=5e-12, rtol=0)
+    assert np.allclose(norm_coord23['px_norm'][:3], [0.1, 0.2, 0.3], atol=6e-12, rtol=0)
     assert np.allclose(norm_coord23['px_norm'][3:6], [0.1, 0.2, 0.3], atol=5e-12, rtol=0)
     assert np.allclose(norm_coord23['px_norm'][6:], xp.particles.LAST_INVALID_STATE)
     assert np.allclose(norm_coord23['py_norm'][:3], [0.5, 0.6, 0.8], atol=5e-12, rtol=0)


### PR DESCRIPTION
## Description

In a single place in `test_twiss.py:test_get_normalized_coordinates` replace a tolerance from 5e-12 to 6e-12, as it seems that the original tolerance is tight enough to fail on certain machines.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
