### PR TITLE
Fix some issues with to compounds

### DIFF
--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -12,6 +12,7 @@ import xtrack as xt
 import xpart as xp
 
 from xtrack import Line, Node, Multipole
+from xtrack.compounds import Compound, SlicedCompound
 from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
@@ -276,6 +277,34 @@ def test_remove_redundant_apertures():
     assert xt._lines_equal(line, original_line)
 
 
+def test_redundant_apertures_with_compounds():
+    sequence = [
+        ('a1', xt.LimitRect(min_x=-0.3, max_x=0.3, min_y=-0.3, max_y=0.3)),
+        ('d0', xt.Drift(length=0.6)),
+        ('a1', xt.LimitRect(min_x=-0.3, max_x=0.3, min_y=-0.3, max_y=0.3)),
+        ('d1', xt.Drift(length=0.4)),
+        ('a2', xt.LimitRect(min_x=-0.3, max_x=0.3, min_y=-0.3, max_y=0.3)),
+        ('m2', xt.Marker()),
+        ('d2..1', xt.Drift(length=0.2)),
+        ('d2..2', xt.Drift(length=0.2)),
+        ('a3', xt.LimitRect(min_x=-0.3, max_x=0.3, min_y=-0.3, max_y=0.3)),
+        ('d3', xt.Drift(length=0.4)),
+    ]
+    line = xt.Line(elements=dict(sequence), element_names=[n for n, _ in sequence])
+    compound = Compound(core=['d1'], aperture=['a1'])
+    compound_sliced = SlicedCompound(elements=['a2', 'm2', 'd2..1', 'd2..2'])
+    line.compound_container.define_compound('c1', compound)
+    line.compound_container.define_compound('c2', compound_sliced)
+
+    line.remove_redundant_apertures()
+
+    expected_names = ['d0', 'a1', 'd1', 'm2', 'd2..1', 'd2..2', 'a3', 'd3']
+    assert line.element_names == expected_names
+
+    assert 'a1' not in line.get_compound_by_name('c1').elements
+    assert 'a2' not in line.get_compound_by_name('c2').elements
+
+
 def test_remove_redundant_apertures_not_inplace():
 
     # Test removing all consecutive middle apertures
@@ -304,6 +333,40 @@ def test_remove_redundant_apertures_not_inplace():
     assert new_aper == [all_aper[0], all_aper[-1]]
     new_aper_pos = [newline.get_s_position(ap) for ap in new_aper]
     assert new_aper_pos == [all_aper_pos[0], all_aper_pos[-1]]
+
+
+def test_redundant_apertures_with_compounds_not_inplace():
+    sequence = [
+        ('a0', xt.LimitRect(min_x=-0.3, max_x=0.3, min_y=-0.3, max_y=0.3)),
+        ('d0', xt.Drift(length=0.6)),
+        ('a1', xt.LimitRect(min_x=-0.3, max_x=0.3, min_y=-0.3, max_y=0.3)),
+        ('d1', xt.Drift(length=0.4)),
+        ('a2', xt.LimitRect(min_x=-0.3, max_x=0.3, min_y=-0.3, max_y=0.3)),
+        ('m2', xt.Marker()),
+        ('d2..1', xt.Drift(length=0.2)),
+        ('d2..2', xt.Drift(length=0.2)),
+        ('a3', xt.LimitRect(min_x=-0.3, max_x=0.3, min_y=-0.3, max_y=0.3)),
+        ('d3', xt.Drift(length=0.4)),
+    ]
+    line = xt.Line(elements=dict(sequence), element_names=[n for n, _ in sequence])
+    compound = Compound(core=['d1'], aperture=['a1'])
+    compound_sliced = SlicedCompound(elements=['a2', 'm2', 'd2..1', 'd2..2'])
+    line.compound_container.define_compound('c1', compound)
+    line.compound_container.define_compound('c2', compound_sliced)
+
+    new_line = line.remove_redundant_apertures(inplace=False)
+
+    expected_new_names = ['a0', 'd0', 'd1', 'm2', 'd2..1', 'd2..2', 'a3', 'd3']
+    assert new_line.element_names == expected_new_names
+
+    expected_names = ['a0', 'd0', 'a1', 'd1', 'a2', 'm2', 'd2..1', 'd2..2', 'a3', 'd3']
+    assert line.element_names == expected_names
+
+    assert 'a1' not in new_line.get_compound_by_name('c1').elements
+    assert 'a2' not in new_line.get_compound_by_name('c2').elements
+
+    assert 'a1' in line.get_compound_by_name('c1').elements
+    assert 'a2' in line.get_compound_by_name('c2').elements
 
 
 def test_insert():

