### PR TITLE
Enable OpenMP support

### DIFF
--- a/examples/optimized_tracker/001_time_tracking_on_gpu.py
+++ b/examples/optimized_tracker/001_time_tracking_on_gpu.py
@@ -14,7 +14,8 @@ import xobjects as xo
 num_turns = 100
 num_particles = 100000 # Enough to saturate a high-end GPU
 
-context = xo.ContextCpu(omp_num_threads=12)
+context = xo.ContextCpu(omp_num_threads='auto')
+# context = xo.ContextCupy()
 
 #################################
 # Load a line and build tracker #

--- a/examples/optimized_tracker/001_time_tracking_on_gpu.py
+++ b/examples/optimized_tracker/001_time_tracking_on_gpu.py
@@ -14,7 +14,7 @@ import xobjects as xo
 num_turns = 100
 num_particles = 100000 # Enough to saturate a high-end GPU
 
-context = xo.ContextCupy()
+context = xo.ContextCpu()
 
 #################################
 # Load a line and build tracker #
@@ -27,7 +27,8 @@ with open(fname_line_particles, 'r') as fid:
 line = xt.Line.from_dict(input_data['line'])
 line.particle_ref = xp.Particles.from_dict(input_data['particle'])
 
-line.build_tracker(_context=context)
+line.build_tracker(_context=context, compile=False)
+line.config.SKIP_SWAPS = True
 
 ###########################
 # Generate some particles #

--- a/examples/optimized_tracker/001_time_tracking_on_gpu.py
+++ b/examples/optimized_tracker/001_time_tracking_on_gpu.py
@@ -14,7 +14,7 @@ import xobjects as xo
 num_turns = 100
 num_particles = 100000 # Enough to saturate a high-end GPU
 
-context = xo.ContextCpu()
+context = xo.ContextCpu(omp_num_threads=12)
 
 #################################
 # Load a line and build tracker #
@@ -28,7 +28,8 @@ line = xt.Line.from_dict(input_data['line'])
 line.particle_ref = xp.Particles.from_dict(input_data['particle'])
 
 line.build_tracker(_context=context, compile=False)
-line.config.SKIP_SWAPS = True
+#line.config.SKIP_SWAPS = True
+#line.config.DANGER_SKIP_ACTIVE_CHECK_AND_SWAPS = True
 
 ###########################
 # Generate some particles #

--- a/tests/test_spacecharge_in_ring.py
+++ b/tests/test_spacecharge_in_ring.py
@@ -5,6 +5,7 @@
 
 import json
 import pathlib
+import pytest
 
 import numpy as np
 import xfields as xf
@@ -16,8 +17,12 @@ from xpart.test_helpers import flaky_assertions, retry
 
 
 @for_all_test_contexts
+@pytest.mark.parametrize(
+    'mode',
+    ['frozen', 'quasi-frozen', 'pic', 'pic_average_transverse'],
+)
 @retry()
-def test_ring_with_spacecharge(test_context):
+def test_ring_with_spacecharge(test_context, mode):
 
     test_data_folder = pathlib.Path(
             __file__).parent.joinpath('../test_data').absolute()
@@ -83,141 +88,134 @@ def test_ring_with_spacecharge(test_context):
 
     warnings.filterwarnings('default')
 
-    for mode in ['frozen', 'quasi-frozen', 'pic', 'pic_average_transverse']:
-        print('\n\n')
-        print(f"Test {test_context.__class__}")
-        print(f'mode = {mode}')
-        print('\n\n')
+    if (isinstance(test_context, xo.ContextPyopencl)
+        and mode.startswith('pic')):
+        # TODO With pyopencl the test gets to the end
+        # but then hangs or crashes python
+        pytest.skip('Skipped! Known issue...')
+        return
 
-        if (isinstance(test_context, xo.ContextPyopencl)
-            and mode.startswith('pic')):
-            # TODO With pyopencl the test gets to the end
-            # but then hangs or crashes python
-            print('Skipped! Known issue...')
-            continue
+    # We need only particles at zeta close to the probe
+    if mode == 'frozen':
+        particles = particles0.filter(particles0.particle_id < 100)
+    elif mode == 'quasi-frozen':
+        particles = particles0.filter(particles0.particle_id < 1e5)
+        particles.weight[:] = bunch_intensity / 1e5 * 2 # need to have the right peak density
+    elif mode == 'pic' or mode == 'pic_average_transverse':
+        particles = particles0.filter((particles0.zeta>z_range[0]*5)
+                                      & (particles0.zeta<z_range[1]*5))
+    else:
+        raise ValueError('Invalid mode!')
 
