### PR TITLE
Recreate #310

### DIFF
--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -186,7 +186,7 @@ def test_simplification_methods_not_inplace():
     assert 'marker4' not in newline.element_names
 
 
-def test_merging_consecutive_apertures():
+def test_remove_redundant_apertures():
 
     # Lattice:
     # D1-A1-M-D2 D3-A2-M-D4 D5-A3-M-D6 D7-A4-M-D8 D9-A5-M-D10
@@ -205,7 +205,7 @@ def test_merging_consecutive_apertures():
     assert len(line.element_names) == 20
     all_aper = [nn for nn in line.element_names if xt._is_aperture(line[nn])]
     all_aper_pos = [line.get_s_position(ap) for ap in all_aper]
-    line.merge_consecutive_apertures()
+    line.remove_redundant_apertures()
     line.remove_markers()
     line.merge_consecutive_drifts()
     # The lattice is now D1-A1-DD-A5-D10
@@ -222,7 +222,7 @@ def test_merging_consecutive_apertures():
     assert len(line.element_names) == 20
     all_aper = [nn for nn in line.element_names if xt._is_aperture(line[nn])]
     all_aper_pos = [line.get_s_position(ap) for ap in all_aper]
-    line.merge_consecutive_apertures(keep=all_aper[3])
+    line.remove_redundant_apertures(keep=all_aper[3])
     line.remove_markers()
     line.merge_consecutive_drifts()
     # The lattice is now D1-A1-DD-A4-DD-A5-D10
@@ -241,7 +241,7 @@ def test_merging_consecutive_apertures():
     all_aper = [nn for nn in line.element_names if xt._is_aperture(line[nn])]
     all_aper_pos = [line.get_s_position(ap) for ap in all_aper]
     all_drifts = [nn for nn in line.element_names if xt._is_drift(line[nn])]
-    line.merge_consecutive_apertures(drifts_that_need_aperture=all_drifts[8])
+    line.remove_redundant_apertures(drifts_that_need_aperture=all_drifts[8])
     line.remove_markers()
     line.merge_consecutive_drifts()
     # The lattice is now D1-A1-DD-A4-DD-A5-D10
@@ -263,11 +263,11 @@ def test_merging_consecutive_apertures():
         ]
     line = xt.Line(elements=elements)
     original_line = line.copy()
-    line.merge_consecutive_apertures()
+    line.remove_redundant_apertures()
     assert xt._lines_equal(line, original_line)
 
     
-def test_merging_consecutive_apertures_not_inplace():
+def test_remove_redundant_apertures_not_inplace():
 
     # Test removing all consecutive middle apertures
     elements = []
@@ -284,7 +284,7 @@ def test_merging_consecutive_apertures_not_inplace():
     assert len(line.element_names) == 20
     all_aper = [nn for nn in line.element_names if xt._is_aperture(line[nn])]
     all_aper_pos = [line.get_s_position(ap) for ap in all_aper]
-    newline = line.merge_consecutive_apertures(inplace=False)
+    newline = line.remove_redundant_apertures(inplace=False)
     newline = newline.remove_markers(inplace=False)
     newline = newline.merge_consecutive_drifts(inplace=False)
     assert xt._lines_equal(line, original_line)

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -33,7 +33,7 @@ def test_simplification_methods():
     line.insert_element(element=xt.Drift(length=1), name='drift1', at_s=1.2)
     line.insert_element(element=xt.Drift(length=1), name='drift2', at_s=2.2)
     line.merge_consecutive_drifts(inplace=True, keep=['drift2'])
-    assert len(line.element_names) == 4
+    assert len(line.element_names) == 5
     assert 'drift2' in line.element_names
     assert 'drift1' not in line.element_names
     line.merge_consecutive_drifts(inplace=True)

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -18,7 +18,6 @@ def test_simplification_methods():
                     + [xt.Drift(length=0)] # End line marker
             )
         )
-    line._init_var_management()
 
     # Test merging of drifts
     line.insert_element(element=xt.Cavity(), name='cav', at_s=3.3)
@@ -72,7 +71,6 @@ def test_simplification_methods():
     assert np.allclose(line[1].ksl, [52,60,17], rtol=0, atol=1e-15)
 
     # Test removing inactive multipoles
-    line._init_var_management()
     line.insert_element(element=xt.Multipole(knl=[0, 8, 1], ksl=[0, 20, 30]), name='m5', at_s=3.3)
     line.insert_element(element=xt.Multipole(knl=[2, 0, 3], ksl=[10, 34, 15]), name='m6', at_s=3.3)
     line.remove_inactive_multipoles(inplace=True)
