### PR TITLE
Use line directly for survey calculation

### DIFF
--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -24,7 +24,7 @@ import xdeps as xd
 from .compounds import CompoundContainer, CompoundType, Compound, SlicedCompound
 from .slicing import Slicer
 
-from .survey import survey_from_tracker
+from .survey import survey_from_line
 from xtrack.twiss import (compute_one_turn_matrix_finite_differences,
                           find_closed_orbit_line, twiss_line,
                           compute_T_matrix_line,
@@ -1142,7 +1142,7 @@ class Line:
             Survey table.
         """
 
-        return survey_from_tracker(self.tracker, X0=X0, Y0=Y0, Z0=Z0, theta0=theta0,
+        return survey_from_line(self, X0=X0, Y0=Y0, Z0=Z0, theta0=theta0,
                                    phi0=phi0, psi0=psi0, element0=element0,
                                    reverse=reverse)
 

--- a/xtrack/survey.py
+++ b/xtrack/survey.py
@@ -180,7 +180,7 @@ def _get_s_increments(elements):
 
 # Main function
 # ==================================================
-def survey_from_tracker(tracker, X0=0, Y0=0, Z0=0, theta0=0, phi0=0, psi0=0,
+def survey_from_line(line, X0=0, Y0=0, Z0=0, theta0=0, phi0=0, psi0=0,
                         element0=0,
                         values_at_element_exit=False,
                         reverse=True):
@@ -198,8 +198,6 @@ def survey_from_tracker(tracker, X0=0, Y0=0, Z0=0, theta0=0, phi0=0, psi0=0,
                          'Use `survey(...).reverse()` instead.')
 
     assert not values_at_element_exit, "Not implemented yet"
-
-    line = tracker.line
 
     # Extract drift lengths
     drift_length = _get_s_increments(line.elements)


### PR DESCRIPTION
Survey calculation
```python
line = ...
# line.build_tracker()
survey = line.survey()
```
currently requires a tracker, otherwise it throws 

![grafik](https://github.com/xsuite/xsuite/assets/19860638/fc34a796-d1da-4ea8-858b-b9676af204c8)

However, there is no point for this requirement, since [`survey_from_tracker(...)`](https://github.com/xsuite/xtrack/blob/ec6247ba48640bf00a71b4bf11ffa1e3782889c2/xtrack/survey.py#L183C32-L183C32) only uses tracker to do
```python
line = tracker.line
```
and nothing else.

-----

This PR directly passes line to the survey calculation

------

/cc @rahulgsin