-        # We need only particles at zeta close to the probe
-        if mode == 'frozen':
-            particles = particles0.filter(particles0.particle_id < 100)
-        elif mode == 'quasi-frozen':
-            particles = particles0.filter(particles0.particle_id < 1e5)
-            particles.weight[:] = bunch_intensity / 1e5 * 2 # need to have the right peak density
-        elif mode == 'pic' or mode == 'pic_average_transverse':
-            particles = particles0.filter((particles0.zeta>z_range[0]*5)
-                                          & (particles0.zeta<z_range[1]*5))
-        else:
-            raise ValueError('Invalid mode!')
+    particles = particles.copy(_context=test_context)
 
-        particles = particles.copy(_context=test_context)
+    warnings.filterwarnings('ignore')
+    line = line0_no_sc.copy()
+    xf.install_spacecharge_frozen(
+            line=line,
+            particle_ref=particle_ref,
+            longitudinal_profile=lprofile,
+            nemitt_x=nemitt_x, nemitt_y=nemitt_y,
+            sigma_z=sigma_z,
+            num_spacecharge_interactions=num_spacecharge_interactions,
+            tol_spacecharge_position=tol_spacecharge_position)
+    warnings.filterwarnings('default')
 
-        warnings.filterwarnings('ignore')
-        line = line0_no_sc.copy()
-        xf.install_spacecharge_frozen(
-                line=line,
-                particle_ref=particle_ref,
-                longitudinal_profile=lprofile,
-                nemitt_x=nemitt_x, nemitt_y=nemitt_y,
-                sigma_z=sigma_z,
-                num_spacecharge_interactions=num_spacecharge_interactions,
-                tol_spacecharge_position=tol_spacecharge_position)
-        warnings.filterwarnings('default')
+    ##########################
+    # Configure space-charge #
+    ##########################
 
-        ##########################
-        # Configure space-charge #
-        ##########################
+    if mode == 'frozen':
+        pass # Already configured in line
+    elif mode == 'quasi-frozen':
+        xf.replace_spacecharge_with_quasi_frozen(
+                                        line, _buffer=test_context.new_buffer(),
+                                        update_mean_x_on_track=True,
+                                        update_mean_y_on_track=True)
+    elif mode == 'pic' or mode == 'pic_average_transverse':
+        pic_collection, all_pics = xf.replace_spacecharge_with_PIC(
+            _context=test_context, line=line,
+            n_sigmas_range_pic_x=5,
+            n_sigmas_range_pic_y=5,
+            nx_grid=256, ny_grid=256, nz_grid=nz_grid,
+            n_lims_x=7, n_lims_y=3,
+            z_range=z_range,
+            _average_transverse_distribution=(
+                                mode == 'pic_average_transverse'))
+    else:
+        raise ValueError(f'Invalid mode: {mode}')
 
-        if mode == 'frozen':
-            pass # Already configured in line
-        elif mode == 'quasi-frozen':
-            xf.replace_spacecharge_with_quasi_frozen(
-                                            line, _buffer=test_context.new_buffer(),
-                                            update_mean_x_on_track=True,
-                                            update_mean_y_on_track=True)
-        elif mode == 'pic' or mode == 'pic_average_transverse':
-            pic_collection, all_pics = xf.replace_spacecharge_with_PIC(
-                _context=test_context, line=line,
-                n_sigmas_range_pic_x=5,
-                n_sigmas_range_pic_y=5,
-                nx_grid=256, ny_grid=256, nz_grid=nz_grid,
-                n_lims_x=7, n_lims_y=3,
-                z_range=z_range,
-                _average_transverse_distribution=(
-                                    mode == 'pic_average_transverse'))
-        else:
-            raise ValueError(f'Invalid mode: {mode}')
+    #################
+    # Build Tracker #
+    #################
+    line.build_tracker(_context=test_context)
 
-        #################
-        # Build Tracker #
-        #################
-        line.build_tracker(_context=test_context)
+    ###############################
+    # Tune shift from single turn #
+    ###############################
 