--- a/tests/test_sps_thick.py
+++ b/tests/test_sps_thick.py
@@ -34,11 +34,11 @@ def test_sps_thick(test_context, deferred_expressions):
     line.twiss_default['method'] = '4d'
 
     # Check a bend
-    assert line.element_names[52] == 'mbb.10150_entry'
-    assert line.element_names[53] == 'mbb.10150_den'
-    assert line.element_names[54] == 'mbb.10150'
-    assert line.element_names[55] == 'mbb.10150_dex'
-    assert line.element_names[56] == 'mbb.10150_exit'
+    assert line.element_names[60] == 'mbb.10150_entry'
+    assert line.element_names[61] == 'mbb.10150_den'
+    assert line.element_names[62] == 'mbb.10150'
+    assert line.element_names[63] == 'mbb.10150_dex'
+    assert line.element_names[64] == 'mbb.10150_exit'
 
     assert isinstance(line['mbb.10150_entry'], xt.Marker)
     assert isinstance(line['mbb.10150_den'], xt.DipoleEdge)
@@ -139,9 +139,8 @@ def test_sps_thick(test_context, deferred_expressions):
     line.build_tracker(_context=test_context)
 
     # Check a bend
-    assert line.element_names[111] == 'mbb.10150_entry'
-    assert line.element_names[112] == 'mbb.10150_den'
-    assert line.element_names[113] == 'mbb.10150'
+    assert line.element_names[112] == 'mbb.10150_entry'
+    assert line.element_names[113] == 'mbb.10150_den'
     assert line.element_names[114] == 'drift_mbb.10150..0'
     assert line.element_names[115] == 'mbb.10150..0'
     assert line.element_names[116] == 'drift_mbb.10150..1'
@@ -152,7 +151,6 @@ def test_sps_thick(test_context, deferred_expressions):
 
     assert isinstance(line['mbb.10150_entry'], xt.Marker)
     assert isinstance(line['mbb.10150_den'], xt.DipoleEdge)
-    assert isinstance(line['mbb.10150'], xt.Marker)
     assert isinstance(line['drift_mbb.10150..0'], xt.Drift)
     assert isinstance(line['mbb.10150..0'], xt.Multipole)
     assert isinstance(line['drift_mbb.10150..1'], xt.Drift)
@@ -162,7 +160,7 @@ def test_sps_thick(test_context, deferred_expressions):
     assert isinstance(line['mbb.10150_exit'], xt.Marker)
 
     # Check a quadrupole
-    assert line.element_names[158] == 'qf.10210'
+    assert line.element_names[158] == 'qf.10210_entry'
     assert line.element_names[159] == 'drift_qf.10210..0'
     assert line.element_names[160] == 'qf.10210..0'
     assert line.element_names[161] == 'drift_qf.10210..1'
@@ -180,6 +178,7 @@ def test_sps_thick(test_context, deferred_expressions):
     assert line.element_names[173] == 'drift_qf.10210..7'
     assert line.element_names[174] == 'qf.10210..7'
     assert line.element_names[175] == 'drift_qf.10210..8'
+    assert line.element_names[176] == 'qf.10210_exit'
 
     assert line['mbb.10150_den'].model == 'full'
     assert line['mbb.10150_den'].side == 'entry'

--- a/xtrack/compounds.py
+++ b/xtrack/compounds.py
@@ -28,6 +28,15 @@ class SlicedCompound:
             'elements': list(self.elements),
         }
 
