### PR TITLE
Increase tolerance in test_radiation_equilibrium_emittances

### DIFF
--- a/tests/test_radiation_equilibrium_emittances.py
+++ b/tests/test_radiation_equilibrium_emittances.py
@@ -146,7 +146,7 @@ def test_eq_emitt(conf):
         assert np.isclose(ez, 3.8595e-6,  atol=0,     rtol=1e-4)
         checked = True
     elif tilt_machine_by_90_degrees and not vertical_orbit_distortion and wiggler_on:
-        assert np.isclose(ex, 5.8575e-13, atol=0,     rtol=4e-3) # Quite large, to be kept in mind
+        assert np.isclose(ex, 5.8575e-13, atol=0,     rtol=4e-3)  # Quite large, to be kept in mind
         assert np.isclose(ey, 6.9955e-10, atol=0,     rtol=1e-4)
         assert np.isclose(ez, 3.8595e-6,  atol=0,     rtol=1e-4)
         checked = True
@@ -156,7 +156,7 @@ def test_eq_emitt(conf):
         assert np.isclose(ez, 3.5762e-6,  atol=0,     rtol=1e-4)
         checked = True
     elif tilt_machine_by_90_degrees and vertical_orbit_distortion and not wiggler_on:
-        assert np.isclose(ex, 2.5531e-12, atol=0,     rtol=2e-3)
+        assert np.isclose(ex, 2.5531e-12, atol=0,     rtol=4e-3)
         assert np.isclose(ey, 7.0576e-10, atol=0,     rtol=1e-4)
         assert np.isclose(ez, 3.5763e-6,  atol=0,     rtol=1e-4)
         checked = True


### PR DESCRIPTION
## Description

Increase the tolerance as on some machines the test fails because it's is too tight.