### PR TITLE
Fix the test of precompiled kernels

### DIFF
--- a/tests/test_prebuild_kernels.py
+++ b/tests/test_prebuild_kernels.py
@@ -6,6 +6,7 @@ import json
 
 import cffi
 
+import xobjects as xo
 import xpart as xp
 import xtrack as xt
 from xtrack.prebuild_kernels import regenerate_kernels
@@ -55,7 +56,9 @@ def test_prebuild_kernels(mocker, tmp_path):
     cffi_compile = mocker.patch.object(cffi.FFI, 'compile')
 
     line = xt.Line(elements=[xt.Drift(length=2.0)])
-    line.build_tracker()
+
+    # Build the tracker on a fresh context, so that the kernel comes from a file
+    line.build_tracker(_context=xo.ContextCpu())
 
     p = xp.Particles(p0c=1e9, px=3e-6)
     line.track(p)


### PR DESCRIPTION
## Description

The test was not testing actually loading kernels from a file. This was caused by the fact that a supposedly fresh tracker would reuse the same CPU context, and thus, the previous kernel.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