+    def remove_element(self, element):
+        if element in self.elements:
+            self.elements.remove(element)
+        else:
+            raise ValueError(f'{element} not in {self}')
+
+    def copy(self):
+        return SlicedCompound(self.elements.copy())
+
 
 class Compound:
     """A logical beam element that is composed of other elements.
@@ -67,8 +76,8 @@ class Compound:
         self.entry_transform = set(entry_transform)
         self.exit_transform = set(exit_transform)
 
-        self.entry = {entry} if entry is not None else []
-        self.exit = {exit_} if exit_ is not None else []
+        self.entry = self._make_singleton_set(entry)
+        self.exit = self._make_singleton_set(exit_)
 
     def __repr__(self):
         return (
@@ -98,6 +107,46 @@ class Compound:
             'entry': list(self.entry)[0],
             'exit_': list(self.exit)[0],
         }
+
+    def remove_element(self, element):
+        if element in self.core:
+            self.core.remove(element)
+        elif element in self.aperture:
+            self.aperture.remove(element)
+        elif element in self.entry_transform:
+            self.entry_transform.remove(element)
+        elif element in self.exit_transform:
+            self.exit_transform.remove(element)
+        elif element in self.entry:
+            self.entry.remove(element)
+        elif element in self.exit:
+            self.exit.remove(element)
+        else:
+            raise ValueError(f'Element {element} not found in compound')
+
+    def copy(self):
+        return Compound(
+            core=self.core.copy(),
+            aperture=self.aperture.copy(),
+            entry_transform=self.entry_transform.copy(),
+            exit_transform=self.exit_transform.copy(),
+            entry=self.entry.copy(),
+            exit_=self.exit.copy(),
+        )
+
+    @staticmethod
+    def _make_singleton_set(var):
+        if var is None or len(var) == 0:
+            return set()
+
+        if isinstance(var, str):
+            return {var}
+
+        try:
+            var, = var
+            return {var}
+        except ValueError:
+            raise ValueError(f'Expected singleton set, got {var}')
 
 
 class CompoundContainer:
@@ -162,3 +211,10 @@ class CompoundContainer:
             name: compound.to_dict()
             for name, compound in self._compounds.items()
         }
+
+    def copy(self):
+        copied_compounds = {
+            name: compound.copy()
+            for name, compound in self._compounds.items()
+        }
+        return self.__class__(compounds=copied_compounds)

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -624,6 +624,8 @@ class Line:
         if self._var_management is not None:
             out._init_var_management(dct=self._var_management_to_dict())
 
+        out.compound_container = self.compound_container.copy()
+
         out.config.update(self.config.copy())
         out._extra_config.update(self._extra_config.copy())
 
@@ -2402,6 +2404,10 @@ class Line:
 
         for name in aper_to_remove:
             newline.element_names.remove(name)
+            compound_name = self.compound_container.compound_name_for_element(name)
+            if compound_name is not None:
+                newline.get_compound_by_name(compound_name).remove_element(name)
+
 
         return newline
 
@@ -3137,23 +3143,23 @@ def _next_name(prefix, names, name_format='{}{}'):
 
 def _dicts_equal(dict1, dict2):
     if not isinstance(dict1, dict) or not isinstance(dict2, dict):
-        raise ValueError
+        return False
     if set(dict1.keys()) != set(dict2.keys()):
-        raise ValueError
+        return False
     for key in dict1.keys():
         if hasattr(dict1[key], '__iter__'):
             if not hasattr(dict2[key], '__iter__'):
-                raise ValueError
+                return False
             elif isinstance(dict1[key], dict):
                 if not isinstance(dict2[key], dict):
-                    raise ValueError
+                    return False
                 else:
                     if not _dicts_equal(dict1[key], dict2[key]):
-                        raise ValueError
+                        return False
             elif not np.array_equal(dict1[key], dict2[key]):
-                raise ValueError
+                return False
         elif dict1[key] != dict2[key]:
-            raise ValueError
+            return False
     return True
 
 


### PR DESCRIPTION
## Description

This fixes a couple of test failures in release/v0.39.0 related to the compounds:

- `remove_redundant_apertures` did not work with compounds
- some rearranging of the markers necessitates changes in `test_sps_thick`

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
