### PR TITLE
fix survey to be compatible with Python < 3.9

### DIFF
--- a/xtrack/survey.py
+++ b/xtrack/survey.py
@@ -193,6 +193,10 @@ def survey_from_tracker(tracker, X0=0, Y0=0, Z0=0, theta0=0, phi0=0, psi0=0,
     phi0      (float)    Initial elevation angle.
     psi0      (float)    Initial roll angle."""
 
+    if reverse:
+        raise ValueError('`survey(..., reverse=True)` not supported anymore. '
+                         'Use `survey(...).reverse()` instead.')
+
     assert not values_at_element_exit, "Not implemented yet"
 
     line = tracker.line
@@ -240,12 +244,8 @@ def survey_from_tracker(tracker, X0=0, Y0=0, Z0=0, theta0=0, phi0=0, psi0=0,
 
     out_scalars['element0'] = element0
 
-    out = SurveyTable(data=(out_columns | out_scalars), # this is a merge
+    out = SurveyTable(data={**out_columns, **out_scalars},  # this is a merge
                       col_names=out_columns.keys())
-
-    if reverse:
-        raise ValueError('`survey(..., reverse=True)` not supported anymore. '
-                         'Use `survey(...).reverse()` instead.')
 
     return out
 


### PR DESCRIPTION
## Description

The survey code would fail under Python 3.8 since it used a dictionary merge only introduced in 3.9. This small change makes it backwards compatible.

Also move the deprecation guard for `reversed=True` to the top of the function.