@@ -113,7 +111,6 @@ def test_simplification_methods_not_inplace():
                     + [xt.Drift(length=0)] # End line marker
             )
         )
-    line._init_var_management()
 
     # Test merging of drifts
     line.insert_element(element=xt.Cavity(), name="cav", at_s=3.3)
@@ -150,7 +147,6 @@ def test_simplification_methods_not_inplace():
     line.merge_consecutive_multipoles(inplace=True)
 
     # Test removing inactive multipoles
-    line._init_var_management()
     original_line = line.copy()
     newline = line.remove_inactive_multipoles(inplace=False)
     assert xt._lines_equal(line, original_line)
@@ -203,7 +199,6 @@ def test_merging_consecutive_apertures():
             xt.Drift(length=0.4)
         ]
     line = xt.Line(elements=elements)
-    line._init_var_management()
     original_line = line.copy()
 
     # Test removing all consecutive middle apertures
@@ -284,7 +279,6 @@ def test_merging_consecutive_apertures_not_inplace():
             xt.Drift(length=0.4)
         ]
     line = xt.Line(elements=elements)
-    line._init_var_management()
     original_line = line.copy()
 
     assert len(line.element_names) == 20

--- a/xtrack/__init__.py
+++ b/xtrack/__init__.py
@@ -26,8 +26,9 @@ from .mad_loader import MadLoader
 
 from .multisetter import MultiSetter
 
-# Flag test functions
+# Flags and test functions
 from .line import _is_drift, _behaves_like_drift, _is_aperture, _is_thick, _allow_backtrack
+from .line import _lines_equal, _apertures_equal
 from .loss_location_refinement import _skip_in_loss_location_refinement
 
 import xpart as _xp

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -1084,7 +1084,7 @@ class Line:
     # For every occurence of three or more apertures that are the same,
     # only separated by Drifts or Markers, this script removes the
     # middle apertures
