### PR TITLE
Bugfix/madx misalignments

### DIFF
--- a/tests/test_madloader.py
+++ b/tests/test_madloader.py
@@ -242,9 +242,6 @@ def test_shift_tilt_order():
             lrad=1;
     seq: sequence, l=1;
     elm1:elm, at=1;
-    !mk:marker, at=0.1;
-    !elm2:elm, at=0.5;
-    !elm3:elm, at=0.5;
     endsequence;
     beam;
     use,sequence=seq;

--- a/xtrack/mad_loader.py
+++ b/xtrack/mad_loader.py
@@ -409,14 +409,6 @@ class Alignment:
 
     def entry(self):
         out = []
-        if self.tilt:
-            out.append(
-                self.Builder(
-                    self.name + "_tilt_entry",
-                    self.classes.SRotation,
-                    angle=self.tilt,
-                )
-            )
         if self.dx or self.dy:
             out.append(
                 self.Builder(
@@ -426,10 +418,26 @@ class Alignment:
                     dy=self.dy,
                 )
             )
+        if self.tilt:
+            out.append(
+                self.Builder(
+                    self.name + "_tilt_entry",
+                    self.classes.SRotation,
+                    angle=self.tilt,
+                )
+            )
         return out
 
     def exit(self):
         out = []
+        if self.tilt:
+            out.append(
+                self.Builder(
+                    self.name + "_tilt_exit",
+                    self.classes.SRotation,
+                    angle=-self.tilt,
+                )
+            )
         if self.dx or self.dy:
             out.append(
                 self.Builder(
@@ -437,14 +445,6 @@ class Alignment:
                     self.classes.XYShift,
                     dx=-self.dx,
                     dy=-self.dy,
-                )
-            )
-        if self.tilt:
-            out.append(
-                self.Builder(
-                    self.name + "_tilt_exit",
-                    self.classes.SRotation,
-                    angle=-self.tilt,
                 )
             )
         return out


### PR DESCRIPTION
## Description
Order of dx/dy and dpsi  when importing from madx error tables was wrong.
Added test to check, and reversed the order.

Fixes xsuite Issue # 302 (https://github.com/xsuite/xsuite/issues/302)

tests/test_prebuild_kernels.py does not pass, but was also not passing before.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
