### PR TITLE
allow the use of thick elements in a Line.from_sequence

### DIFF
--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -7,6 +7,7 @@ import pickle
 import pathlib
 
 import numpy as np
+import pytest
 
 import xtrack as xt
 import xpart as xp
@@ -600,7 +601,6 @@ def test_from_dict_current():
 
 
 def test_from_sequence():
-
     # direct element definition
     # -------------------------
     line = Line.from_sequence([
@@ -679,18 +679,55 @@ def test_from_sequence():
     # test negative drift
     # -------------------
     Line.from_sequence([Node(3, Multipole()), Node(2, Multipole())], 10, auto_reorder=True)
-    try:
+
+    with pytest.raises(ValueError):
         Line.from_sequence([Node(3, Multipole()), Node(2, Multipole())], 10)
-    except ValueError:
-        pass  # expected due to negative drift
-    else:
-        raise AssertionError('Expected exception not raised')
-    try:
+
+    with pytest.raises(ValueError):
         Line.from_sequence([Node(1, Multipole()), Node(4, Multipole())], 2)
-    except ValueError:
-        pass  # expected due to insufficient length
-    else:
-        raise AssertionError('Expected exception not raised')
+
+
+@pytest.mark.parametrize('refer', ['entry', 'centre', 'exit'])
+def test_from_sequence_with_thick(refer):
+    sequence = [
+        xt.Node(1.2, xt.Drift(length=1), name='my_drift'),
+        xt.Node(3, xt.Bend(length=1, k0=0.2), name='my_bend'),
+    ]
+    line = xt.Line.from_sequence(sequence, 5, refer=refer)  # noqa
+
+    assert len(line) == 5
+    assert line.get_length() == 5.0
+
+    assert line.element_names[1] == 'my_drift'
+    assert line.element_names[3] == 'my_bend'
+
+    offset = 0
+    if refer == 'centre':
+        offset = -0.5
+    elif refer == 'exit':
+        offset = -1
+
+    assert np.allclose(
+        line.get_s_position(line.element_names),
+        [
+            0,             # drift
+            1.2 + offset,  # my_drift
+            2.2 + offset,  # drift
+            3 + offset,    # my_bend
+            4 + offset,    # drift
+        ],
+        atol=1e-15,
+    )
+
+
+def test_from_sequence_with_thick_fails():
+    sequence = [
+        xt.Node(1.2, xt.Drift(length=3), name='my_drift'),
+        xt.Node(3, xt.Bend(length=3, k0=0.2), name='my_bend'),
+    ]
+    with pytest.raises(ValueError):
+        _ = xt.Line.from_sequence(sequence, 5)
+
 
 @for_all_test_contexts
 def test_optimize_multipoles(test_context):

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -10,7 +10,7 @@ import json
 from contextlib import contextmanager
 from copy import deepcopy
 from pprint import pformat
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 import numpy as np
 
@@ -237,7 +237,9 @@ class Line:
     @classmethod
     def from_sequence(cls, nodes=None, length=None, elements=None,
                       sequences=None, copy_elements=False,
-                      naming_scheme='{}{}', auto_reorder=False, **kwargs):
+                      naming_scheme='{}{}', auto_reorder=False,
+                      refer: Literal['entry', 'centre', 'exit'] = 'entry',
+                      **kwargs):
 
         """
 
@@ -266,8 +268,14 @@ class Line:
         auto_reorder : bool, optional
             If false (default), nodes must be defined in order of increasing `s`
             coordinate, otherwise an exception is thrown. If true, nodes can be
-            defined in any order and are re-ordered as neseccary. Useful to
+            defined in any order and are re-ordered as necessary. Useful to
             place additional elements inside of sub-sequences.
+        refer : str, optional
+            Specifies where in the node the s coordinate refers to. Can be
+            'entry', 'centre' or 'exit'. By default given s specifies the
+            entry point of the element. If 'centre' is given, the s coordinate
+            marks the centre of the element. If 'exit' is given, the s coordinate
+            marks the exit point of the element.
         **kwargs : dict
             Arguments passed to constructor of the line
 
@@ -320,16 +328,28 @@ class Line:
         drifts = {}
         last_s = 0
         for node in nodes:
-            if node.s < last_s:
-                raise ValueError(f'Negative drift space from {last_s} to {node.s}'
-                    f' ({node.name}). Fix or set auto_reorder=True')
             if _is_thick(node.what):
-                raise NotImplementedError(
-                    f'Thick elements currently not implemented: {node.name}')
+                node_length = node.what.length
+                if refer == 'entry':
+                    offset = 0
+                elif refer == 'centre':
+                    offset = -node_length / 2
+                elif refer == 'exit':
+                    offset = -node_length
+            else:
+                node_length = 0
+                offset = 0
+
+            node_s = node.s + offset
+
+            if node_s < last_s:
+                raise ValueError(
+                    f'Negative drift space from {last_s} to {node_s} '
+                    f'({node.name} {refer}). Fix or set auto_reorder=True')
 
             # insert drift as needed (re-use if possible)
-            if node.s > last_s:
-                ds = node.s - last_s
+            if node_s > last_s:
+                ds = node_s - last_s
                 if ds not in drifts:
                     drifts[ds] = Drift(length=ds)
                 element_objects.append(drifts[ds])
@@ -338,7 +358,7 @@ class Line:
             # insert element
             element_objects.append(node.what)
             element_names.append(node.name)
-            last_s = node.s
+            last_s = node_s + node_length
 
         # add last drift
         if length < last_s:


### PR DESCRIPTION
## Description

Proposed fix for xsuite/xsuite#359 to allow thick element in the sequence.

I added a `refer` parameter to `from_sequence` to mirror the same behaviour in MAD-X, however I made `entry` the default to align with the other behaviours of Xsuite.

Closes xsuite/xsuite#359.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
