### PR TITLE
Add a Particles class for purely longitudinal studies (without "minitracker")

### DIFF
--- a/examples/full_ring/007_test_freeze_vars.py
+++ b/examples/full_ring/007_test_freeze_vars.py
@@ -47,7 +47,7 @@ line.particle_ref = xp.Particles(**input_data['particle'])
 # Build Tracker #
 #################
 print('Build tracker...')
-freeze_vars = xp.particles.part_energy_varnames() + ['zeta']
+freeze_vars = xp.Particles.part_energy_varnames() + ['zeta']
 line.build_tracker(_context=context)
 
 line.freeze_longitudinal()

--- a/tests/test_collimation.py
+++ b/tests/test_collimation.py
@@ -123,7 +123,7 @@ def test_aperture_refinement():
     rot_deg_aper_1 = 10.
 
     # aper_0_sandwitch
-    line_aper_0 = line=xt.Line(
+    line_aper_0 = xt.Line(
         elements=[xt.XYShift(_buffer=buf, dx=shift_aper_0[0], dy=shift_aper_0[1]),
                   xt.SRotation(_buffer=buf, angle=rot_deg_aper_0),
                   aper_0,

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -889,7 +889,7 @@ void test_function(TestElementData el,
         const int64_t ipart = part->ipart;
         double const val = b[ipart];
 
-        LocalParticle_add_to_x(part, val + a);
+        LocalParticle_add_to_s(part, val + a);
 
     //end_per_particle_block
 }
@@ -902,7 +902,7 @@ void TestElement_track_local_particle(TestElementData el,
 
     //start_per_particle_block (part0->part)
 
-        LocalParticle_set_x(part, a);
+        LocalParticle_set_s(part, a);
 
     //end_per_particle_block
 }
@@ -910,10 +910,14 @@ void TestElement_track_local_particle(TestElementData el,
 """
 
 
+@pytest.mark.parametrize(
+    'particles_class',
+    [xp.Particles, xp.ParticlesPurelyLongitudinal],
+)
 @for_all_test_contexts
-def test_per_particle_kernel(test_context):
+def test_per_particle_kernel(test_context, particles_class):
     class TestElement(xt.BeamElement):
-        _xofields={
+        _xofields = {
             'a': xo.Float64
         }
 
@@ -929,13 +933,13 @@ def test_per_particle_kernel(test_context):
 
     el = TestElement(_context=test_context, a=10)
 
-    # p = xp.Particles(p0c=1e9, x=[1,2,3], _context=test_context)
-    # el.track(p)
-    # p.move(_context=xo.ContextCpu())
-    # assert np.all(p.x == [10,10,10])
+    p = xp.Particles(p0c=1e9, s=[1, 2, 3], _context=test_context)
+    el.track(p)
+    p.move(_context=xo.ContextCpu())
+    assert np.all(p.s == [10, 10, 10])
 
-    p = xp.Particles(p0c=1e9, x=[1, 2, 3], _context=test_context)
-    b = p.x*0.5
+    p = particles_class(p0c=1e9, s=[1, 2, 3], _context=test_context)
+    b = p.s*0.5
     el.test_kernel(p, b=b)
     p.move(_context=xo.ContextCpu())
-    assert np.all(p.x == np.array([11.5, 13, 14.5]))
+    assert np.all(p.s == np.array([11.5, 13, 14.5]))

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -16,6 +16,8 @@ import ducktrack as dtk
 
 from scipy.stats import linregress
 
+from xpart.particles import Particles, ParticlesPurelyLongitudinal
+
 @for_all_test_contexts
 def test_constructor(test_context):
     elements = [
@@ -912,7 +914,7 @@ void TestElement_track_local_particle(TestElementData el,
 
 @pytest.mark.parametrize(
     'particles_class',
-    [xp.Particles, xp.ParticlesPurelyLongitudinal],
+    [Particles, ParticlesPurelyLongitudinal],
 )
 @for_all_test_contexts
 def test_per_particle_kernel(test_context, particles_class):
@@ -933,7 +935,7 @@ def test_per_particle_kernel(test_context, particles_class):
 
     el = TestElement(_context=test_context, a=10)
 
-    p = xp.Particles(p0c=1e9, s=[1, 2, 3], _context=test_context)
+    p = Particles(p0c=1e9, s=[1, 2, 3], _context=test_context)
     el.track(p)
     p.move(_context=xo.ContextCpu())
     assert np.all(p.s == [10, 10, 10])

--- a/tests/test_full_rings.py
+++ b/tests/test_full_rings.py
@@ -187,7 +187,7 @@ def test_freeze_vars(test_context):
     # Build Tracker #
     #################
     print('Build tracker...')
-    freeze_vars = xp.particles.part_energy_varnames() + ['zeta']
+    freeze_vars = xp.Particles.part_energy_varnames() + ['zeta']
     line.build_tracker(_context=test_context, reset_s_at_end_turn=False)
     line.freeze_vars(freeze_vars)
 

--- a/tests/test_overriden_particle.py
+++ b/tests/test_overriden_particle.py
@@ -13,8 +13,19 @@ from xobjects.test_helpers import for_all_test_contexts
 
 
 @for_all_test_contexts
-def test_overriden_particle(test_context):
-    p = xp.ParticlesFixed()
+def test_purely_longitudinal(test_context):
+    p_fixed = xp.ParticlesFixed(p0c=[1, 2, 3], delta=[3, 2, 1])
+    p = xp.Particles(p0c=[1, 2, 3], delta=[3, 2, 1], x=[1, 2, 3])
+
     l = xt.Line(elements=[xt.Cavity(voltage=1e6, frequency=1e6)])
     t = xt.Tracker(line=l, compile=False, _context=test_context)
+
+    t.track(p_fixed)
     t.track(p)
+
+    d_fixed = p_fixed.to_dict()
+    d = {k: v for k, v in p.to_dict().items() if k in d_fixed}
+
+    assert d.keys() == d_fixed.keys()
+    for k in d.keys():
+        assert np.allclose(d[k], d_fixed[k])

--- a/tests/test_overriden_particle.py
+++ b/tests/test_overriden_particle.py
@@ -95,13 +95,17 @@ def test_per_particle_kernel(test_context, mocker):
 
     # Now do it again, but verify that the kernels are reused, not recompiled.
     el.new_state = 64
+    p1.move(_context=test_context)
+    p2.move(_context=test_context)
 
     cffi_compile = mocker.patch.object(cffi.FFI, 'compile')
 
     el.test_kernel(p1)
+    p1.move(_context=xo.ContextCpu())
     assert np.all(p1.state == 64)
 
     el.test_kernel(p2)
+    p2.move(_context=xo.ContextCpu())
     assert np.all(p1.state == 64)
 
     cffi_compile.assert_not_called()

--- a/tests/test_overriden_particle.py
+++ b/tests/test_overriden_particle.py
@@ -1,0 +1,20 @@
+# copyright ############################### #
+# This file is part of the Xtrack Package.  #
+# Copyright (c) CERN, 2023.                 #
+# ######################################### #
+
+import pathlib
+
+import numpy as np
+import xobjects as xo
+import xtrack as xt
+import xpart as xp
+from xobjects.test_helpers import for_all_test_contexts
+
+
+@for_all_test_contexts
+def test_overriden_particle(test_context):
+    p = xp.ParticlesFixed()
+    l = xt.Line(elements=[xt.Cavity(voltage=1e6, frequency=1e6)])
+    t = xt.Tracker(line=l, compile=False, _context=test_context)
+    t.track(p)

--- a/tests/test_overriden_particle.py
+++ b/tests/test_overriden_particle.py
@@ -3,6 +3,7 @@
 # Copyright (c) CERN, 2023.                 #
 # ######################################### #
 
+import cffi
 import pathlib
 
 import numpy as np
@@ -14,7 +15,7 @@ from xobjects.test_helpers import for_all_test_contexts
 
 @for_all_test_contexts
 def test_purely_longitudinal(test_context):
-    p_fixed = xp.ParticlesFixed(p0c=[1, 2, 3], delta=[3, 2, 1], _context=test_context)
+    p_fixed = xp.ParticlesPurelyLongitudinal(p0c=[1, 2, 3], delta=[3, 2, 1], _context=test_context)
     p = xp.Particles(p0c=[1, 2, 3], delta=[3, 2, 1], x=[1, 2, 3], _context=test_context)
 
     l = xt.Line(elements=[xt.Cavity(voltage=1e6, frequency=1e6)])
@@ -29,3 +30,78 @@ def test_purely_longitudinal(test_context):
     assert d.keys() == d_fixed.keys()
     for k in d.keys():
         assert np.allclose(d[k], d_fixed[k])
+
+
+@for_all_test_contexts
+def test_per_particle_kernel(test_context, mocker):
+    class TestElement(xt.BeamElement):
+        _xofields = {
+            'new_state': xo.Float64
+        }
+
+        _extra_c_sources = ["""
+            /*gpufun*/
+            void test_function(
+                TestElementData el,
+                LocalParticle* part0
+            ) {
+                double const new_state = TestElementData_get_new_state(el);
+
+                //start_per_particle_block (part0->part)
+
+                    // This function has different implementations for
+                    // different particle types. It will change x for
+                    // Particles, but not ParticlesPurelyLongitudinal since
+                    // it does not have x.
+                    LocalParticle_kill_particle(part, new_state);
+            
+                //end_per_particle_block
+            }
+            
+            /*gpufun*/
+            void TestElement_track_local_particle(
+                TestElementData el,
+                LocalParticle* part0
+            ) {
+                // irrelevant
+            }
+        """]
+
+        _per_particle_kernels = {
+            'test_kernel': xo.Kernel(
+                c_name='test_function',
+                args=[]),
+        }
+
+    el = TestElement(_context=test_context, new_state=42)
+
+    # The per particle kernel should work for both particle types transparently.
+    p1 = xp.ParticlesPurelyLongitudinal(p0c=1e9, zeta=[1, 2, 3], _context=test_context)
+    p2 = xp.Particles(p0c=1e9, x=[1, 2, 3], zeta=[1, 2, 3], _context=test_context)
+
+    el.test_kernel(p1)
+    p1.move(_context=xo.ContextCpu())
+    assert np.all(p1.zeta == 1e30)
+    assert np.all(p1.state == 42)
+
+    # Now, the kernel for `p1` should not be used, instead a new one must be
+    # compiled. We check that by asserting a change in `x`: the kernel for a
+    # purely longitudinal particles cannot change `x`.
+    el.test_kernel(p2)
+    p2.move(_context=xo.ContextCpu())
+    assert np.all(p2.zeta == 1e30)
+    assert np.all(p2.state == 42)
+    assert np.all(p2.x == 1e30)
+
+    # Now do it again, but verify that the kernels are reused, not recompiled.
+    el.new_state = 64
+
+    cffi_compile = mocker.patch.object(cffi.FFI, 'compile')
+
+    el.test_kernel(p1)
+    assert np.all(p1.state == 64)
+
+    el.test_kernel(p2)
+    assert np.all(p1.state == 64)
+
+    cffi_compile.assert_not_called()

--- a/tests/test_overriden_particle.py
+++ b/tests/test_overriden_particle.py
@@ -14,8 +14,8 @@ from xobjects.test_helpers import for_all_test_contexts
 
 @for_all_test_contexts
 def test_purely_longitudinal(test_context):
-    p_fixed = xp.ParticlesFixed(p0c=[1, 2, 3], delta=[3, 2, 1])
-    p = xp.Particles(p0c=[1, 2, 3], delta=[3, 2, 1], x=[1, 2, 3])
+    p_fixed = xp.ParticlesFixed(p0c=[1, 2, 3], delta=[3, 2, 1], _context=test_context)
+    p = xp.Particles(p0c=[1, 2, 3], delta=[3, 2, 1], x=[1, 2, 3], _context=test_context)
 
     l = xt.Line(elements=[xt.Cavity(voltage=1e6, frequency=1e6)])
     t = xt.Tracker(line=l, compile=False, _context=test_context)

--- a/tests/test_overriden_particle.py
+++ b/tests/test_overriden_particle.py
@@ -4,25 +4,25 @@
 # ######################################### #
 
 import cffi
-import pathlib
 
 import numpy as np
 import xobjects as xo
 import xtrack as xt
-import xpart as xp
 from xobjects.test_helpers import for_all_test_contexts
+
+from xpart.particles import Particles, ParticlesPurelyLongitudinal
 
 
 @for_all_test_contexts
 def test_purely_longitudinal(test_context):
-    p_fixed = xp.ParticlesPurelyLongitudinal(p0c=[1, 2, 3], delta=[3, 2, 1], _context=test_context)
-    p = xp.Particles(p0c=[1, 2, 3], delta=[3, 2, 1], x=[1, 2, 3], _context=test_context)
+    p_fixed = ParticlesPurelyLongitudinal(p0c=[1, 2, 3], delta=[3, 2, 1], _context=test_context)
+    p = Particles(p0c=[1, 2, 3], delta=[3, 2, 1], x=[1, 2, 3], _context=test_context)
 
-    l = xt.Line(elements=[xt.Cavity(voltage=1e6, frequency=1e6)])
-    t = xt.Tracker(line=l, compile=False, _context=test_context)
+    line = xt.Line(elements=[xt.Cavity(voltage=1e6, frequency=1e6)])
+    line.build_tracker(compile=False, _context=test_context)
 
-    t.track(p_fixed)
-    t.track(p)
+    line.track(p_fixed)
+    line.track(p)
 
     d_fixed = p_fixed.to_dict()
     d = {k: v for k, v in p.to_dict().items() if k in d_fixed}
@@ -76,8 +76,8 @@ def test_per_particle_kernel(test_context, mocker):
     el = TestElement(_context=test_context, new_state=42)
 
     # The per particle kernel should work for both particle types transparently.
-    p1 = xp.ParticlesPurelyLongitudinal(p0c=1e9, zeta=[1, 2, 3], _context=test_context)
-    p2 = xp.Particles(p0c=1e9, x=[1, 2, 3], zeta=[1, 2, 3], _context=test_context)
+    p1 = ParticlesPurelyLongitudinal(p0c=1e9, zeta=[1, 2, 3], _context=test_context)
+    p2 = Particles(p0c=1e9, x=[1, 2, 3], zeta=[1, 2, 3], _context=test_context)
 
     el.test_kernel(p1)
     p1.move(_context=xo.ContextCpu())

--- a/tests/test_prebuild_kernels.py
+++ b/tests/test_prebuild_kernels.py
@@ -54,7 +54,7 @@ def test_prebuild_kernels(mocker, tmp_path):
     # Test that reloading the kernel works
     cffi_compile = mocker.patch.object(cffi.FFI, 'compile')
 
-    line=xt.Line(elements=[xt.Drift(length=2.0)])
+    line = xt.Line(elements=[xt.Drift(length=2.0)])
     line.build_tracker()
 
     p = xp.Particles(p0c=1e9, px=3e-6)

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -37,7 +37,7 @@ def test_ebe_monitor(test_context):
     mon = line.record_last_track
 
     for ii, ee in enumerate(line.elements):
-        for tt, nn in particles._structure['per_particle_vars']:
+        for tt, nn in particles.per_particle_vars:
             assert np.all(particles.to_dict()[nn] == getattr(mon, nn)[:, ii])
         ee.track(particles)
         particles.at_element += 1

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -251,7 +251,6 @@ class BeamElement(xo.HybridClass, metaclass=MetaBeamElement):
 
 
     def track(self, particles, increment_at_element=False):
-
         context = self._buffer.context
         if not hasattr(self, '_track_kernel'):
             if self._track_kernel_name not in context.kernels.keys():
@@ -261,7 +260,7 @@ class BeamElement(xo.HybridClass, metaclass=MetaBeamElement):
         if hasattr(self, 'io_buffer') and self.io_buffer is not None:
             io_buffer_arr = self.io_buffer.buffer
         else:
-            io_buffer_arr=context.zeros(1, dtype=np.int8) # dummy
+            io_buffer_arr = context.zeros(1, dtype=np.int8)  # dummy
 
         self._track_kernel.description.n_threads = particles._capacity
         self._track_kernel(el=self._xobject, particles=particles,

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -249,7 +249,6 @@ class BeamElement(xo.HybridClass, metaclass=MetaBeamElement):
                                        extra_classes=[particles_class._XoStruct],
                                        *args, **kwargs)
 
-
     def track(self, particles, increment_at_element=False):
         context = self._buffer.context
         if not hasattr(self, '_track_kernel'):

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -245,7 +245,9 @@ class BeamElement(xo.HybridClass, metaclass=MetaBeamElement):
         kwargs['apply_to_source'].append(
             partial(_handle_per_particle_blocks,
                     local_particle_src=particles_class.gen_local_particle_api()))
-        xo.HybridClass.compile_kernels(self, *args, **kwargs)
+        xo.HybridClass.compile_kernels(self,
+                                       extra_classes=[particles_class._XoStruct],
+                                       *args, **kwargs)
 
 
     def track(self, particles, increment_at_element=False):

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -126,6 +126,7 @@ class MetaBeamElement(xo.MetaHybridClass):
 
     def __new__(cls, name, bases, data):
         _XoStruct_name = name+'Data'
+        particles_class = xp.ParticlesInterface
 
         # Take xofields from data['_xofields'] or from bases
         xofields = _build_xofields_dict(bases, data)
@@ -170,13 +171,13 @@ class MetaBeamElement(xo.MetaHybridClass):
                 local_particle_function_name=name+'_track_local_particle'))
 
         # Add dependency on Particles class
-        depends_on.append(xp.Particles._XoStruct)
+        depends_on.append(particles_class._XoStruct)
 
         # Define track kernel
         track_kernel_name = f'{name}_track_particles'
         kernels[track_kernel_name] = xo.Kernel(
                     args=[xo.Arg(xo.ThisClass, name='el'),
-                        xo.Arg(xp.Particles._XoStruct, name='particles'),
+                        xo.Arg(particles_class._XoStruct, name='particles'),
                         xo.Arg(xo.Int64, name='flag_increment_at_element'),
                         xo.Arg(xo.Int8, pointer=True, name="io_buffer")]
                     )
@@ -189,13 +190,13 @@ class MetaBeamElement(xo.MetaHybridClass):
                         element_name=name, kernel_name=nn,
                         local_particle_function_name=kk.c_name,
                         additional_args=kk.args))
-                if xp.Particles._XoStruct not in depends_on:
-                    depends_on.append(xp.Particles._XoStruct)
+                if particles_class._XoStruct not in depends_on:
+                    depends_on.append(particles_class._XoStruct)
 
                 kernels.update(
                     {nn:
                         xo.Kernel(args=[xo.Arg(xo.ThisClass, name='el'),
-                            xo.Arg(xp.Particles._XoStruct, name='particles')]
+                            xo.Arg(particles_class._XoStruct, name='particles')]
                             + kk.args + [
                             xo.Arg(xo.Int64, name='flag_increment_at_element'),
                             xo.Arg(xo.Int8, pointer=True, name="io_buffer")])}
@@ -221,6 +222,7 @@ class MetaBeamElement(xo.MetaHybridClass):
 
         return new_class
 
+
 class BeamElement(xo.HybridClass, metaclass=MetaBeamElement):
 
     iscollective = None
@@ -229,19 +231,20 @@ class BeamElement(xo.HybridClass, metaclass=MetaBeamElement):
     allow_backtrack = False
     skip_in_loss_location_refinement = False
 
-    def init_pipeline(self,pipeline_manager,name,partners_names=[]):
+    def __init__(self, *args, **kwargs):
+        xo.HybridClass.__init__(self, *args, **kwargs)
+
+    def init_pipeline(self, pipeline_manager, name, partners_names=[]):
         self._pipeline_manager = pipeline_manager
         self.name = name
         self.partners_names = partners_names
 
-    def compile_kernels(self, *args, **kwargs):
-
+    def compile_kernels(self, particles_class, *args, **kwargs):
         if 'apply_to_source' not in kwargs.keys():
             kwargs['apply_to_source'] = []
         kwargs['apply_to_source'].append(
             partial(_handle_per_particle_blocks,
-                    local_particle_src=xp.gen_local_particle_api()))
-
+                    local_particle_src=particles_class.gen_local_particle_api()))
         xo.HybridClass.compile_kernels(self, *args, **kwargs)
 
 
@@ -250,7 +253,7 @@ class BeamElement(xo.HybridClass, metaclass=MetaBeamElement):
         context = self._buffer.context
         if not hasattr(self, '_track_kernel'):
             if self._track_kernel_name not in context.kernels.keys():
-                self.compile_kernels()
+                self.compile_kernels(particles_class=particles.__class__)
             self._track_kernel = context.kernels[self._track_kernel_name]
 
         if hasattr(self, 'io_buffer') and self.io_buffer is not None:
@@ -262,6 +265,10 @@ class BeamElement(xo.HybridClass, metaclass=MetaBeamElement):
         self._track_kernel(el=self._xobject, particles=particles,
                            flag_increment_at_element=increment_at_element,
                            io_buffer=io_buffer_arr)
+
+    @property
+    def context(self):
+        return self._buffer.context
 
     def _arr2ctx(self, arr):
         ctx = self._buffer.context
@@ -284,35 +291,37 @@ class BeamElement(xo.HybridClass, metaclass=MetaBeamElement):
 
 class PerParticlePyMethod:
 
-    def __init__(self, kernel, element):
-        self.kernel = kernel
+    def __init__(self, kernel_name, element):
+        self.kernel_name = kernel_name
         self.element = element
 
     def __call__(self, particles, increment_at_element=False, **kwargs):
+        instance = self.element
+        context = instance.context
+        if not hasattr(instance, '_track_kernel'):
+            if instance._track_kernel_name not in context.kernels.keys():
+                instance.compile_kernels(particles_class=particles.__class__)
+            instance._track_kernel = context.kernels[instance._track_kernel_name]
+        self.kernel = context.kernels[self.kernel_name]
 
         if hasattr(self.element, 'io_buffer') and self.element.io_buffer is not None:
             io_buffer_arr = self.element.io_buffer.buffer
         else:
             context = self.kernel.context
-            io_buffer_arr=context.zeros(1, dtype=np.int8) # dummy
+            io_buffer_arr = context.zeros(1, dtype=np.int8)  # dummy
 
         self.kernel.description.n_threads = particles._capacity
-        self.kernel(el=self.element._xobject, particles=particles,
-                           flag_increment_at_element=increment_at_element,
-                           io_buffer=io_buffer_arr,
-                           **kwargs)
+        self.kernel(el=self.element._xobject,
+                    particles=particles,
+                    flag_increment_at_element=increment_at_element,
+                    io_buffer=io_buffer_arr,
+                    **kwargs)
+
 
 class PerParticlePyMethodDescriptor:
-
     def __init__(self, kernel_name):
         self.kernel_name = kernel_name
 
     def __get__(self, instance, owner):
-        context = instance._buffer.context
-        if not hasattr(instance, '_track_kernel'):
-            if instance._track_kernel_name not in context.kernels.keys():
-                instance.compile_kernels()
-            instance._track_kernel = context.kernels[instance._track_kernel_name]
-
-        return PerParticlePyMethod(kernel=context.kernels[self.kernel_name],
-                                 element=instance)
+        return PerParticlePyMethod(kernel_name=self.kernel_name,
+                                   element=instance)

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -126,7 +126,6 @@ class MetaBeamElement(xo.MetaHybridClass):
 
     def __new__(cls, name, bases, data):
         _XoStruct_name = name+'Data'
-        particles_class = xp.ParticlesInterface
 
         # Take xofields from data['_xofields'] or from bases
         xofields = _build_xofields_dict(bases, data)
@@ -171,13 +170,13 @@ class MetaBeamElement(xo.MetaHybridClass):
                 local_particle_function_name=name+'_track_local_particle'))
 
         # Add dependency on Particles class
-        depends_on.append(particles_class._XoStruct)
+        depends_on.append(xp.ParticlesBase._XoStruct)
 
         # Define track kernel
         track_kernel_name = f'{name}_track_particles'
         kernels[track_kernel_name] = xo.Kernel(
                     args=[xo.Arg(xo.ThisClass, name='el'),
-                        xo.Arg(particles_class._XoStruct, name='particles'),
+                        xo.Arg(xp.ParticlesBase._XoStruct, name='particles'),
                         xo.Arg(xo.Int64, name='flag_increment_at_element'),
                         xo.Arg(xo.Int8, pointer=True, name="io_buffer")]
                     )
@@ -190,13 +189,13 @@ class MetaBeamElement(xo.MetaHybridClass):
                         element_name=name, kernel_name=nn,
                         local_particle_function_name=kk.c_name,
                         additional_args=kk.args))
-                if particles_class._XoStruct not in depends_on:
-                    depends_on.append(particles_class._XoStruct)
+                if xp.ParticlesBase._XoStruct not in depends_on:
+                    depends_on.append(xp.ParticlesBase._XoStruct)
 
                 kernels.update(
                     {nn:
                         xo.Kernel(args=[xo.Arg(xo.ThisClass, name='el'),
-                            xo.Arg(particles_class._XoStruct, name='particles')]
+                            xo.Arg(xp.ParticlesBase._XoStruct, name='particles')]
                             + kk.args + [
                             xo.Arg(xo.Int64, name='flag_increment_at_element'),
                             xo.Arg(xo.Int8, pointer=True, name="io_buffer")])}

--- a/xtrack/beam_elements/apertures.py
+++ b/xtrack/beam_elements/apertures.py
@@ -248,12 +248,13 @@ class LimitPolygon(BeamElement):
         return np.concatenate([yy, np.array([yy[0]])])
 
     def impact_point_and_normal(self, x_in, y_in, z_in,
-                                x_out, y_out, z_out):
+                                x_out, y_out, z_out, particles_class):
 
         ctx = self._buffer.context
 
         if 'LimitPolygon_impact_point_and_normal' not in ctx.kernels.keys():
-            self.compile_kernels(only_if_needed=True)
+            self.compile_kernels(particles_class=particles_class,
+                                 only_if_needed=True)
 
         x_inters = ctx.zeros(shape=x_in.shape, dtype=np.float64)
         y_inters = ctx.zeros(shape=x_in.shape, dtype=np.float64)

--- a/xtrack/beam_elements/apertures.py
+++ b/xtrack/beam_elements/apertures.py
@@ -6,6 +6,7 @@
 import numpy as np
 
 import xobjects as xo
+import xpart as xp
 
 from ..base_element import BeamElement
 from ..general import _pkg_root
@@ -248,12 +249,13 @@ class LimitPolygon(BeamElement):
         return np.concatenate([yy, np.array([yy[0]])])
 
     def impact_point_and_normal(self, x_in, y_in, z_in,
-                                x_out, y_out, z_out, particles_class):
+                                x_out, y_out, z_out):
 
         ctx = self._buffer.context
 
         if 'LimitPolygon_impact_point_and_normal' not in ctx.kernels.keys():
-            self.compile_kernels(particles_class=particles_class,
+            # The tracking kernel requires the usual particle class
+            self.compile_kernels(particles_class=xp.Particles,
                                  only_if_needed=True)
 
         x_inters = ctx.zeros(shape=x_in.shape, dtype=np.float64)

--- a/xtrack/beam_elements/elements_src/cavity.h
+++ b/xtrack/beam_elements/elements_src/cavity.h
@@ -15,7 +15,7 @@ void Cavity_track_local_particle(CavityData el, LocalParticle* part0){
         double const   beta0  = LocalParticle_get_beta0(part);
         double const   zeta   = LocalParticle_get_zeta(part);
         double const   q      = fabs(LocalParticle_get_q0(part))
-                		    * LocalParticle_get_charge_ratio(part);
+                		        * LocalParticle_get_charge_ratio(part);
         double const   tau    = zeta / beta0;
 
         double const   phase  = DEG2RAD  * CavityData_get_lag(el) -

--- a/xtrack/headers/checks.h
+++ b/xtrack/headers/checks.h
@@ -7,20 +7,9 @@
 #define XTRACK_FUNCTIONS_H
 
 /*gpufun*/
-void kill_particle(LocalParticle* part, int64_t kill_state) {
-//    LocalParticle_set_x(part, 1e30);
-//    LocalParticle_set_px(part, 1e30);
-//    LocalParticle_set_y(part, 1e30);
-//    LocalParticle_set_py(part, 1e30);
-    LocalParticle_set_zeta(part, 1e30);
-    LocalParticle_update_delta(part, -1);  // zero energy
-    LocalParticle_set_state(part, kill_state);
-}
-
-/*gpufun*/
 void kill_all_particles(LocalParticle* part0, int64_t kill_state) {
     //start_per_particle_block (part0->part)
-        kill_particle(part, kill_state);
+        LocalParticle_kill_particle(part, kill_state);
     //end_per_particle_block
 }
 
@@ -30,7 +19,7 @@ int8_t assert_tracking(LocalParticle* part, int64_t kill_state){
     // Whenever we are not tracking, e.g. in a twiss, the particle will be at_turn < 0.
     // We test this to distinguish genuine tracking from twiss.
     if (LocalParticle_get_at_turn(part) < 0){
-        kill_particle(part, kill_state);
+        LocalParticle_kill_particle(part, kill_state);
         return 0;
     }
     return 1;

--- a/xtrack/headers/checks.h
+++ b/xtrack/headers/checks.h
@@ -8,10 +8,10 @@
 
 /*gpufun*/
 void kill_particle(LocalParticle* part, int64_t kill_state) {
-    LocalParticle_set_x(part, 1e30);
-    LocalParticle_set_px(part, 1e30);
-    LocalParticle_set_y(part, 1e30);
-    LocalParticle_set_py(part, 1e30);
+//    LocalParticle_set_x(part, 1e30);
+//    LocalParticle_set_px(part, 1e30);
+//    LocalParticle_set_y(part, 1e30);
+//    LocalParticle_set_py(part, 1e30);
     LocalParticle_set_zeta(part, 1e30);
     LocalParticle_update_delta(part, -1);  // zero energy
     LocalParticle_set_state(part, kill_state);

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -496,7 +496,7 @@ class Line:
     def build_tracker(self, **kwargs):
         "Build a tracker associated for the line."
         assert self.tracker is None, 'The line already has an associated tracker'
-        import xtrack as xt # avoid circular import
+        import xtrack as xt  # avoid circular import
         self.tracker = xt.Tracker(line=self, **kwargs)
         return self.tracker
 

--- a/xtrack/loss_location_refinement/loss_location_refinement.py
+++ b/xtrack/loss_location_refinement/loss_location_refinement.py
@@ -43,8 +43,7 @@ class LossLocationRefinement:
         temp_poly = LimitPolygon(_buffer=self.tracker._tracker_data._buffer,
                 x_vertices=[1,-1, -1, 1], y_vertices=[1,1,-1,-1])
         na = lambda a : np.array(a, dtype=np.float64)
-        temp_poly.impact_point_and_normal(particles_class=tracker.particles_class,
-                                          x_in=na([0]), y_in=na([0]),
+        temp_poly.impact_point_and_normal(x_in=na([0]), y_in=na([0]),
                                           z_in=na([0]), x_out=na([2]),
                                           y_out=na([2]), z_out=na([0]))
 
@@ -466,7 +465,6 @@ def characterize_aperture(tracker, i_aperture, n_theta, r_max, dr,
     # Get a convex polygon that has vertices at all requested angles
     r_out = 1. # m
     res = temp_poly.impact_point_and_normal(
-            particles_class=tracker.particles_class,
             x_in=0*theta_vect, y_in=0*theta_vect, z_in=0*theta_vect,
             x_out=r_out*np.cos(theta_vect),
             y_out=r_out*np.sin(theta_vect),

--- a/xtrack/loss_location_refinement/loss_location_refinement.py
+++ b/xtrack/loss_location_refinement/loss_location_refinement.py
@@ -43,8 +43,10 @@ class LossLocationRefinement:
         temp_poly = LimitPolygon(_buffer=self.tracker._tracker_data._buffer,
                 x_vertices=[1,-1, -1, 1], y_vertices=[1,1,-1,-1])
         na = lambda a : np.array(a, dtype=np.float64)
-        temp_poly.impact_point_and_normal(x_in=na([0]), y_in=na([0]), z_in=na([0]),
-                                   x_out=na([2]), y_out=na([2]), z_out=na([0]))
+        temp_poly.impact_point_and_normal(particles_class=tracker.particles_class,
+                                          x_in=na([0]), y_in=na([0]),
+                                          z_in=na([0]), x_out=na([2]),
+                                          y_out=na([2]), z_out=na([0]))
 
         # Build track kernel with all elements + polygon
         trk_gen = Tracker(_buffer=self.tracker._tracker_data._buffer,
@@ -464,6 +466,7 @@ def characterize_aperture(tracker, i_aperture, n_theta, r_max, dr,
     # Get a convex polygon that has vertices at all requested angles
     r_out = 1. # m
     res = temp_poly.impact_point_and_normal(
+            particles_class=tracker.particles_class,
             x_in=0*theta_vect, y_in=0*theta_vect, z_in=0*theta_vect,
             x_out=r_out*np.cos(theta_vect),
             y_out=r_out*np.sin(theta_vect),
@@ -473,4 +476,3 @@ def characterize_aperture(tracker, i_aperture, n_theta, r_max, dr,
                               _buffer=buffer_for_poly)
 
     return polygon, i_start
-

--- a/xtrack/monitors/particles_monitor.py
+++ b/xtrack/monitors/particles_monitor.py
@@ -55,7 +55,7 @@ def _monitor_init(
         n_records = n_turns * n_part_ids * n_repetitions
 
         data_init = {nn: n_records for tt, nn in
-                        self._ParticlesClass._structure["per_particle_vars"]}
+                        self._ParticlesClass.per_particle_vars}
 
         self.xoinitialize(
             _context=_context,
@@ -76,7 +76,7 @@ def _monitor_init(
         self.auto_to_numpy = auto_to_numpy
 
         with self.data._bypass_linked_vars():
-            for tt, nn in self._ParticlesClass._structure["per_particle_vars"]:
+            for tt, nn in self._ParticlesClass.per_particle_vars:
                 getattr(self.data, nn)[:] = 0
 
 class _FieldOfMonitor:
@@ -137,7 +137,7 @@ def generate_monitor_class(ParticlesClass):
     ParticlesMonitorClass.behaves_like_drift = True
     ParticlesMonitorClass.allow_backtrack = True
 
-    per_particle_vars = ParticlesClass._structure["per_particle_vars"]
+    per_particle_vars = ParticlesClass.per_particle_vars
     for tt, nn in per_particle_vars:
         setattr(ParticlesMonitorClass, nn, _FieldOfMonitor(name=nn))
 

--- a/xtrack/multisetter/multisetter.py
+++ b/xtrack/multisetter/multisetter.py
@@ -89,13 +89,13 @@ class MultiSetter(xo.HybridClass):
     def get_values(self):
         out = self._context.zeros(len(self.offsets), dtype=np.float64)
         kernel = self._context.kernels.get_values_at_offsets
-        kernel.description.n_threads = len(self.offsets)
+        kernel.set_n_threads(len(self.offsets))
         kernel(data=self, buffer=self._tracker_buffer.buffer, out=out)
         return out
 
     def set_values(self, values):
         kernel = self._context.kernels.set_values_at_offsets
-        kernel.description.n_threads = len(self.offsets)
+        kernel.set_n_threads(len(self.offsets))
         kernel(data=self, buffer=self._tracker_buffer.buffer,
                input=xt.BeamElement._arr2ctx(self,values))
 

--- a/xtrack/random/random_src/rutherford.h
+++ b/xtrack/random/random_src/rutherford.h
@@ -15,7 +15,7 @@ int8_t assert_rutherford_set(RandomRutherfordData rng, LocalParticle* part, int6
     double A = RandomRutherfordData_get_A(rng);
     double B = RandomRutherfordData_get_B(rng);
     if (A==0. && B==0.) {
-        kill_particle(part, kill_state);
+        LocalParticle_kill_particle(part, kill_state);
         return 0;
     }
     return 1;
@@ -59,7 +59,7 @@ double RandomRutherford_generate(RandomRutherfordData rng, LocalParticle* part){
     
     if (A==0. || B==0.){
         // Not initialised
-        kill_particle(part, RNG_ERR_RUTH_NOT_SET);
+        LocalParticle_kill_particle(part, RNG_ERR_RUTH_NOT_SET);
         return 0.;
     }
 

--- a/xtrack/random/random_src/uniform.h
+++ b/xtrack/random/random_src/uniform.h
@@ -17,7 +17,7 @@ int8_t assert_rng_set(LocalParticle* part, int64_t kill_state){
     int64_t s3 = LocalParticle_get__rng_s3(part);
     int64_t s4 = LocalParticle_get__rng_s4(part);
     if (s1==0 && s2==0 && s3==0 && s4==0) {
-        kill_particle(part, kill_state);
+        LocalParticle_kill_particle(part, kill_state);
         return 0;
     }
     return 1;
@@ -32,7 +32,7 @@ double RandomUniform_generate(LocalParticle* part){
     uint32_t s4 = LocalParticle_get__rng_s4(part);
 
     if (s1==0 && s2==0 && s3==0 && s4==0) {
-        kill_particle(part, RNG_ERR_SEEDS_NOT_SET);
+        LocalParticle_kill_particle(part, RNG_ERR_SEEDS_NOT_SET);
         return 0;
     }
 

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -802,7 +802,9 @@ class Tracker:
                     kernel_descriptions={'track_line': kernel_description},
                 )
                 self._context.kernels.update(kernels)
-                self._current_track_kernel = self._context.kernels['track_line']
+                classes = (type(self._tracker_data._element_ref_data),
+                           self.particles_class._XoStruct)
+                self._current_track_kernel = self._context.kernels[('track_line', classes)]
                 self.element_classes = [cls._XoStruct for cls in modules_classes]
                 self._tracker_data = TrackerData(
                     line=self.line,
@@ -972,7 +974,9 @@ class Tracker:
         )
         context.kernels.update(out_kernels)
 
-        self._current_track_kernel = context.kernels.track_line
+        classes = (type(self._tracker_data._element_ref_data),
+                   self.particles_class._XoStruct)
+        self._current_track_kernel = context.kernels[('track_line', classes)]
 
     def get_kernel_descriptions(self, _context=None):
         if not _context:

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -338,7 +338,7 @@ class Tracker:
             particles_class = xp.Particles
 
         if local_particle_src is None:
-            local_particle_src = xp.gen_local_particle_api()
+            local_particle_src = particles_class.gen_local_particle_api()
 
         self.global_xy_limit = global_xy_limit
         self.extra_headers = extra_headers

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -1366,6 +1366,8 @@ class Tracker:
         freeze_longitudinal=False,
         time=False
     ):
+        # Add the Particles class to the config, so the kernel is recompiled
+        # and stored if a new Particles class is given.
         if type(particles) != xp.Particles:
             self.config.particles_class_name = type(particles).__name__
         else:

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -802,8 +802,7 @@ class Tracker:
                     kernel_descriptions={'track_line': kernel_description},
                 )
                 self._context.kernels.update(kernels)
-                classes = (type(self._tracker_data._element_ref_data),
-                           self.particles_class._XoStruct)
+                classes = (self.particles_class._XoStruct,)
                 self._current_track_kernel = self._context.kernels[('track_line', classes)]
                 self.element_classes = [cls._XoStruct for cls in modules_classes]
                 self._tracker_data = TrackerData(
@@ -974,8 +973,7 @@ class Tracker:
         )
         context.kernels.update(out_kernels)
 
-        classes = (type(self._tracker_data._element_ref_data),
-                   self.particles_class._XoStruct)
+        classes = (self.particles_class._XoStruct,)
         self._current_track_kernel = context.kernels[('track_line', classes)]
 
     def get_kernel_descriptions(self, _context=None):

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -1178,9 +1178,9 @@ class Tracker:
         assert self.iscollective is False, ('Cannot freeze longitudinal '
                         'variables in collective mode (not yet implemented)')
         if state:
-            self.freeze_vars(xp.particles.part_energy_varnames() + ['zeta'])
+            self.freeze_vars(self.particles_class.part_energy_varnames() + ['zeta'])
         else:
-            self.unfreeze_vars(xp.particles.part_energy_varnames() + ['zeta'])
+            self.unfreeze_vars(self.particles_class.part_energy_varnames() + ['zeta'])
 
     def _track_with_collective(
         self,

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -248,7 +248,7 @@ class Tracker:
                 noncollective_xelements.append(
                     Drift(_buffer=_buffer, length=ldrift))
 
-        # Build tracker for all non collective elements
+        # Build tracker for all non-collective elements
         # (with collective elements replaced by Drifts)
         supertracker = Tracker(_buffer=_buffer,
                 line=Line(elements=noncollective_xelements,
@@ -266,21 +266,21 @@ class Tracker:
                 )
         supertracker.config = self.config
 
-        # Build trackers for non collective parts
+        # Build trackers for non-collective parts
         for ii, pp in enumerate(parts):
             if not _check_is_collective(pp):
                 parts[ii] = Tracker(_buffer=_buffer,
-                                line=pp,
-                                element_classes=supertracker.element_classes,
-                                track_kernel=supertracker.track_kernel,
-                                particles_class=particles_class,
-                                particles_monitor_class=particles_monitor_class,
-                                global_xy_limit=global_xy_limit,
-                                extra_headers=extra_headers,
-                                local_particle_src=local_particle_src,
-                                skip_end_turn_actions=True,
-                                io_buffer=self.io_buffer,
-                                use_prebuilt_kernels=use_prebuilt_kernels,)
+                                    line=pp,
+                                    element_classes=supertracker.element_classes,
+                                    track_kernel=supertracker.track_kernel,
+                                    particles_class=particles_class,
+                                    particles_monitor_class=particles_monitor_class,
+                                    global_xy_limit=global_xy_limit,
+                                    extra_headers=extra_headers,
+                                    local_particle_src=local_particle_src,
+                                    skip_end_turn_actions=True,
+                                    io_buffer=self.io_buffer,
+                                    use_prebuilt_kernels=use_prebuilt_kernels,)
                 parts[ii].config = self.config
 
         # Make a "marker" element to increase at_element

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -55,7 +55,7 @@ class Tracker:
         sequence=None,
         track_kernel=None,
         element_classes=None,
-        particles_class=None,
+        particles_class=xp.Particles,
         skip_end_turn_actions=False,
         reset_s_at_end_turn=True,
         particles_monitor_class=None,
@@ -1366,6 +1366,12 @@ class Tracker:
         freeze_longitudinal=False,
         time=False
     ):
+        if type(particles) != xp.Particles:
+            self.config.particles_class_name = type(particles).__name__
+        else:
+            self.config.pop('particles_class_name', None)
+        self.particles_class = particles.__class__
+        self.local_particle_src = particles.gen_local_particle_api()
 
         if time:
             t0 = perf_counter()

--- a/xtrack/tracker_data.py
+++ b/xtrack/tracker_data.py
@@ -7,6 +7,8 @@ from typing import Tuple
 
 import xobjects as xo
 
+from xobjects.struct import Struct, MetaStruct
+
 from .line import Line, mk_class_namespace
 
 
@@ -21,12 +23,27 @@ class SerializationHeader(xo.Struct):
     reftype_names = xo.String[:]
 
 
+class MetaElementRefData(MetaStruct):
+    """
+    Since ElementRefData is a class that is generated on the fly, this
+    metaclass is used to make it hashable.
+    """
+    def __hash__(cls):
+        """Return a unique hash for the ElementRefData class."""
+        return hash(('ElementRefData', MetaElementRefData))
+
+
+    def __eq__(cls, other):
+        return hash(cls) == hash(other)
+
+
 class TrackerData:
     @staticmethod
     def generate_element_ref_data(element_ref_class) -> 'ElementRefData':
-        class ElementRefData(xo.Struct):
+        class ElementRefData(Struct, metaclass=MetaElementRefData):
             elements = element_ref_class[:]
             names = xo.String[:]
+            _is_element_ref_data = True
 
         return ElementRefData
 

--- a/xtrack/tracker_data.py
+++ b/xtrack/tracker_data.py
@@ -23,27 +23,13 @@ class SerializationHeader(xo.Struct):
     reftype_names = xo.String[:]
 
 
-class MetaElementRefData(MetaStruct):
-    """
-    Since ElementRefData is a class that is generated on the fly, this
-    metaclass is used to make it hashable.
-    """
-    def __hash__(cls):
-        """Return a unique hash for the ElementRefData class."""
-        return hash(('ElementRefData', MetaElementRefData))
-
-
-    def __eq__(cls, other):
-        return hash(cls) == hash(other)
-
-
 class TrackerData:
     @staticmethod
     def generate_element_ref_data(element_ref_class) -> 'ElementRefData':
-        class ElementRefData(Struct, metaclass=MetaElementRefData):
+        class ElementRefData(Struct):
             elements = element_ref_class[:]
             names = xo.String[:]
-            _is_element_ref_data = True
+            _overridable = False
 
         return ElementRefData
 


### PR DESCRIPTION
## Description

Adapt xtrack to the new particles classes introduced in xsuite/xpart#73, however do not use the idea of a minitracker proposed in #312.

Replaces #312.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
