### PR TITLE
Initial commit for Henon map line element.

### DIFF
--- a/tests/test_henonmap.py
+++ b/tests/test_henonmap.py
@@ -1,0 +1,88 @@
+# copyright ############################### #
+# This file is part of the Xtrack Package.  #
+# Copyright (c) CERN, 2021.                 #
+# ######################################### #
+
+import numpy as np
+
+import xpart as xp
+import xtrack as xt
+from xobjects.test_helpers import for_all_test_contexts
+
+@for_all_test_contexts
+def test_henonmap(test_context):
+    alpha_x = 0.0
+    beta_x = 100.0
+    alpha_y = 0.0
+    beta_y = 10.0
+    K2 = 0.1
+    lmbd = K2 * beta_x**(3.0/2.0) / 2.0
+    K3 = -5.0 * 3.0 * K2**2 * beta_x / 2.0
+
+    N = 10
+    x_n = np.linspace(0, 0.2, N)
+    x = x_n / lmbd * np.sqrt(beta_x)
+
+    p_n = xp.Particles(x=x_n, _context=test_context)
+    p = xp.Particles(x=x, _context=test_context)
+
+    henon_n = xt.Henonmap(omega_x = 2 * np.pi * 0.334,
+                          omega_y = 2 * np.pi * 0.279,
+                          n_turns = 1, 
+                          twiss_params = [0., 1., 0., 1.],
+                          multipole_coeffs = [2.0, -30.0],
+                          norm = True)
+    line_n = xt.Line(elements=[henon_n], element_names=["henon_n"])
+    line_n.build_tracker(_context=test_context)
+    henon = xt.Henonmap(omega_x = 2 * np.pi * 0.334,
+                        omega_y = 2 * np.pi * 0.279,
+                        n_turns = 1, 
+                        twiss_params = [alpha_x, beta_x, alpha_y, beta_y],
+                        multipole_coeffs = [K2, K3],
+                        norm = False)
+    line = xt.Line(elements=[henon], element_names=["henon"])
+    line.build_tracker(_context=test_context)
+    
+    nTurns = 100
+    x_n_all = np.zeros(N * nTurns)
+    x_all = np.zeros(N * nTurns)
+    for n in range(nTurns):
+        line_n.track(p_n)
+        line.track(p)
+        x_n_all[n*N:(n+1)*N] = test_context.nparray_from_context_array(p_n.x)
+        x_all[n*N:(n+1)*N] = test_context.nparray_from_context_array(p.x)
+    x_all_n = x_all * lmbd / np.sqrt(beta_x)
+
+    assert np.all(np.isclose(x_n_all, x_all_n, atol=0, rtol=1e-10))
+
+    x_in_test  = np.asarray([1, 0, 0, 0, 2, 2, 2, 0, 0, 0, 3, 3, 3, 0, 4])
+    px_in_test = np.asarray([0, 1, 0, 0, 2, 0, 0, 2, 2, 0, 3, 3, 0, 3, 4])
+    y_in_test  = np.asarray([0, 0, 1, 0, 0, 2, 0, 2, 0, 2, 3, 0, 3, 3, 4])
+    py_in_test = np.asarray([0, 0, 0, 1, 0, 0, 2, 0, 2, 2, 0, 3, 3, 3, 4])
+    x_out_test  = -0.5 * x_in_test + np.sqrt(3.0) / 2.0 * (px_in_test + (x_in_test**2 - y_in_test**2 / 100.0) / 20.0)
+    px_out_test = -np.sqrt(3.0) / 2.0 * x_in_test - 0.5 * (px_in_test + (x_in_test**2 - y_in_test**2 / 100.0) / 20.0)
+    y_out_test  = np.sqrt(2.0) / 2.0 * y_in_test + np.sqrt(2.0) / 2.0 * (py_in_test - x_in_test * y_in_test / 1000.0)
+    py_out_test = -np.sqrt(2.0) / 2.0 * y_in_test + np.sqrt(2.0) / 2.0 * (py_in_test - x_in_test * y_in_test / 1000.0)
+
+    p_test = xp.Particles(x=x_in_test, px=px_in_test, y=y_in_test, py=py_in_test, _context=test_context)
+
+    henon_test = xt.Henonmap(omega_x = 2 * np.pi / 3.0,
+                             omega_y = 2 * np.pi / 8.0,
+                             n_turns = 1, 
+                             twiss_params = [0.0, 1.0, 0.0, 0.01],
+                             multipole_coeffs = [0.1],
+                             norm = False)
+    line_test = xt.Line(elements=[henon_test], element_names=["henon"])
+    line_test.build_tracker(_context=test_context)
+
+    line_test.track(p_test)
+
+    x_out = test_context.nparray_from_context_array(p_test.x)[np.argsort(test_context.nparray_from_context_array(p_test.particle_id))]
+    px_out = test_context.nparray_from_context_array(p_test.px)[np.argsort(test_context.nparray_from_context_array(p_test.particle_id))]
+    y_out = test_context.nparray_from_context_array(p_test.y)[np.argsort(test_context.nparray_from_context_array(p_test.particle_id))]
+    py_out = test_context.nparray_from_context_array(p_test.py)[np.argsort(test_context.nparray_from_context_array(p_test.particle_id))]
+
+    assert np.any(np.isclose(x_out, x_out_test, atol=0, rtol=1e-10))
+    assert np.any(np.isclose(px_out, px_out_test, atol=0, rtol=1e-10))
+    assert np.any(np.isclose(y_out, y_out_test, atol=0, rtol=1e-10))
+    assert np.any(np.isclose(py_out, py_out_test, atol=0, rtol=1e-10))