-        ###############################
-        # Tune shift from single turn #
-        ###############################
+    line_no_sc = line.filter_elements(exclude_types_starting_with='SpaceCh')
+    tw = line_no_sc.twiss(
+            particle_ref=particle_ref,  at_elements=[0])
 
-        line_no_sc = line.filter_elements(exclude_types_starting_with='SpaceCh')
-        tw = line_no_sc.twiss(
-                particle_ref=particle_ref,  at_elements=[0])
+    p_probe_before = particles.filter(
+            particles.particle_id == 0).to_dict()
 
-        p_probe_before = particles.filter(
-                particles.particle_id == 0).to_dict()
+    print('Start tracking...')
+    line.track(particles)
+    print('Done tracking.')
 
-        print('Start tracking...')
-        line.track(particles)
-        print('Done tracking.')
+    p_probe_after = particles.filter(
+            particles.particle_id == 0).to_dict()
 
-        p_probe_after = particles.filter(
-                particles.particle_id == 0).to_dict()
+    betx = tw['betx'][0]
+    alfx = tw['alfx'][0]
+    print(f'{alfx=} {betx=}')
+    phasex_0 = np.angle(p_probe_before['x'] / np.sqrt(betx) -
+                        1j*(p_probe_before['x'] * alfx / np.sqrt(betx) +
+                        p_probe_before['px'] * np.sqrt(betx)))[0]
+    phasex_1 = np.angle(p_probe_after['x'] / np.sqrt(betx) -
+                       1j*(p_probe_after['x'] * alfx / np.sqrt(betx) +
+                           p_probe_after['px'] * np.sqrt(betx)))[0]
+    bety = tw['bety'][0]
+    alfy = tw['alfy'][0]
+    print(f'{alfy=} {bety=}')
+    phasey_0 = np.angle(p_probe_before['y'] / np.sqrt(bety) -
+                        1j*(p_probe_before['y'] * alfy / np.sqrt(bety) +
+                        p_probe_before['py'] * np.sqrt(bety)))[0]
+    phasey_1 = np.angle(p_probe_after['y'] / np.sqrt(bety) -
+                        1j*(p_probe_after['y'] * alfy / np.sqrt(bety) +
+                        p_probe_after['py'] * np.sqrt(bety)))[0]
+    qx_probe = (phasex_1 - phasex_0)/(2*np.pi)
+    qy_probe = (phasey_1 - phasey_0)/(2*np.pi)
 
-        betx = tw['betx'][0]
-        alfx = tw['alfx'][0]
-        print(f'{alfx=} {betx=}')
-        phasex_0 = np.angle(p_probe_before['x'] / np.sqrt(betx) -
-                            1j*(p_probe_before['x'] * alfx / np.sqrt(betx) +
-                            p_probe_before['px'] * np.sqrt(betx)))[0]
-        phasex_1 = np.angle(p_probe_after['x'] / np.sqrt(betx) -
-                           1j*(p_probe_after['x'] * alfx / np.sqrt(betx) +
-                               p_probe_after['px'] * np.sqrt(betx)))[0]
-        bety = tw['bety'][0]
-        alfy = tw['alfy'][0]
-        print(f'{alfy=} {bety=}')
-        phasey_0 = np.angle(p_probe_before['y'] / np.sqrt(bety) -
-                            1j*(p_probe_before['y'] * alfy / np.sqrt(bety) +
-                            p_probe_before['py'] * np.sqrt(bety)))[0]
-        phasey_1 = np.angle(p_probe_after['y'] / np.sqrt(bety) -
-                            1j*(p_probe_after['y'] * alfy / np.sqrt(bety) +
-                            p_probe_after['py'] * np.sqrt(bety)))[0]
-        qx_probe = (phasex_1 - phasex_0)/(2*np.pi)
-        qy_probe = (phasey_1 - phasey_0)/(2*np.pi)
+    qx_target = 0.12424673159186882
+    qy_target = 0.21993469870358598
 
-        qx_target = 0.12424673159186882
-        qy_target = 0.21993469870358598
+    print(f'ex={(qx_probe - qx_target)/1e-3:.6f}e-3 '
+          f'ey={(qy_probe - qy_target)/1e-3:.6f}e-3')
 
