### PR TITLE
fix bugs related to the progress bar

### DIFF
--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -342,3 +342,25 @@ def test_slicing_thick_bend_into_thick_bends_simple(element_type):
     _fact = np.math.factorial
     assert np.isclose(_fact(bend0.order) * bend0.inv_factorial_order, 1, atol=1e-16)
     assert np.isclose(_fact(bend1.order) * bend0.inv_factorial_order, 1, atol=1e-16)
+
+
+def test_slicing_xdeps_consistency():
+    num_elements = 50000
+    num_slices = 1
+
+    line = xt.Line(
+        elements=[xt.Bend(k0=1, length=100)] * num_elements,
+        element_names=[f'bend{ii}' for ii in range(num_elements)],
+    )
+    line._init_var_management()
+
+    for ii in range(num_elements):
+        line.vars[f'k{ii}'] = 1
+        line.element_refs[f'bend{ii}'].k0 = line.vars[f'k{ii}']
+
+    sgy = xt.slicing.Strategy(
+        element_type=xt.Bend,
+        slicing=xt.slicing.Uniform(num_slices),
+    )
+    line.slice_thick_elements([sgy])
+    assert len(line.to_dict()['_var_manager']) == num_elements * num_slices

--- a/xtrack/monitors/particles_monitor.py
+++ b/xtrack/monitors/particles_monitor.py
@@ -143,6 +143,7 @@ def _monitor_get_backtrack_element(
 
     return xt.Marker(_context=_context, _buffer=_buffer, _offset=_offset)
 
+
 class ParticlesMonitor(BeamElement):
 
     _xofields = {
@@ -166,6 +167,7 @@ class ParticlesMonitor(BeamElement):
     has_backtrack = True
     allow_backtrack = True
     _ParticlesClass = xp.Particles
+
 
 ParticlesMonitor.__init__ = _monitor_init
 ParticlesMonitor.get_backtrack_element = _monitor_get_backtrack_element

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -2,10 +2,8 @@
 # This file is part of the Xtrack Package.  #
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
-from math import ceil
 from time import perf_counter
 from typing import Literal, Union
-from contextlib import contextmanager
 import logging
 from functools import partial
 from collections import UserDict, defaultdict
@@ -16,8 +14,6 @@ import numpy as np
 import xobjects as xo
 import xpart as xp
 import xtrack as xt
-
-from .general import _print
 
 from .base_element import _handle_per_particle_blocks
 from .beam_elements import Drift
@@ -282,7 +278,7 @@ class Tracker:
                 "This tracker is not anymore valid, most probably because the corresponding line has been unfrozen. "
                 "Please rebuild the tracker, for example using `line.build_tracker(...)`.")
 
-    def _track(self, particles, *args, with_progress: Union[bool, int]=False,
+    def _track(self, particles, *args, with_progress: Union[bool, int] = False,
                time=False, **kwargs):
 
         out = None
@@ -307,21 +303,52 @@ class Tracker:
                                  'possible over more than one turn.')
 
             if with_progress is True:
-                with_progress = scaling = 100
+                batch_size = scaling = 100
             else:
-                with_progress = int(with_progress)
-                scaling = with_progress if with_progress > 1 else None
+                batch_size = int(with_progress)
+                scaling = with_progress if batch_size > 1 else None
+
+            if kwargs.get('turn_by_turn_monitor') is True:
+                ele_start = kwargs.get('ele_start') or 0
+                ele_stop = kwargs.get('ele_stop')
+                if ele_stop is None:
+                    ele_stop = len(self.line)
+
+                if ele_start >= ele_stop:
+                    # we need an additional turn and space in the monitor for
+                    # the incomplete turn
+                    num_turns += 1
+                _, monitor, _, _ = self._get_monitor(particles, True, num_turns)
+                kwargs['turn_by_turn_monitor'] = monitor
 
             for ii in progress(
-                    range(0, num_turns, with_progress),
+                    range(0, num_turns, batch_size),
                     desc='Tracking',
                     unit_scale=scaling,
             ):
                 one_turn_kwargs = kwargs.copy()
-                if ii + with_progress > num_turns:  # last group of turns
-                    one_turn_kwargs['num_turns'] = num_turns % with_progress
-                else:
-                    one_turn_kwargs['num_turns'] = scaling
+                is_first_batch = ii == 0
+                is_last_batch = ii + batch_size >= num_turns
+
+                if is_first_batch and is_last_batch:
+                    # This is the only batch, we track as normal
+                    pass
+                elif is_first_batch:
+                    # Not the last batch, so track until the last element
+                    one_turn_kwargs['ele_stop'] = None
+                    one_turn_kwargs['num_turns'] = batch_size
+                elif is_last_batch:
+                    # Not the first batch, so track from the first element
+                    one_turn_kwargs['ele_start'] = None
+                    remaining_turns = num_turns % batch_size
+                    if remaining_turns == 0:
+                        remaining_turns = batch_size
+                    one_turn_kwargs['num_turns'] = remaining_turns
+                elif not is_first_batch and not is_last_batch:
+                    # A 'middle batch', track from first to last element
+                    one_turn_kwargs['num_turns'] = batch_size
+                    one_turn_kwargs['ele_start'] = None
+                    one_turn_kwargs['ele_stop'] = None
 
                 tracking_func(particles, *args, **one_turn_kwargs)
                 # particles.reorganize() # could be done in the future to optimize GPU usage
@@ -683,7 +710,7 @@ class Tracker:
                 num_turns = 1
             else:
                 assert num_turns > 0
-            if isinstance(ele_stop,str):
+            if isinstance(ele_stop, str):
                 ele_stop = self.line.element_names.index(ele_stop)
 
             # If ele_stop comes before ele_start, we need to add an additional turn to
@@ -1360,18 +1387,6 @@ class Tracker:
     @skip_end_turn_actions.setter
     def skip_end_turn_actions(self, value):
         self.line.skip_end_turn_actions = value
-
-    # def __getattr__(self, attr):
-    #     # If not in self look in self.line (if not None)
-    #     if attr == 'line':
-    #         raise AttributeError(f'Tracker object has no attribute `{attr}`')
-    #     if self.line is not None and attr in object.__dir__(self.line):
-    #         _print(f'Warning! The use of `Tracker.{attr}` is deprecated.'
-    #             f' Please use `Line.{attr}` (for more info see '
-    #             'https://github.com/xsuite/xsuite/issues/322)')
-    #         return getattr(self.line, attr)
-    #     else:
-    #         raise AttributeError(f'Tracker object has no attribute `{attr}`')
 
     def __dir__(self):
         return list(set(object.__dir__(self) + dir(self.line)))


### PR DESCRIPTION
## Description

- Fix xsuite/xsuite#435, which was caused by the fact that individual run of `Tracker._track` by default allocates a monitor for the minimum required number of turns.
- Additionally handle `ele_start` and `ele_stop` correctly.
- Add a workaround for a broken progressbar in notebooks. This patch is necessary, because notebook.tqdm has a bug. Until it is fixed, this workaround makes it possible to use tqdm with unit_scale in Jupyter. See issue tqdm/tqdm#1399 and PRs tqdm/tqdm#1528 and tqdm/tqdm#1461.
- Fix a bug when iterating on empty containers with the built-in DefaultProgressIndicator.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
