### PR TITLE
Add a progress bar facility to xtrack

### DIFF
--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -10,7 +10,7 @@ import json
 from contextlib import contextmanager
 from copy import deepcopy
 from pprint import pformat
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Collection
 
 import numpy as np
 from scipy.constants import c as clight
@@ -22,6 +22,7 @@ import xpart as xp
 import xtrack as xt
 import xdeps as xd
 from .compounds import CompoundContainer, CompoundType, Compound, SlicedCompound
+from .progress_indicator import progress
 from .slicing import Slicer
 
 from .survey import survey_from_tracker
@@ -171,19 +172,13 @@ class Line:
 
         if isinstance(dct['elements'], dict):
             elements = {}
-            num_elements = len(dct['elements'].keys())
-            for ii, (kk, ee) in enumerate(dct['elements'].items()):
-                if ii % 100 == 0:
-                    _print('Loading line from dict: '
-                        f'{round(ii/num_elements*100):2d}%  ',end="\r", flush=True)
+            for ii, (kk, ee) in enumerate(
+                    progress(dct['elements'].items(), desc='Loading line from dict')):
                 elements[kk] = _deserialize_element(ee, class_dict, _buffer)
         elif isinstance(dct['elements'], list):
             elements = []
-            num_elements = len(dct['elements'])
-            for ii, ee in enumerate(dct['elements']):
-                if ii % 100 == 0:
-                    _print('Loading line from dict: '
-                        f'{round(ii/num_elements*100):2d}%  ',end="\r", flush=True)
+            for ii, ee in enumerate(
+                    progress(dct['elements'], desc='Loading line from dict')):
                 elements.append(_deserialize_element(ee, class_dict, _buffer))
         else:
             raise ValueError('Field `elements` must be a dict or a list')
@@ -733,6 +728,7 @@ class Line:
         turn_by_turn_monitor=None,
         freeze_longitudinal=False,
         time=False,
+        with_progress=False,
         **kwargs):
 
         """
@@ -770,7 +766,11 @@ class Line:
         time: bool, optional
             If True, the time taken for tracking is recorded and can be retrieved
             in `line.time_last_track`.
-
+        with_progress: bool or int, optional
+            If truthy, a progress bar is displayed during tracking. If an integer
+            is provided, it is used as the number of turns between two updates
+            of the progress bar. If True, 100 is taken by default. By default,
+            equals to False and no progress bar is displayed.
         """
 
         self._check_valid_tracker()
@@ -783,6 +783,7 @@ class Line:
             turn_by_turn_monitor=turn_by_turn_monitor,
             freeze_longitudinal=freeze_longitudinal,
             time=time,
+            with_progress=with_progress,
             **kwargs)
 
     def slice_thick_elements(self, slicing_strategies):
@@ -2618,13 +2619,7 @@ class Line:
         i_prev_aperture = elements_df[elements_df['is_aperture']].index[0]
         i_next_aperture = 0
 
-        for iee in range(i_prev_aperture, num_elements):
-
-            if iee % 100 == 0:
-                _print(
-                    f'Checking aperture: {round(iee/num_elements*100):2d}%  ',
-                    end="\r", flush=True)
-
+        for iee in progress(range(i_prev_aperture, num_elements), desc='Checking aperture'):
             if dont_need_aperture[elements_df.loc[iee, 'name']]:
                 continue
 