-        print(f'ex={(qx_probe - qx_target)/1e-3:.6f}e-3 '
-              f'ey={(qy_probe - qy_target)/1e-3:.6f}e-3')
+    with flaky_assertions():
+        assert np.isclose(qx_probe, qx_target, atol=5e-4, rtol=0)
+        assert np.isclose(qy_probe, qy_target, atol=5e-4, rtol=0)
 
-        with flaky_assertions():
-            assert np.isclose(qx_probe, qx_target, atol=5e-4, rtol=0)
-            assert np.isclose(qy_probe, qy_target, atol=5e-4, rtol=0)
-
-        if mode == 'pic_average_transverse':
-            sc_test = all_pics[50]
-            ctx2np = sc_test._context.nparray_from_context_array
-            assert sc_test.fieldmap._average_transverse_distribution == True
-            assert hasattr(sc_test.fieldmap, '_rho_before_average')
+    if mode == 'pic_average_transverse':
+        sc_test = all_pics[50]
+        ctx2np = sc_test._context.nparray_from_context_array
+        assert sc_test.fieldmap._average_transverse_distribution == True
+        assert hasattr(sc_test.fieldmap, '_rho_before_average')
+        assert np.allclose(
+            ctx2np(sc_test.fieldmap._rho_before_average.sum(axis=(0, 1))),
+            ctx2np(sc_test.fieldmap.rho.sum(axis=(0, 1))),
+            atol=1e-14, rtol=1e-10)
+        for dtest in [sc_test.fieldmap.dphi_dx, sc_test.fieldmap.dphi_dy]:
+            # Check that the normalized electric field is the same
+            dtest = ctx2np(dtest)
             assert np.allclose(
-                ctx2np(sc_test.fieldmap._rho_before_average.sum(axis=(0, 1))),
-                ctx2np(sc_test.fieldmap.rho.sum(axis=(0, 1))),
-                atol=1e-14, rtol=1e-10)
-            for dtest in [sc_test.fieldmap.dphi_dx, sc_test.fieldmap.dphi_dy]:
-                # Check that the normalized electric field is the same
-                dtest = ctx2np(dtest)
-                assert np.allclose(
-                    dtest[:, :, 3] / np.max(dtest[:, :, 3]),
-                    dtest[:, :, 4] / np.max(dtest[:, :, 4]),
-                    atol=1e-10, rtol=1e-5)
-        elif mode == 'pic':
-            sc_test = all_pics[50]
-            assert sc_test.fieldmap._average_transverse_distribution == False
-            assert not hasattr(sc_test.fieldmap, '_rho_before_average')
-
+                dtest[:, :, 3] / np.max(dtest[:, :, 3]),
+                dtest[:, :, 4] / np.max(dtest[:, :, 4]),
+                atol=1e-10, rtol=1e-5)
+    elif mode == 'pic':
+        sc_test = all_pics[50]
+        assert sc_test.fieldmap._average_transverse_distribution == False
+        assert not hasattr(sc_test.fieldmap, '_rho_before_average')

--- a/tests/test_spacecharge_in_ring.py
+++ b/tests/test_spacecharge_in_ring.py
@@ -89,10 +89,10 @@ def test_ring_with_spacecharge(test_context, mode):
     warnings.filterwarnings('default')
 
     if (isinstance(test_context, xo.ContextPyopencl)
-        and mode.startswith('pic')):
+            and mode.startswith('pic')):
         # TODO With pyopencl the test gets to the end
         # but then hangs or crashes python
