### PR TITLE
Optional entry and exit markers

### DIFF
--- a/xtrack/beam_elements/elements_src/track_yrotation.h
+++ b/xtrack/beam_elements/elements_src/track_yrotation.h
@@ -19,7 +19,7 @@ void YRotation_single_particle(LocalParticle* part, double sin_angle, double cos
     double const pt = LocalParticle_get_pzeta(part)*beta0;
 
     double pz = sqrt(1.0 + 2.0*pt/beta + pt*pt - px*px - py*py);
-    double ptt = 1.0 - tan_angle*px/pz;
+    double ptt = 1.0 - tan_angle*px/pz;   // TYPO?   I believe it should be 1 + tan * px / pz
     double x_hat = x/(cos_angle*ptt);
     double px_hat = cos_angle*px + sin_angle*pz;
     double y_hat = y + tan_angle*x*py/(pz*ptt);

--- a/xtrack/compounds.py
+++ b/xtrack/compounds.py
@@ -104,8 +104,8 @@ class Compound:
             'aperture': list(self.aperture),
             'entry_transform': list(self.entry_transform),
             'exit_transform': list(self.exit_transform),
-            'entry': list(self.entry)[0],
-            'exit_': list(self.exit)[0],
+            'entry': list(self.entry)[0] if len(self.entry) > 0 else None,
+            'exit_': list(self.exit)[0] if len(self.exit) > 0 else None,
         }
 
     def remove_element(self, element):

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -397,6 +397,7 @@ class Line:
         ignored_madtypes=(),
         allow_thick=False,
         use_compound_elements=True,
+        make_end_markers=True,
     ):
 
         """
@@ -468,6 +469,7 @@ class Line:
             replace_in_expr=replace_in_expr,
             allow_thick=allow_thick,
             use_compound_elements=use_compound_elements,
+            make_end_markers=make_end_markers,
         )
         line = loader.make_line()
         return line
@@ -2528,6 +2530,8 @@ class Line:
         for name in elements_df['name']:
             ee = self.element_dict[name]
             if _allow_backtrack(ee) and not name in needs_aperture:
+                dont_need_aperture[name] = True
+            if name.endswith('_entry') or name.endswith('_exit'):
                 dont_need_aperture[name] = True
 
             # Correct isthick for elements that need aperture but have zero length.

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -442,6 +442,9 @@ class Line:
             in xtrack will be grouped together with a marker attached in front,
             and will be accessible through __getattr__. Otherwise, the line will
             be flattened.
+        make_end_markers : bool, optional
+            If true (default), entry and exit markers will be added for thick
+            elements.
 
         Returns
         -------

--- a/xtrack/mad_loader.py
+++ b/xtrack/mad_loader.py
@@ -701,10 +701,10 @@ class MadLoader:
             converter = getattr(self, "convert_" + el.type, None)
             adder = getattr(self, "add_" + el.type, None)
             if self.expressions_for_element_types is not None:
-               if el.type in self.expressions_for_element_types:
-                   self.Builder = ElementBuilderWithExpr
-                   el.madeval = madeval
-               else:
+                if el.type in self.expressions_for_element_types:
+                    self.Builder = ElementBuilderWithExpr
+                    el.madeval = madeval
+                else:
                     self.Builder = ElementBuilder
                     el.madeval = None
             if adder:

--- a/xtrack/mad_loader.py
+++ b/xtrack/mad_loader.py
@@ -3,8 +3,8 @@
 Structure of the code:
 
 MadLoader takes a sequence and several options
-MadLooder.make_line(buffer=None) returns a line with elements installed in one buffer
-MadLooder.iter_elements() iterates over the elements of the sequence,
+MadLoader.make_line(buffer=None) returns a line with elements installed in one buffer
+MadLoader.iter_elements() iterates over the elements of the sequence,
                           yielding a MadElement and applies some simplifications
 
 Developers:

--- a/xtrack/mad_loader.py
+++ b/xtrack/mad_loader.py
@@ -344,29 +344,38 @@ class CompoundElementBuilder:
         entry_transform: List[ElementBuilder],
         exit_transform: List[ElementBuilder],
         aperture: List[ElementBuilder],
+        make_end_markers: bool = True,
     ):
         self.name = name
         self.core = core
         self.entry_transform = entry_transform
         self.exit_transform = exit_transform
         self.aperture = aperture
+        self.make_end_markers = make_end_markers
 
     def add_to_line(self, line, buffer):
-        start_marker = ElementBuilder(
-            name=self.name + "_entry",
-            type=xtrack.Marker,
-        )
-
-        end_marker = ElementBuilder(
-            name=self.name + "_exit",
-            type=xtrack.Marker,
-        )
+        if self.make_end_markers:
+            start_marker = [ElementBuilder(
+                name=self.name + "_entry",
+                type=xtrack.Marker,
+            )]
+            end_marker = [ElementBuilder(
+                name=self.name + "_exit",
+                type=xtrack.Marker,
+            )]
+            start_marker_name = start_marker[0].name
+            end_marker_name = end_marker[0].name
+        else:
+            start_marker = []
+            end_marker = []
+            start_marker_name = None
+            end_marker_name = None
 
         component_elements = (
-            [start_marker] +
+            start_marker +
             self.aperture +
             self.entry_transform + self.core + self.exit_transform +
-            [end_marker]
+            end_marker
         )
 
         for el in component_elements:
@@ -380,8 +389,8 @@ class CompoundElementBuilder:
             aperture=_get_names(self.aperture),
             entry_transform=_get_names(self.entry_transform),
             exit_transform=_get_names(self.exit_transform),
-            entry=start_marker.name,
-            exit_=end_marker.name,
+            entry=start_marker_name,
+            exit_=end_marker_name,
         )
         line.compound_container.define_compound(self.name, compound)
 
@@ -592,6 +601,7 @@ class MadLoader:
         replace_in_expr=None,
         allow_thick=False,
         use_compound_elements=True,
+        make_end_markers=True,
     ):
 
         if enable_errors is not None:
@@ -631,6 +641,7 @@ class MadLoader:
 
         self.allow_thick = allow_thick
         self.use_compound_elements = use_compound_elements
+        self.make_end_markers = make_end_markers
 
     def iter_elements(self, madeval=None):
         """Yield element data for each known element"""
@@ -816,6 +827,7 @@ class MadLoader:
                 entry_transform=align.entry(),
                 exit_transform=align.exit(),
                 aperture=aperture_seq,
+                make_end_markers=self.make_end_markers,
             ),
         ]
 


### PR DESCRIPTION
Made entry and exit markers optional (default on) when importing from MAD-X, and made the aperture check skip them if imported.

## Description

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