--- a/xtrack/mad_loader.py
+++ b/xtrack/mad_loader.py
@@ -27,20 +27,15 @@ Loader.add_<name>(mad_elem,line,buffer) to add a new element to line
 
 if the want to control how the xobject is created
 """
-import abc
-import functools
-import re
-from itertools import zip_longest
-from typing import List, Iterable, Iterator, Tuple, Union
+from typing import List, Union
 
 import numpy as np
-from math import tan
 
-import xtrack, xobjects
+import xobjects
+import xtrack
 from .compounds import Compound
-
 from .general import _print
-
+from .progress_indicator import progress
 
 # Generic functions
 
@@ -691,10 +686,11 @@ class MadLoader:
             madeval = None
             self.Builder = ElementBuilder
 
-        nelem = len(self.sequence.expanded_elements)
-
-        for ii, el in enumerate(self.iter_elements(madeval=madeval)):
-
+        for ii, el in enumerate(progress(
+                self.iter_elements(madeval=madeval),
+                desc=f'Converting sequence "{self.sequence.name}"',
+                total=len(self.sequence.expanded_elements)),
+        ):
             # for each mad element create xtract elements in a buffer and add to a line
             converter = getattr(self, "convert_" + el.type, None)
             adder = getattr(self, "add_" + el.type, None)
@@ -715,14 +711,6 @@ class MadLoader:
                     f'Element {el.type} not supported,\nimplement "add_{el.type}"'
                     f" or convert_{el.type} in function in MadLoader"
                 )
-            if ii % 100 == 0:
-                _print(
-                    f'Converting sequence "{self.sequence.name}":'
-                    f' {round(ii/nelem*100):2d}%     ',
-                    end="\r",
-                    flush=True,
-                )
-        _print()
         return line
 
     def add_elements(

--- a/xtrack/progress_indicator.py
+++ b/xtrack/progress_indicator.py
@@ -1,0 +1,93 @@
+from math import ceil
+from typing import cast, Iterable, Collection
+
+from .general import _print
+
+
+class DefaultProgressIndicator:
+    """Display progress of a task.
+
+    This is a simple progress indicator, with an API that is a subset of the
+    one of `tqdm`. It will provide simple progress information if tqdm is
+    missing on the system.
+
+    Parameters
+    ----------
+    iterable: Iterable
+        The iterable to iterate over.
+    desc: str
+        Description of the task.
+    total: int, optional
+        Total number of iterations, if unspecified `len(iterable)` is used.
+    miniters: int, optional
+        Minimum number of iterations between updates, by default 1.
+    unit_scale: int, optional
+        Unused, kept for compatibility with tqdm. To be interpreted as the
+        scale by which the iteration number and `total` are multiplied: i.e.,
+        one iteration corresponds to `unit_scale` events.
+    """
+    def __init__(
+            self,
+            iterable: Iterable,
+            desc: str,
+            total: int = None,
+            miniters: int = None,
+            unit_scale: int = None,
+    ):
+        self.iterable = iterable
+        self.desc = desc
+        self._iterator = None
+        self._iteration = 0
+        self._total = total or len(cast(Collection, iterable))
+        self._update_interval = miniters or ceil(self._total / 100)
+        self._unit_scale = unit_scale or 1
+        print(f'Init: interval {self._update_interval}, total {self._total}')
+
+    def __iter__(self):
+        self._iterator = iter(self.iterable)
+        return self
+
+    def __next__(self):
+        if self._iteration % self._update_interval == 0:
+            self._print_progress()
+
+        try:
+            return next(self._iterator)
+        except StopIteration:
+            self._print_progress()
+            _print()  # finish with a newline
+            raise
+        finally:
+            self._iteration += 1
+
+    def _print_progress(self):
+        percent = round(self._iteration * 100 / self._total)
+        index = self._iteration * self._unit_scale
+        scaled_total = self._total * self._unit_scale
+        message = f'{self.desc}: {percent:3}% ({index}/{scaled_total} iterations)'
+        _print(message, end='\r', flush=True)
+
+
+class _ProgressIndicatorConfig:
+    default_indicator_cls = DefaultProgressIndicator
+    default_options = {}
+
+
+_config = _ProgressIndicatorConfig()
+
+
+def set_default_indicator(indicator_cls, **options):
+    _config.default_indicator_cls = indicator_cls
+    _config.default_options = options
+
+
+def progress(iterable: Iterable, **options):
+    indicator = _config.default_indicator_cls
+    return indicator(iterable, **_config.default_options, **options)
+
+
+try:
+    from tqdm import tqdm
+    set_default_indicator(tqdm)
+except ModuleNotFoundError:
+    pass

--- a/xtrack/progress_indicator.py
+++ b/xtrack/progress_indicator.py
@@ -87,7 +87,7 @@ def progress(iterable: Iterable, **options):
 
 
 try:
-    from tqdm import tqdm
+    from tqdm.autonotebook import tqdm
     set_default_indicator(tqdm)
 except ModuleNotFoundError:
     pass

--- a/xtrack/slicing.py
+++ b/xtrack/slicing.py
@@ -5,13 +5,12 @@
 
 import abc
 import re
-from collections import defaultdict
 
 from itertools import zip_longest
 from typing import List, Tuple, Iterator, Optional, Literal
 
 from .compounds import SlicedCompound
-from .general import _print
+from .progress_indicator import progress
 
 import xtrack as xt
 
@@ -156,10 +155,7 @@ class Slicer:
         thin_names = []
 
         collapsed_names = self.line.get_collapsed_names()
-        n_elements = len(collapsed_names)
-        for ii, name in enumerate(collapsed_names):
-            _print(f'Slicing line: {100*(ii + 1)/n_elements:.0f}%', end='\r', flush=True)
-
+        for ii, name in enumerate(progress(collapsed_names, desc='Slicing line')):
             compound = self.line.get_compound_by_name(name)
             if compound is not None:
                 subsequence = self._slice_compound(name, compound)

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -282,7 +282,7 @@ class Tracker:
                 "This tracker is not anymore valid, most probably because the corresponding line has been unfrozen. "
                 "Please rebuild the tracker, for example using `line.build_tracker(...)`.")
 
-    def _track(self, *args, with_progress: Union[bool, int] = False, **kwargs):
+    def _track(self, particles, *args, with_progress: Union[bool, int] = False, **kwargs):
         assert self.iscollective in (True, False)
         if self.iscollective or self.line.enable_time_dependent_vars:
             tracking_func = self._track_with_collective
@@ -312,9 +312,11 @@ class Tracker:
                     one_turn_kwargs['num_turns'] = num_turns % with_progress
                 else:
                     one_turn_kwargs['num_turns'] = scaling
-                tracking_func(*args, **one_turn_kwargs)
+
+                tracking_func(particles, *args, **one_turn_kwargs)
+                particles.reorganize()
         else:
-            tracking_func(*args, **kwargs)
+            tracking_func(particles, *args, **kwargs)
 
     @property
     def particle_ref(self) -> xp.Particles:


### PR DESCRIPTION
## Description

Add a common progress indicator functionality to Xtrack. This includes the current progress messages in the madloader, when slicing, and during aperture check, as well as adds an optional progress indicator when tracking. When calling the `Line.track` function a parameter `with_progress` can be specified to enable the progress monitoring.

If `with_progress` is truthy, a progress bar is displayed during tracking. If an integer is provided, it is used as the number of turns between two updates of the progress bar. If True, 100 is taken by default. By default, `with_progress` equals to False and no progress bar is displayed.

If the package [tqdm](https://tqdm.github.io/) is installed it will be used automatically for all these progress indicators. Otherwise, a simple progress report akin to the one we already have in Xtrack will be showed. This can be overriden manually with `xtrack.progress_indicator.set_default_indicator`, and more options can be passed to customise the behaviour of `tqdm` (or potentially other progress bars with the same inteface!)

When new feature is implemented requiring a progress indicator, in a for loop, one simply needs to wrap the object over which the iteration is taking place in `xtrack.progress_indicator.progress` and the progress indicator will be displayed automatically. For more background, including the optional settings consult the docstrings of `xtrack.progress_indicator.DefaultProgressIndicator`.

Closes xsuite/xsuite#390.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