-        pytest.skip('Skipped! Known issue...')
+        pytest.skip('This test in broken on OpenCL. Known issue...')
         return
 
     # We need only particles at zeta close to the probe

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -16,28 +16,31 @@ from .general import _pkg_root
 from .internal_record import RecordIdentifier, RecordIndex, generate_get_record
 
 start_per_part_block = """
-   const int64_t part_id = part0->ipart;  //only_for_context cpu_openmp
-   const int64_t end_id = part0->endpart; //only_for_context cpu_openmp
-   //#pragma omp simd                     //only_for_context cpu_openmp
-   for (int64_t ii=part_id; ii<end_id; ii++){ //only_for_context cpu_openmp
-   
-   int64_t const n_part = LocalParticle_get__num_active_particles(part0); //only_for_context cpu_serial
-   for (int jj=0; jj<n_part; jj+=!!CHUNK_SIZE!!){                 //only_for_context cpu_serial
-    for (int iii=0; iii<!!CHUNK_SIZE!!; iii++){                   //only_for_context cpu_serial
-      int const ii = iii+jj;                                      //only_for_context cpu_serial
-      if (ii<n_part){                                             //only_for_context cpu_serial
+    const int64_t part_id = part0->ipart;  //only_for_context cpu_openmp
+    const int64_t end_id = part0->endpart; //only_for_context cpu_openmp
+    //#pragma omp simd                     //only_for_context cpu_openmp
+    for (int64_t ii=part_id; ii<end_id; ii++) { //only_for_context cpu_openmp
 
-        LocalParticle lpart = *part0;//only_for_context cpu_serial cpu_openmp
-        LocalParticle* part = &lpart;//only_for_context cpu_serial cpu_openmp
-        part->ipart = ii;            //only_for_context cpu_serial cpu_openmp
+    int64_t const n_part = LocalParticle_get__num_active_particles(part0); //only_for_context cpu_serial
+    for (int jj=0; jj<n_part; jj+=!!CHUNK_SIZE!!){                 //only_for_context cpu_serial
+        for (int iii=0; iii<!!CHUNK_SIZE!!; iii++){                //only_for_context cpu_serial
+            int const ii = iii+jj;                                 //only_for_context cpu_serial
+            if (ii<n_part) {                                       //only_for_context cpu_serial
 
-        LocalParticle* part = part0;//only_for_context opencl cuda
+                LocalParticle lpart = *part0;  //only_for_context cpu_serial cpu_openmp
+                LocalParticle* part = &lpart;  //only_for_context cpu_serial cpu_openmp
+                part->ipart = ii;              //only_for_context cpu_serial cpu_openmp
+        
+                LocalParticle* part = part0;   //only_for_context opencl cuda
+                
+                if (LocalParticle_get_state(part) > 0) {  //only_for_context cpu_openmp
 """.replace("!!CHUNK_SIZE!!", "128")
 
 end_part_part_block = """
-     } //only_for_context cpu_serial
-    }  //only_for_context cpu_serial
-   }   //only_for_context cpu_serial cpu_openmp
+                }  //only_for_context cpu_openmp
+            }  //only_for_context cpu_serial
+        }  //only_for_context cpu_serial
+    }  //only_for_context cpu_serial cpu_openmp
 """
 
 def _handle_per_particle_blocks(sources, local_particle_src):

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -17,30 +17,26 @@ from .internal_record import RecordIdentifier, RecordIndex, generate_get_record
 
 start_per_part_block = """
     {
-    const int64_t part_id = part0->ipart;  //only_for_context cpu_openmp
-    const int64_t end_id = part0->endpart; //only_for_context cpu_openmp
-    //#pragma omp simd                     //only_for_context cpu_openmp
-    for (int64_t ii=part_id; ii<end_id; ii++) { //only_for_context cpu_openmp
+    const int64_t start_idx = part0->ipart; //only_for_context cpu_openmp
+    const int64_t end_idx = part0->endpart; //only_for_context cpu_openmp
+    
+    const int64_t start_idx = 0;                                            //only_for_context cpu_serial
+    const int64_t end_idx = LocalParticle_get__num_active_particles(part0); //only_for_context cpu_serial
+    
+    //#pragma omp simd // TODO: currently does not work, needs investigating
+    for (int64_t ii=start_idx; ii<end_idx; ii++) { //only_for_context cpu_openmp cpu_serial
 
-    int64_t const n_part = LocalParticle_get__num_active_particles(part0); //only_for_context cpu_serial
-    for (int jj=0; jj<n_part; jj+=!!CHUNK_SIZE!!){                 //only_for_context cpu_serial
-        for (int iii=0; iii<!!CHUNK_SIZE!!; iii++){                //only_for_context cpu_serial
-            int const ii = iii+jj;                                 //only_for_context cpu_serial
-            if (ii<n_part) {                                       //only_for_context cpu_serial
+        LocalParticle lpart = *part0;  //only_for_context cpu_serial cpu_openmp
+        LocalParticle* part = &lpart;  //only_for_context cpu_serial cpu_openmp
+        part->ipart = ii;              //only_for_context cpu_serial cpu_openmp
 
-                LocalParticle lpart = *part0;  //only_for_context cpu_serial cpu_openmp
-                LocalParticle* part = &lpart;  //only_for_context cpu_serial cpu_openmp
-                part->ipart = ii;              //only_for_context cpu_serial cpu_openmp
+        LocalParticle* part = part0;   //only_for_context opencl cuda
         
-                LocalParticle* part = part0;   //only_for_context opencl cuda
-                
-                if (LocalParticle_get_state(part) > 0) {  //only_for_context cpu_openmp
-""".replace("!!CHUNK_SIZE!!", "128")
+        if (LocalParticle_get_state(part) > 0) {  //only_for_context cpu_openmp
+"""
 
 end_part_part_block = """
-                }  //only_for_context cpu_openmp
-            }  //only_for_context cpu_serial
-        }  //only_for_context cpu_serial
+        }  //only_for_context cpu_openmp
     }  //only_for_context cpu_serial cpu_openmp
     }
 """

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -108,14 +108,13 @@ def _generate_per_particle_kernel_from_local_particle_function(
             LocalParticle lpart;
             lpart.io_buffer = io_buffer;
             
-            const int64_t num_threads = omp_get_num_threads();                             //only_for_context cpu_openmp            
-            #pragma omp parallel                                                           //only_for_context cpu_openmp
-            {                                                                              //only_for_context cpu_openmp
-            int64_t thread = omp_get_thread_num();                                         //only_for_context cpu_openmp
+            const int64_t num_batches = 12;                                                //only_for_context cpu_openmp
+            #pragma omp parallel for                                                       //only_for_context cpu_openmp
+            for (int64_t batch_id = 0; batch_id < num_batches; batch_id++) {               //only_for_context cpu_openmp
             int64_t capacity = ParticlesData_get__capacity(particles);                     //only_for_context cpu_openmp
-            int64_t chunk_size = (capacity + num_threads - 1)/num_threads; // ceil divide  //only_for_context cpu_openmp
-            int64_t part_id = thread * chunk_size;                                         //only_for_context cpu_openmp
-            int64_t end_id = (thread + 1) * chunk_size;                                    //only_for_context cpu_openmp
+            int64_t chunk_size = (capacity + num_batches - 1)/num_batches; // ceil divide  //only_for_context cpu_openmp
+            int64_t part_id = batch_id * chunk_size;                                       //only_for_context cpu_openmp
+            int64_t end_id = (batch_id + 1) * chunk_size;                                  //only_for_context cpu_openmp
             if (end_id > capacity) end_id = capacity;                                      //only_for_context cpu_openmp
 
             int64_t part_id = 0;                    //only_for_context cpu_serial

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -16,6 +16,7 @@ from .general import _pkg_root
 from .internal_record import RecordIdentifier, RecordIndex, generate_get_record
 
 start_per_part_block = """