--- a/xtrack/beam_elements/elements_src/henonmap.h
+++ b/xtrack/beam_elements/elements_src/henonmap.h
@@ -1,0 +1,150 @@
+// copyright ############################### //
+// This file is part of the Xtrack Package.  //
+// Copyright (c) CERN, 2021.                 //
+// ######################################### //
+
+#ifndef XTRACK_HENONMAP_H
+#define XTRACK_HENONMAP_H
+
+
+/*gpufun*/
+void Henonmap_track_local_particle(HenonmapData el, LocalParticle* part0){
+
+    double const sin_omega_x = HenonmapData_get_sin_omega_x(el);
+    double const cos_omega_x = HenonmapData_get_cos_omega_x(el);
+    double const sin_omega_y = HenonmapData_get_sin_omega_y(el);
+    double const cos_omega_y = HenonmapData_get_cos_omega_y(el);
+
+    int const n_turns = HenonmapData_get_n_turns(el);
+
+    int const n_fx_coeffs = HenonmapData_get_n_fx_coeffs(el);
+    int const n_fy_coeffs = HenonmapData_get_n_fy_coeffs(el);
+
+    double const alpha_x = HenonmapData_get_twiss_params(el, 0);
+    double const beta_x = HenonmapData_get_twiss_params(el, 1);
+    double const alpha_y = HenonmapData_get_twiss_params(el, 2);
+    double const beta_y = HenonmapData_get_twiss_params(el, 3);
+    double const sqrt_beta_x = sqrt(beta_x);
+    double const sqrt_beta_y = sqrt(beta_y);
+
+    int const norm = HenonmapData_get_norm(el);
+
+    double fx_coeffs[128];
+    int fx_x_exps[128];
+    int fx_y_exps[128];
+    for (int i = 0; i < n_fx_coeffs; i++)
+    {
+        fx_coeffs[i] = HenonmapData_get_fx_coeffs(el, i);
+        fx_x_exps[i] = HenonmapData_get_fx_x_exps(el, i);
+        fx_y_exps[i] = HenonmapData_get_fx_y_exps(el, i);
+    }
+
+    double fy_coeffs[128];
+    int fy_x_exps[128];
+    int fy_y_exps[128];
+    for (int i = 0; i < n_fy_coeffs; i++)
+    {
+        fy_coeffs[i] = HenonmapData_get_fy_coeffs(el, i);
+        fy_x_exps[i] = HenonmapData_get_fy_x_exps(el, i);
+        fy_y_exps[i] = HenonmapData_get_fy_y_exps(el, i);
+    }
+
+    //start_per_particle_block (part0->part)
+
+        double x = LocalParticle_get_x(part);
+        double px = LocalParticle_get_px(part);
+        double y = LocalParticle_get_y(part);
+        double py = LocalParticle_get_py(part);
+
+        double x_hat, px_hat, y_hat, py_hat;
+        if (norm)
+        {
+            x_hat = x;
+            px_hat = px;
+            y_hat = y;
+            py_hat = py;
+        }
+        else
+        {
+            x_hat = x / sqrt_beta_x;
+            px_hat = alpha_x * x / sqrt_beta_x + px * sqrt_beta_x;
+            y_hat = y / sqrt_beta_y;
+            py_hat = alpha_y * y / sqrt_beta_y + py * sqrt_beta_y;
+        }
+
+        for (int n = 0; n < n_turns; n++)
+        {
+
+            double fx = 0;
+            for (int i = 0; i < n_fx_coeffs; i++)
+            {
+                double prod = fx_coeffs[i];
+                int x_power = fx_x_exps[i];
+                int y_power = fx_y_exps[i];
+                for (int j = 0; j < x_power; j++)
+                {
+                    prod *= (sqrt_beta_x * x_hat);
+                }
+                for (int j = 0; j < y_power; j++)
+                {
+                    prod *= (sqrt_beta_y * y_hat);
+                }
+                fx += prod;
+            }
+            double fy = 0;
+            for (int i = 0; i < n_fy_coeffs; i++)
+            {
+                double prod = fy_coeffs[i];
+                int x_power = fy_x_exps[i];
+                int y_power = fy_y_exps[i];
+                for (int j = 0; j < x_power; j++)
+                {
+                    prod *= (sqrt_beta_x * x_hat);
+                }
+                for (int j = 0; j < y_power; j++)
+                {
+                    prod *= (sqrt_beta_y * y_hat);
+                }
+                fy += prod;
+            }
+            fx *= sqrt_beta_x;
+            fy *= sqrt_beta_y;
+
+            double x_hat_new, px_hat_new, y_hat_new, py_hat_new;
+            x_hat_new = cos_omega_x * x_hat + sin_omega_x * (px_hat + fx);
+            px_hat_new = -sin_omega_x * x_hat + cos_omega_x * (px_hat + fx);
+            y_hat_new = cos_omega_y * y_hat + sin_omega_y * (py_hat + fy);
+            py_hat_new = -sin_omega_y * y_hat + cos_omega_y * (py_hat + fy);
+            x_hat = x_hat_new;
+            px_hat = px_hat_new;
+            y_hat = y_hat_new;
+            py_hat = py_hat_new;
+
+        }
+
+        if (norm)
+        {
+            x = x_hat;
+            px = px_hat;
+            y = y_hat;
+            py = py_hat;
+        }
+        else
+        {
+            x = sqrt_beta_x * x_hat;
+            px = -alpha_x * x_hat / sqrt_beta_x + px_hat / sqrt_beta_x;
+            y = sqrt_beta_y * y_hat;
+            py = -alpha_y * y_hat / sqrt_beta_y + py_hat / sqrt_beta_y;
+        }
+
+        LocalParticle_set_x(part, x);
+        LocalParticle_set_px(part, px);
+        LocalParticle_set_y(part, y);
+        LocalParticle_set_py(part, py);
+
+    //end_per_particle_block
+
+}
+
+
+#endif /* XTRACK_HENONMAP_H */


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

A new beam element that simulates a Henon map is added. The Henon map can be created with arbitrary multipoles, but all assumed to be at the same phase advance. The element is useful when theoretical studies on a relatively simple mathematical model are needed.

## Checklist

Mandatory: 

- [X] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [X] I have tested also GPU contexts
