### PR TITLE
Split Drift into two functions (expanded and exact).

### DIFF
--- a/xtrack/beam_elements/elements_src/drift.h
+++ b/xtrack/beam_elements/elements_src/drift.h
@@ -8,38 +8,46 @@
 
 
 /*gpufun*/
+void Drift_single_particle_expanded(LocalParticle* part, double length){
+    double const rpp    = LocalParticle_get_rpp(part);
+    double const rv0v    = 1./LocalParticle_get_rvv(part);
+    double const xp     = LocalParticle_get_px(part) * rpp;
+    double const yp     = LocalParticle_get_py(part) * rpp;
+    double const dzeta  = 1 - rv0v * ( 1. + ( xp*xp + yp*yp ) / 2. );
+
+    LocalParticle_add_to_x(part, xp * length );
+    LocalParticle_add_to_y(part, yp * length );
+    LocalParticle_add_to_s(part, length);
+    LocalParticle_add_to_zeta(part, length * dzeta );
+}
+
+
+/*gpufun*/
+void Drift_single_particle_exact(LocalParticle* part, double length){
+    double const px = LocalParticle_get_px(part);
+    double const py = LocalParticle_get_py(part);
+    double const rv0v    = 1./LocalParticle_get_rvv(part);
+    double const one_plus_delta = 1. + LocalParticle_get_delta(part);
+
+    double const one_over_pz = 1./sqrt(one_plus_delta*one_plus_delta
+                                       - px * px - py * py);
+    double const dzeta = 1 - rv0v * one_plus_delta * one_over_pz;
+
+    LocalParticle_add_to_x(part, px * one_over_pz * length);
+    LocalParticle_add_to_y(part, py * one_over_pz * length);
+    LocalParticle_add_to_zeta(part, dzeta * length);
+    LocalParticle_add_to_s(part, length);
+}
+
+
+/*gpufun*/
 void Drift_single_particle(LocalParticle* part, double length){
-
     #ifndef XTRACK_USE_EXACT_DRIFTS
-
-        double const rpp    = LocalParticle_get_rpp(part);
-        double const rv0v    = 1./LocalParticle_get_rvv(part);
-        double const xp     = LocalParticle_get_px(part) * rpp;
-        double const yp     = LocalParticle_get_py(part) * rpp;
-        double const dzeta  = 1 - rv0v * ( 1. + ( xp*xp + yp*yp ) / 2. );
-
-        LocalParticle_add_to_x(part, xp * length );
-        LocalParticle_add_to_y(part, yp * length );
-        LocalParticle_add_to_s(part, length);
-        LocalParticle_add_to_zeta(part, length * dzeta );
-
+        Drift_single_particle_expanded(part, length);
     #else
-
-        double const px = LocalParticle_get_px(part);
-        double const py = LocalParticle_get_py(part);
-        double const rv0v    = 1./LocalParticle_get_rvv(part);
-        double const one_plus_delta = 1. + LocalParticle_get_delta(part);
-
-        double const one_over_pz = 1./sqrt(one_plus_delta*one_plus_delta
-                                           - px * px - py * py);
-        double const dzeta = 1 - rv0v * one_plus_delta * one_over_pz;
-
-        LocalParticle_add_to_x(part, px * one_over_pz * length);
-        LocalParticle_add_to_y(part, py * one_over_pz * length);
-        LocalParticle_add_to_zeta(part, dzeta * length);
-        LocalParticle_add_to_s(part, length);
-
+        Drift_single_particle_exact(part, length);
     #endif
 }
+
 
 #endif /* XTRACK_DRIFT_H */

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -2556,6 +2556,8 @@ class Line:
             ee = self.element_dict[name]
             if _allow_backtrack(ee) and not name in needs_aperture:
                 dont_need_aperture[name] = True
+            if name.endswith('_entry') or name.endswith('_exit'):
+                dont_need_aperture[name] = True
 
             # Correct isthick for elements that need aperture but have zero length.
             # Use-case example: Before collimators are installed as EverestCollimator


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->
 
This is useful to be able to select between expanded and exact drifts on a beamelement-by-beamelement basis.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [X] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