+    {
     const int64_t part_id = part0->ipart;  //only_for_context cpu_openmp
     const int64_t end_id = part0->endpart; //only_for_context cpu_openmp
     //#pragma omp simd                     //only_for_context cpu_openmp
@@ -41,6 +42,7 @@ end_part_part_block = """
             }  //only_for_context cpu_serial
         }  //only_for_context cpu_serial
     }  //only_for_context cpu_serial cpu_openmp
+    }
 """
 
 def _handle_per_particle_blocks(sources, local_particle_src):
@@ -105,35 +107,34 @@ def _generate_per_particle_kernel_from_local_particle_function(
 '''
                              int64_t flag_increment_at_element,
                 /*gpuglmem*/ int8_t* io_buffer){
-            LocalParticle lpart;
-            lpart.io_buffer = io_buffer;
-            
-            const int64_t num_batches = 12;                                                //only_for_context cpu_openmp
+            const int num_threads = omp_get_max_threads();                                 //only_for_context cpu_openmp
+            const int64_t capacity = ParticlesData_get__capacity(particles);               //only_for_context cpu_openmp
+            const int64_t chunk_size = (capacity + num_threads - 1)/num_threads; // ceil division  //only_for_context cpu_openmp
             #pragma omp parallel for                                                       //only_for_context cpu_openmp
-            for (int64_t batch_id = 0; batch_id < num_batches; batch_id++) {               //only_for_context cpu_openmp
-            int64_t capacity = ParticlesData_get__capacity(particles);                     //only_for_context cpu_openmp
-            int64_t chunk_size = (capacity + num_batches - 1)/num_batches; // ceil divide  //only_for_context cpu_openmp
-            int64_t part_id = batch_id * chunk_size;                                       //only_for_context cpu_openmp
-            int64_t end_id = (batch_id + 1) * chunk_size;                                  //only_for_context cpu_openmp
-            if (end_id > capacity) end_id = capacity;                                      //only_for_context cpu_openmp
-
-            int64_t part_id = 0;                    //only_for_context cpu_serial
-            int64_t part_id = blockDim.x * blockIdx.x + threadIdx.x; //only_for_context cuda
-            int64_t part_id = get_global_id(0);                    //only_for_context opencl
-            int64_t end_id = 0; // unused outside of openmp  //only_for_context cpu_serial cuda opencl
-
-            int64_t part_capacity = ParticlesData_get__capacity(particles);
-            if (part_id<part_capacity){
-                Particles_to_LocalParticle(particles, &lpart, part_id, end_id);
-                if (check_is_active(&lpart)>0){
-'''
-            f'      {local_particle_function_name}(el, &lpart{(add_to_call if len(additional_args) > 0 else "")});\n'
-'''
+            for (int64_t batch_id = 0; batch_id < num_threads; batch_id++) {               //only_for_context cpu_openmp
+                LocalParticle lpart;
+                lpart.io_buffer = io_buffer;
+                int64_t part_id = batch_id * chunk_size;                                       //only_for_context cpu_openmp
+                int64_t end_id = (batch_id + 1) * chunk_size;                                  //only_for_context cpu_openmp
+                if (end_id > capacity) end_id = capacity;                                      //only_for_context cpu_openmp
+    
+                int64_t part_id = 0;                    //only_for_context cpu_serial
+                int64_t part_id = blockDim.x * blockIdx.x + threadIdx.x; //only_for_context cuda
+                int64_t part_id = get_global_id(0);                    //only_for_context opencl
+                int64_t end_id = 0; // unused outside of openmp  //only_for_context cpu_serial cuda opencl
+    
+                int64_t part_capacity = ParticlesData_get__capacity(particles);
+                if (part_id<part_capacity){
+                    Particles_to_LocalParticle(particles, &lpart, part_id, end_id);
+                    if (check_is_active(&lpart)>0){
+    '''
+            f'          {local_particle_function_name}(el, &lpart{(add_to_call if len(additional_args) > 0 else "")});\n'
+    '''
+                    }
+                    if (check_is_active(&lpart)>0 && flag_increment_at_element){
+                            increment_at_element(&lpart);
+                    }
                 }
-                if (check_is_active(&lpart)>0 && flag_increment_at_element){
-                        increment_at_element(&lpart);
-                }
-            }
             } //only_for_context cpu_openmp
         }
 ''')

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -136,6 +136,15 @@ def _generate_per_particle_kernel_from_local_particle_function(
                     }
                 }
             } //only_for_context cpu_openmp
