### PR TITLE
add a function to the line to transform compounds

### DIFF
--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -7,6 +7,7 @@ import pickle
 import pathlib
 
 import numpy as np
+import pytest
 
 import xtrack as xt
 import xpart as xp
@@ -14,10 +15,10 @@ import xpart as xp
 from xtrack import Line, Node, Multipole
 from xtrack.compounds import Compound, SlicedCompound
 from xobjects.test_helpers import for_all_test_contexts
+from xtrack.compounds import SlicedCompound, Compound
 
 test_data_folder = pathlib.Path(
             __file__).parent.joinpath('../test_data').absolute()
-
 
 
 def test_simplification_methods():
@@ -853,3 +854,63 @@ def test_pickle():
         raise RuntimeError('Should have raised RuntimeError')
 
 
+@pytest.mark.parametrize('compound_type', [SlicedCompound, Compound])
+def test_compound_transformations(compound_type):
+    line = xt.Line(
+        elements=[xt.Marker() for i in range(4)],
+        element_names=['m1', 'm2', 'm3', 'm4'],
+    )
+
+    if compound_type is SlicedCompound:
+        compound = SlicedCompound(elements=['m2', 'm3'])
+    else:
+        compound = Compound(core=['m2', 'm3'])
+
+    line.compound_container.define_compound('c', compound)
+
+    # Add all the transforms
+    line.transform_compound(
+        compound_name='c',
+        x_shift=0.1,
+        y_shift=0.2,
+        x_rotation=0.3,
+        y_rotation=0.4,
+        s_rotation=0.5,
+    )
+    # And then some more to test duplicated names resolution
+    line.transform_compound(compound_name='c', x_shift=0.6)
+
+    result_names = line.element_names
+    expected_names = [
+        'm1',
+        'c_offset_entry_1',
+        'c_offset_entry', 'c_xrot_entry', 'c_yrot_entry', 'c_tilt_entry',
+        'm2', 'm3',
+        'c_tilt_exit', 'c_yrot_exit', 'c_xrot_exit', 'c_offset_exit',
+        'c_offset_exit_1',
+        'm4',
+    ]
+    assert result_names == expected_names
+
+    # Check that the transformations are correct
+    assert line['c_offset_entry_1'].dx == 0.6
+    assert line['c_offset_entry_1'].dy == 0
+    assert line['c_offset_entry'].dx == 0.1
+    assert line['c_offset_entry'].dy == 0.2
+    assert line['c_xrot_entry'].angle == 0.3
+    assert line['c_yrot_entry'].angle == 0.4
+    assert line['c_tilt_entry'].angle == 0.5
+    assert line['c_tilt_exit'].angle == -0.5
+    assert line['c_yrot_exit'].angle == -0.4
+    assert line['c_xrot_exit'].angle == -0.3
+    assert line['c_offset_exit'].dx == -0.1
+    assert line['c_offset_exit'].dy == -0.2
+    assert line['c_offset_exit_1'].dx == -0.6
+    assert line['c_offset_exit_1'].dy == 0
+
+    # Check that the compound is right
+    assert line.get_compound_subsequence('c') == expected_names[1:-1]
+    if compound_type is Compound:
+        assert len(line.get_compound_by_name('c').core) == 2
+        assert len(line.get_compound_by_name('c').entry_transform) == 5
+        assert len(line.get_compound_by_name('c').exit_transform) == 5

--- a/xtrack/compounds.py
+++ b/xtrack/compounds.py
@@ -3,7 +3,7 @@
 # Copyright (c) CERN, 2023.                 #
 # ######################################### #
 
-from typing import Union, Optional, Iterable
+from typing import Union, Optional, Iterable, Literal
 
 CompoundType = Union['SlicedCompound', 'Compound']
 
@@ -11,13 +11,6 @@ CompoundType = Union['SlicedCompound', 'Compound']
 class SlicedCompound:
     def __init__(self, elements):
         self.elements = set(elements)
-
-        self.core = self.elements
-        self.aperture = set()
-        self.entry_transform = set()
-        self.exit_transform = set()
-        self.entry = set()
-        self.exit = set()
 
     def __repr__(self):
         return f'{type(self).__name__}({self.elements})'
@@ -36,6 +29,35 @@ class SlicedCompound:
 
     def copy(self):
         return SlicedCompound(self.elements.copy())
+
+    def add_transform(self, name, side: Literal['entry', 'exit']):
+        if side not in ('entry', 'exit'):
+            raise ValueError(f'Unknown side {side}')
+        self.elements.add(name)
+
+    @property
+    def core(self):
+        return self.elements
+
+    @property
+    def aperture(self):
+        return frozenset()
+
+    @property
+    def entry_transform(self):
+        return frozenset()
+
+    @property
+    def exit_transform(self):
+        return frozenset()
+
+    @property
+    def entry(self):
+        return frozenset()
+
+    @property
+    def exit(self):
+        return frozenset()
 
 
 class Compound:
@@ -133,6 +155,14 @@ class Compound:
             entry=self.entry.copy(),
             exit_=self.exit.copy(),
         )
+
+    def add_transform(self, name, side: Literal['entry', 'exit']):
+        if side == 'entry':
+            self.entry_transform.add(name)
+        elif side == 'exit':
+            self.exit_transform.add(name)
+        else:
+            raise ValueError(f'Unknown side {side}')
 
     @staticmethod
     def _make_singleton_set(var):


### PR DESCRIPTION
## Description

Add a method to the line that applies transformations (shift, tilt, rotations) to compound elements.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
