### PR TITLE
Fix IndexError in multisetter when elements is empty

### DIFF
--- a/tests/test_multisetter.py
+++ b/tests/test_multisetter.py
@@ -116,3 +116,22 @@ def test_custom_setter_fast_dipole(test_context):
     assert line['df1'].knl[0] == 1.1
     assert line['df2'].knl[0] == 1.2
     assert line['df3'].knl[0] == 1.3
+
+
+@for_all_test_contexts
+def test_custom_setter_empty(test_context):
+    line = xt.Line(elements={
+            'dr1': xt.Drift(length=1.),
+            'dr2': xt.Drift(length=1.),
+            'dr3': xt.Drift(length=1.),
+        },
+        element_names=['dr1', 'dr2', 'dr3', 'dr1'],
+    )
+
+    line.build_tracker(_context=test_context)
+    qf_setter = xt.MultiSetter(line, [], field='knl', index=0)
+
+    ctx2np = test_context.nparray_from_context_array
+
+    values = qf_setter.get_values()
+    assert not np.size(ctx2np(values))

--- a/xtrack/multisetter/multisetter.py
+++ b/xtrack/multisetter/multisetter.py
@@ -114,9 +114,7 @@ class MultiSetter(xo.HybridClass):
     }
 
     def __init__(self, line, elements, field, index=None):
-
-        '''
-        Create object to efficiently set and get values of a specific field of
+        """Create object to efficiently set and get values of a specific field of
         several elements of a line.
 
         Parameters
@@ -129,8 +127,11 @@ class MultiSetter(xo.HybridClass):
             Name of the field to be mutated.
         index: int or None
             If the field is an array, the index of the array to be mutated.
-
-        '''
+        """
+        if len(elements) == 0:
+            self._empty = True
+            return
+        self._empty = False
 
         if isinstance(line, xt.Tracker):
             tracker = line
@@ -178,10 +179,9 @@ class MultiSetter(xo.HybridClass):
         }[self.dtype]
 
     def get_values(self):
-
-        '''
-        Get the values of the multisetter fields.
-        '''
+        """Get the values of the multisetter fields."""
+        if self._empty:
+            return []
 
         out = self._context.zeros(len(self.offsets), dtype=self.dtype)
         self._get_kernel.set_n_threads(len(self.offsets))
@@ -189,15 +189,15 @@ class MultiSetter(xo.HybridClass):
         return out
 
     def set_values(self, values):
-
-        '''
-        Set the values of the multisetter fields.
+        """Set the values of the multisetter fields.
 
         Parameters
         ----------
         values: np.ndarray
             Array of values to be set.
-        '''
+        """
+        if self._empty:
+            return
 
         self._set_kernel.set_n_threads(len(self.offsets))
         self._set_kernel(data=self, buffer=self._tracker_buffer.buffer,

--- a/xtrack/multisetter/multisetter.py
+++ b/xtrack/multisetter/multisetter.py
@@ -128,10 +128,6 @@ class MultiSetter(xo.HybridClass):
         index: int or None
             If the field is an array, the index of the array to be mutated.
         """
-        if len(elements) == 0:
-            self._empty = True
-            return
-        self._empty = False
 
         if isinstance(line, xt.Tracker):
             tracker = line
@@ -142,6 +138,13 @@ class MultiSetter(xo.HybridClass):
 
         tracker_buffer = tracker._buffer
         line = tracker.line
+
+        if len(elements) == 0:
+            self._empty = True
+            self.xoinitialize(_context=context, offsets=[])
+            return
+
+        self._empty = False
 
         # Get dtype from first element
         el = line[elements[0]]
@@ -181,7 +184,7 @@ class MultiSetter(xo.HybridClass):
     def get_values(self):
         """Get the values of the multisetter fields."""
         if self._empty:
-            return []
+            return self._context.zeros(0, dtype=np.float64)
 
         out = self._context.zeros(len(self.offsets), dtype=self.dtype)
         self._get_kernel.set_n_threads(len(self.offsets))
@@ -201,7 +204,7 @@ class MultiSetter(xo.HybridClass):
 
         self._set_kernel.set_n_threads(len(self.offsets))
         self._set_kernel(data=self, buffer=self._tracker_buffer.buffer,
-               input=xt.BeamElement._arr2ctx(self,values))
+               input=xt.BeamElement._arr2ctx(self, values))
 
 
 def _extract_offset(obj, field_name, index, dtype, xodtype):


### PR DESCRIPTION
## Description

In the multisetter, catch the case when the number of elements is zero. In such a case there is no need to use the kernel at all.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