+            
+            // On OpenMP we want to additionally by default reorganize all
+            // the particles.
+            #ifndef XT_OMP_SKIP_REORGANIZE                             //only_for_context cpu_openmp
+            LocalParticle lpart;                                       //only_for_context cpu_openmp
+            lpart.io_buffer = io_buffer;                               //only_for_context cpu_openmp
+            Particles_to_LocalParticle(particles, &lpart, 0, capacity);//only_for_context cpu_openmp
+            check_is_active(&lpart);                                   //only_for_context cpu_openmp
+            #endif                                                     //only_for_context cpu_openmp
         }
 ''')
     return source

--- a/xtrack/internal_record.py
+++ b/xtrack/internal_record.py
@@ -46,8 +46,8 @@ int64_t RecordIndex_get_slot(RecordIndex record_index){
 
     uint32_t slot = atomic_add(num_recorded, 1);   //only_for_context opencl
     uint32_t slot = atomicAdd(num_recorded, 1);    //only_for_context cuda
-    uint32_t slot = *num_recorded;                 //only_for_context cpu_serial
-    *num_recorded = slot + 1;                      //only_for_context cpu_serial
+    uint32_t slot = *num_recorded;                 //only_for_context cpu_serial cpu_openmp
+    *num_recorded = slot + 1;                      //only_for_context cpu_serial cpu_openmp
 
     if (slot >= capacity){
         *num_recorded = capacity;

--- a/xtrack/monitors/particles_monitor.h
+++ b/xtrack/monitors/particles_monitor.h
@@ -42,7 +42,8 @@ void ParticlesMonitor_track_local_particle(ParticlesMonitorData el,
     }
     else if (n_repetitions > 1){
         if (at_turn < start_at_turn){
-            return;
+            return; //only_for_context cuda opencl
+            break; //only_for_context cpu_serial cpu_openmp
         }
         int64_t const i_frame = (at_turn - start_at_turn) / repetition_period;
         if (i_frame < n_repetitions

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -522,6 +522,15 @@ class Tracker:
 
             }// if partid
             } //only_for_context cpu_openmp
+            
+            // On OpenMP we want to additionally by default reorganize all
+            // the particles.
+            #ifndef XT_OMP_SKIP_REORGANIZE                             //only_for_context cpu_openmp
+            LocalParticle lpart;                                       //only_for_context cpu_openmp
+            lpart.io_buffer = io_buffer;                               //only_for_context cpu_openmp
+            Particles_to_LocalParticle(particles, &lpart, 0, capacity);//only_for_context cpu_openmp
+            check_is_active(&lpart);                                   //only_for_context cpu_openmp
+            #endif                                                     //only_for_context cpu_openmp
         }//kernel
         """
         )

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -415,12 +415,11 @@ class Tracker:
                              int64_t offset_tbt_monitor,
                 /*gpuglmem*/ int8_t* io_buffer){
 
-            omp_set_num_threads(12);                                                       //only_for_context cpu_openmp
             const int64_t capacity = ParticlesData_get__capacity(particles);               //only_for_context cpu_openmp
-            const int64_t num_chunks = 12;//omp_get_num_threads();                         //only_for_context cpu_openmp
-            const int64_t chunk_size = (capacity + num_chunks - 1)/num_chunks; // ceil division  //only_for_context cpu_openmp
+            const int num_threads = omp_get_max_threads();                                 //only_for_context cpu_openmp
+            const int64_t chunk_size = (capacity + num_threads - 1)/num_threads; // ceil division  //only_for_context cpu_openmp
             #pragma omp parallel for                                                       //only_for_context cpu_openmp
-            for (int chunk = 0; chunk < num_chunks; chunk++) {                             //only_for_context cpu_openmp
+            for (int chunk = 0; chunk < num_threads; chunk++) {                            //only_for_context cpu_openmp
             int64_t part_id = chunk * chunk_size;                                          //only_for_context cpu_openmp
             int64_t end_id = (chunk + 1) * chunk_size;                                     //only_for_context cpu_openmp
             if (end_id > capacity) end_id = capacity;                                      //only_for_context cpu_openmp

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -422,6 +422,8 @@ class Tracker:
             int64_t part_id = 0;                    //only_for_context cpu_serial cpu_openmp
             int64_t part_id = blockDim.x * blockIdx.x + threadIdx.x; //only_for_context cuda
             int64_t part_id = get_global_id(0);                    //only_for_context opencl
+            
+            #pragma omp parallel for 
 
 
             /*gpuglmem*/ int8_t* tbt_mon_pointer =

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -415,8 +415,6 @@ class Tracker:
                              int64_t offset_tbt_monitor,
                 /*gpuglmem*/ int8_t* io_buffer){
 
-
-            int64_t done = 0;
             omp_set_num_threads(12);                                                       //only_for_context cpu_openmp
             const int64_t capacity = ParticlesData_get__capacity(particles);               //only_for_context cpu_openmp
             const int64_t num_chunks = 12;//omp_get_num_threads();                         //only_for_context cpu_openmp


### PR DESCRIPTION
## Description

This PR is part of the effort to enable OpenMP support in Xsuite.

In Xtrack, on the OpenMP context we introduce two loops particle loops:
- an outer loop over batches of particles that is the one being paralellised (this is similar to the GPU behaviour, but for batches instead of single particles)
- an inner loop inside of each element, which loops over individual particles, and which allows for potential gains from vectorisation (this is similar to the serial CPU behaviour)

In addition, at the end of each kernel, particles are reorganised such that they conform to the expectations from the serial CPU behaviour. Nevertheless, this behaviour can be disabled by setting `XT_OMP_SKIP_REORGANIZE` in the config of the line (it should be noted that our current test suite passes with this flag set as well).

Needs xsuite/xobjects#106 and xsuite/xpart#78.

Closes xsuite/xsuite#15.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
