### PR TITLE
Missing backtrack

### DIFF
--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -701,6 +701,8 @@ class SimpleThinQuadrupole(BeamElement):
         'knl': xo.Float64[2],
     }
 
+    has_backtrack = True
+
     _extra_c_sources = [
         _pkg_root.joinpath('beam_elements/elements_src/simplethinquadrupole.h')]
 
@@ -1399,6 +1401,8 @@ class SimpleThinBend(BeamElement):
         'hxl': xo.Float64,
         'length': xo.Float64,
     }
+
+    has_backtrack = True
 
     _extra_c_sources = [
         _pkg_root.joinpath('beam_elements/elements_src/simplethinbend.h')]

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -754,7 +754,8 @@ def _twiss_open(line, twiss_init,
     if not _continue_if_lost:
         assert np.all(ctx2np(part_for_twiss.state) == 1), (
             'Some test particles were lost during twiss! '
-          + f'(state: {np.unique(ctx2np(part_for_twiss.state))})')
+          + f'(state {np.unique(ctx2np(part_for_twiss.state))}, '
+          + f'at element {np.unique(ctx2np(part_for_twiss.at_element))})')
 
     if twiss_orientation == 'forward':
         i_start = ele_start
@@ -772,7 +773,8 @@ def _twiss_open(line, twiss_init,
     if not _continue_if_lost:
         assert np.all(recorded_state == 1), (
              'Some test particles were lost during twiss! '
-          + f'(state: {np.unique(recorded_state)})')
+          + f'(state {np.unique(recorded_state)}, '
+          + f'at element {np.unique(line.record_last_track.at_element[:, i_start:i_stop+1].copy())})')
 
     x_co = line.record_last_track.x[0, i_start:i_stop+1].copy()
     y_co = line.record_last_track.y[0, i_start:i_stop+1].copy()

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -753,7 +753,8 @@ def _twiss_open(line, twiss_init,
 
     if not _continue_if_lost:
         assert np.all(ctx2np(part_for_twiss.state) == 1), (
-            'Some test particles were lost during twiss!')
+            'Some test particles were lost during twiss! '
+          + f'(state: {np.unique(ctx2np(part_for_twiss.state))})')
 
     if twiss_orientation == 'forward':
         i_start = ele_start
@@ -770,7 +771,8 @@ def _twiss_open(line, twiss_init,
     recorded_state = line.record_last_track.state[:, i_start:i_stop+1].copy()
     if not _continue_if_lost:
         assert np.all(recorded_state == 1), (
-            'Some test particles were lost during twiss!')
+             'Some test particles were lost during twiss! '
+          + f'(state: {np.unique(recorded_state)})')
 
     x_co = line.record_last_track.x[0, i_start:i_stop+1].copy()
     y_co = line.record_last_track.y[0, i_start:i_stop+1].copy()


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Very small changes:
- `SimpleThinQuadrupole` and `SimpleThinBend` were missing a backtrack flag
- in `twiss`, if particles are lost also their state and the element where they are lost are outputted in the error for easier debugging

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [X] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20,](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
