### PR TITLE
Fix sign of slip factor (documentation inconsistency)

### DIFF
--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -192,7 +192,7 @@ def twiss_line(line, particle_ref=None, method=None,
             - dqx: horizontal chromaticity (d qx / d delta)
             - dqy: vertical chromaticity (d qy / d delta)
             - c_minus: closest tune approach coefficient
-            - slip_factor: slip factor (-1 / f_ref * d f_ref / d delta)
+            - slip_factor: slip factor (-1 / f_ref * d f_ref / d delta) (positive above transition)
             - momentum_compaction_factor: momentum compaction factor (slip_factor + 1/gamma_0^2)
             - T_rev0: reference revolution period
             - partice_on_co: particle on closed orbit

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -192,8 +192,8 @@ def twiss_line(line, particle_ref=None, method=None,
             - dqx: horizontal chromaticity (d qx / d delta)
             - dqy: vertical chromaticity (d qy / d delta)
             - c_minus: closest tune approach coefficient
-            - slip_factor: slip factor (1 / f_ref * d f_ref / d delta)
-            - momentum_compaction_factor: momentum compaction factor
+            - slip_factor: slip factor (-1 / f_ref * d f_ref / d delta)
+            - momentum_compaction_factor: momentum compaction factor (slip_factor + 1/gamma_0^2)
             - T_rev0: reference revolution period
             - partice_on_co: particle on closed orbit
             - R_matrix: R matrix (if calculated or provided)


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Fixes the sign of the slip factor in the docstring.

Both, [code](https://github.com/xsuite/xtrack/blob/18d16aa2a78e565a54fef4eeb71c209f7131dac7/xtrack/twiss.py#L1114) and physics manual define eta with a negative sign (positive above transition):

$$\eta = -\frac{\Delta f/f}{\Delta p/p}=\alpha_c-\frac{1}{\gamma_0^2}$$

```python
        eta = -dzeta[-1]/circumference
        alpha = eta + 1/part_on_co._xobject.gamma0[0]**2
```

But in the docstring the minus was missing, leading to confusion as the definition with opposite sign (positive below transition) is also commonly used in literature.




## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