-    def merge_consecutive_apertures(self, inplace=True, keep=None,
+    def remove_redundant_apertures(self, inplace=True, keep=None,
                                   drifts_that_need_aperture=[]):
         '''
         Merge consecutive aperture checks by deleting the middle ones
@@ -1092,7 +1092,7 @@ class Line:
 
         # TODO: this probably actually works, but better be safe than sorry
         if self._var_management is not None:
-            raise NotImplementedError('`merge_consecutive_apertures` not'
+            raise NotImplementedError('`remove_redundant_apertures` not'
                                       ' available when deferred expressions are'
                                       ' used')
 

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -946,6 +946,11 @@ class Line:
             Name of the markers to keep (default: None)
         '''
 
+        if self._var_management is not None:
+            raise NotImplementedError('`remove_markers` not'
+                                      ' available when deferred expressions are'
+                                      ' used')
+
         self._frozen_check()
 
         if keep is None:
@@ -960,29 +965,22 @@ class Line:
                 continue
             newline.append_element(ee, nn)
 
-        _lref = None
-        if self._var_management is not None:
-            import xdeps as xd
-            # Update the lref to point to the new element_dict
-            manager = xd.Manager()
-            _lref = manager.ref(newline.element_dict, 'element_refs')
-
         if inplace:
             self.element_names = newline.element_names
             self.element_dict  = newline.element_dict
-            if _lref is not None:
-                self._var_management['lref'] = _lref
             return self
-        elif _lref is not None:
-            # copy the var management
-            newline._init_var_management(dct=self._var_management_to_dict())
-            newline._var_management['lref'] = _lref
-        return newline
+        else:
+            return newline
 
     def remove_inactive_multipoles(self, inplace=True, keep=None):
         '''
         Remove inactive multipoles from the line
         '''
+
+        if self._var_management is not None:
+            raise NotImplementedError('`remove_inactive_multipoles` not'
+                                      ' available when deferred expressions are'
+                                      ' used')
 
         self._frozen_check()
 
@@ -1002,29 +1000,22 @@ class Line:
                     continue
             newline.append_element(ee, nn)
 
-        _lref = None
-        if self._var_management is not None:
-            import xdeps as xd
-            # Update the lref to point to the new element_dict
-            manager = xd.Manager()
-            _lref = manager.ref(newline.element_dict, 'element_refs')
-
         if inplace:
             self.element_names = newline.element_names
             self.element_dict  = newline.element_dict
-            if _lref is not None:
-                self._var_management['lref'] = _lref
             return self
-        elif _lref is not None:
-            # copy the var management
-            newline._init_var_management(dct=self._var_management_to_dict())
-            newline._var_management['lref'] = _lref
-        return newline
+        else:
+            return newline
 
     def remove_zero_length_drifts(self, inplace=True, keep=None):
         '''
         Remove zero-length drifts from the line
         '''
+
+        if self._var_management is not None:
+            raise NotImplementedError('`remove_zero_length_drifts` not'
+                                      ' available when deferred expressions are'
+                                      ' used')
 
         self._frozen_check()
 
@@ -1041,29 +1032,22 @@ class Line:
                     continue
             newline.append_element(ee, nn)
 
-        _lref = None
-        if self._var_management is not None:
-            import xdeps as xd
-            # Update the lref to point to the new element_dict
-            manager = xd.Manager()
-            _lref = manager.ref(newline.element_dict, 'element_refs')
-
         if inplace:
             self.element_names = newline.element_names
             self.element_dict  = newline.element_dict
-            if _lref is not None:
-                self._var_management['lref'] = _lref
             return self
-        elif _lref is not None:
-            # copy the var management
-            newline._init_var_management(dct=self._var_management_to_dict())
-            newline._var_management['lref'] = _lref
-        return newline
+        else:
+            return newline
 
     def merge_consecutive_drifts(self, inplace=True, keep=None):
         '''
         Merge consecutive drifts into one drift
         '''
+
+        if self._var_management is not None:
+            raise NotImplementedError('`merge_consecutive_drifts` not'
+                                      ' available when deferred expressions are'
+                                      ' used')
 
         self._frozen_check()
 
@@ -1090,24 +1074,12 @@ class Line:
             else:
                 newline.append_element(this_ee, nn)
 
-        _lref = None
-        if self._var_management is not None:
-            import xdeps as xd
-            # Update the lref to point to the new element_dict
-            manager = xd.Manager()
-            _lref = manager.ref(newline.element_dict, 'element_refs')
-
         if inplace:
             self.element_names = newline.element_names
             self.element_dict  = newline.element_dict
-            if _lref is not None:
-                self._var_management['lref'] = _lref
             return self
-        elif _lref is not None:
-            # copy the var management
-            newline._init_var_management(dct=self._var_management_to_dict())
-            newline._var_management['lref'] = _lref
-        return newline
+        else:
+            return newline
 
     # For every occurence of three or more apertures that are the same,
     # only separated by Drifts or Markers, this script removes the
@@ -1115,8 +1087,14 @@ class Line:
     def merge_consecutive_apertures(self, inplace=True, keep=None,
                                   drifts_that_need_aperture=[]):
         '''
-	Merge consecutive aperture checks by deleting the middle ones
+        Merge consecutive aperture checks by deleting the middle ones
         '''
+
+        # TODO: this probably actually works, but better be safe than sorry
+        if self._var_management is not None:
+            raise NotImplementedError('`merge_consecutive_apertures` not'
+                                      ' available when deferred expressions are'
+                                      ' used')
 
         self._frozen_check()
 
@@ -1164,21 +1142,21 @@ class Line:
             newline = self.copy()
 
         for name in aper_to_remove:
-            newline.element_dict.pop(name)
             newline.element_names.remove(name)
 
         return newline
 
     def merge_consecutive_multipoles(self, inplace=True, keep=None):
         '''
-	Merge consecutive multipoles into one multipole
+        Merge consecutive multipoles into one multipole
         '''
 
-        self._frozen_check()
         if self._var_management is not None:
             raise NotImplementedError('`merge_consecutive_multipoles` not'
                                       ' available when deferred expressions are'
                                       ' used')
+
+        self._frozen_check()
 
         if keep is None:
             keep = []
@@ -1224,24 +1202,12 @@ class Line:
             else:
                 newline.append_element(ee, nn)
 
-        _lref = None
-        if self._var_management is not None:
-            import xdeps as xd
-            # Update the lref to point to the new element_dict
-            manager = xd.Manager()
-            _lref = manager.ref(newline.element_dict, 'element_refs')
-
         if inplace:
             self.element_names = newline.element_names
             self.element_dict  = newline.element_dict
-            if _lref is not None:
-                self._var_management['lref'] = _lref
             return self
-        elif _lref is not None:
-            # copy the var management
-            newline._init_var_management(dct=self._var_management_to_dict())
-            newline._var_management['lref'] = _lref
-        return newline
+        else:
+            return newline
 
     def use_simple_quadrupoles(self):
         '''

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -1279,7 +1279,15 @@ class Line:
             ee = self.element_dict[name]
             if _allow_backtrack(ee) and not name in needs_aperture:
                 dont_need_aperture[name] = True
-            # Correct isthick for elements that need aperture but have zero length:
+
+            # Correct isthick for elements that need aperture but have zero length.
+            # Use-case example: Before collimators are installed as EverestCollimator
+            # (or any BaseCollimator element), they are just Markers or Drifts. We
+            # want to enforce that they have an aperture when loading the line (when
+            # they are still Drifts), so their names are added to 'needs_aperture'.
+            # However, it is enough for them to have an upstream aperture as they are
+            # at this stage just Markers (and xcoll takes care of providing the down-
+            # stream aperture), so we mark them as thin.
             if name in needs_aperture and hasattr(ee, 'length') and ee.length == 0:
                 elements_df.loc[elements_df['name']==name, 'isthick'] = False
 

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -70,6 +70,12 @@ def _dicts_equal(dict1, dict2):
         if hasattr(dict1[key], '__iter__'):
             if not hasattr(dict2[key], '__iter__'):
                 return False
+            elif isinstance(dict1[key], dict):
+                if not isinstance(dict2[key], dict):
+                    return False
+                else:
+                    if not _dicts_equal(dict1[key], dict2[key]):
+                        return False
             elif not np.array_equal(dict1[key], dict2[key]):
                 return False
         elif dict1[key] != dict2[key]:
@@ -86,38 +92,7 @@ def _apertures_equal(ap1, ap2):
     return _dicts_equal(ap1, ap2)
 
 def _lines_equal(line1, line2):
-    # Check element_names
-    if line1.element_names != line2.element_names:
-        return False
-    # Check flags
-    if line1._needs_rng != line2._needs_rng:
-        return False
-    # Check var management
-    if line1._var_management is not None:
-        if line2._var_management is None:
-            return False
-        if not _dicts_equal(line1._var_management_to_dict(),
-                            line2._var_management_to_dict()):
-            return False
-    # Compare reference particle
-    if line1.particle_ref is not None:
-        if line2.particle_ref is None:
-            return False
-        if not _dicts_equal(line1.particle_ref.to_dict(),
-                            line2.particle_ref.to_dict()):
-            return False
-    # Compare elements
-    for nn in line1.element_names:
-        ee1 = line1.element_dict[nn]
-        ee2 = line2.element_dict[nn]
-        if not (hasattr(ee1, 'to_dict') and hasattr(ee2, 'to_dict')):
-            raise NotImplementedError(f"Element {nn} does not have a"
-                        + "`to_dict` method. Cannot compare lines.")
-        ee1 = ee1.to_dict()
-        ee2 = ee2.to_dict()
-        if not _dicts_equal(ee1, ee2):
-            return False
-    return True
+    return _dicts_equal(line1.to_dict(), line2.to_dict())
 
 
 DEG2RAD = np.pi / 180.

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -1108,7 +1108,7 @@ class Line:
             if _is_drift(ee) and not nn in keep:
                 prev_nn = newline.element_names[-1]
                 prev_ee = newline.element_dict[prev_nn]
-                if _is_drift(prev_ee):
+                if _is_drift(prev_ee) and not prev_nn in keep:
                     prev_ee.length += ee.length
                 else:
                     newline.append_element(this_ee, nn)

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -430,6 +430,9 @@ class Tracker:
         if verbose: print("Merge consecutive multipoles")
         line.merge_consecutive_multipoles()
 
+        if verbose: print("Remove redundant apertures")
+        line.remove_redundant_apertures()
+
         if verbose: print("Remove zero length drifts")
         line.remove_zero_length_drifts()
 


### PR DESCRIPTION
## Description

From @freddieknets

<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

1. Added a function `merge_consecutive_apertures()` to the `line` to collapse consecutive apertures: in the case of 3 or more consecutive apertures (only separated by `Marker`s or `Drift`s) that are exactly the same, all are removed except the first and the last
2. Expanded the other simplification methods (`remove_zero_length_drifts()`, `merge_consecutive_drifts()`,  `remove_markers()`, `remove_inactive_multipoles()`, and `merge_consecutive_multipoles()`): added a `keep` option to all, and implemented the `inplace=False` functionality
3. Added two tests for `merge_consecutive_apertures()` 
4. Expanded the existing tests for the other simplification methods, to take the new options for `keep` and `inplace` into account
5. Created two helper functions to the `line`: `_apertures_equal()` to check if two apertures are the same, and `_lines_equal()` which compares two lines for equality (this currently only works if all elements in the line have a `to_dict()` method, and raises a `NotImplementedError` otherwise)
6. Updated `check_aperture()` to use the `_is_aperture()` and `_allow_backtrack` helper functions. This improves code consistency, and avoids the need to update the code when new elements are added (like the `XRotation` and `YRotation`)

## Checklist

Mandatory: 

- [X] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [X] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
