### PR TITLE
When on OpenMP context, don't try to load prebuild kernels

### DIFF
--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -329,8 +329,17 @@ class Tracker:
             module_name=None,
             containing_dir='.',
     ):
-        if (self.use_prebuilt_kernels and compile != 'force'
-                and isinstance(self._context, xo.ContextCpu)):
+        if compile == 'force':
+            use_prebuilt_kernels = False
+        elif not isinstance(self._context, xo.ContextCpu):
+            use_prebuilt_kernels = False
+        elif (self._context.omp_num_threads == 'auto'  # CPU context, but OpenMP
+              or self._context.omp_num_threads > 1):
+            use_prebuilt_kernels = False
+        else:
+            use_prebuilt_kernels = self.use_prebuilt_kernels
+
+        if use_prebuilt_kernels:
             kernel_info = get_suitable_kernel(
                 self.config, self.line_element_classes
             )


### PR DESCRIPTION
## Description

When on OpenMP context, don't try to load prebuild kernels.

Closes xsuite/xsuite#401.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
