### PR TITLE
Improve last_turns_monitor performance

### DIFF
--- a/xtrack/monitors/last_turns_monitor.py
+++ b/xtrack/monitors/last_turns_monitor.py
@@ -91,8 +91,9 @@ class LastTurnsMonitor(BeamElement):
 
             # explicitely init with zeros (instead of size only) to have consistent default values for untouched arrays
             # see also https://github.com/xsuite/xsuite/issues/294
-            data = {prop: [0]*(num_particles*n_last_turns) for prop in self.properties} # particle data
-            data['lost_at_offset'] = [0]*(num_particles)  # meta data (rolling buffer offset per particle)
+            size = num_particles*n_last_turns
+            data = {prop: np.zeros(size) if size > 0 else [] for prop in self.properties} # particle data
+            data['lost_at_offset'] = np.zeros(num_particles) if num_particles > 0 else [] # meta data (rolling buffer offset per particle)
 
             super().__init__(n_last_turns=n_last_turns, particle_id_start=particle_id_start,
                              num_particles=num_particles, every_n_turns=every_n_turns, data=data, **kwargs)


### PR DESCRIPTION

## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Initialization with numpy arrays instead of lists reduces compilation time on some GPU contexts significantly.

`np.zeros(size)` is also cleaner than `[0]*size`

## Checklist

Mandatory: 

- [x] I have ~~added~~ tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
