### PR TITLE
release/0.48.0

### DIFF
--- a/examples/twiss/000c_twiss_range_init_middle.py
+++ b/examples/twiss/000c_twiss_range_init_middle.py
@@ -9,7 +9,7 @@ import xtrack as xt
 import xpart as xp
 
 collider = xt.Multiline.from_json(
-    '../../test_data/hllhc15_collider/collider_00_from_mad.json')
+    '../../test_data/hllhc15_thick/hllhc15_collider_thick.json')
 collider.build_trackers()
 
 collider.lhcb1.twiss_default['method'] = '4d'
@@ -22,28 +22,13 @@ line_name = 'lhcb2'
 line = collider.lhcb1
 line_name = 'lhcb1'
 
-tw = line.twiss()
+two = line.twiss(ele_start='ip7', ele_stop='ip3', ele_init='ip1',
+                 betx=.15, bety=.15)
 
-# two = line.twiss(ele_start='ip5', ele_stop='ip8',
-#                  twiss_init=tw.get_twiss_init('ip6'))
-
-# Loop around (init in the second part)
-two = line.twiss(ele_start='ip2', ele_stop='ip5',
-                    twiss_init=tw.get_twiss_init('ip4'))
-
-# Loop around (init in the first part)
-# two = line.twiss(ele_start='ip1', ele_stop='ip4',
-#                  twiss_init=tw.get_twiss_init('ip2'))
-
-# Corner cases
-# two = collider.lhcb1.twiss(ele_start='ip8', ele_stop='ip3', ele_init='ip2',
-#                              betx=10., bety=10.)
-
-# two = collider.lhcb1.twiss(ele_start='ip3', ele_stop='ip6', ele_init='ip5',
-#                              betx=.15, bety=.15)
 
 import matplotlib.pyplot as plt
+plt.close('all')
 plt.figure(1)
-plt.plot(tw.s, tw.betx, label='betx')
 plt.plot(two.s, two.betx, label='betx')
+plt.plot(two.s, two.bety, label='bety')
 plt.show()

--- a/examples/twiss/000d_twiss_ele_co_search.py
+++ b/examples/twiss/000d_twiss_ele_co_search.py
@@ -16,19 +16,17 @@ collider.lhcb1.twiss_default['method'] = '4d'
 collider.lhcb2.twiss_default['method'] = '4d'
 collider.lhcb2.twiss_default['reverse'] = True
 
-line = collider.lhcb2
-line_name = 'lhcb2'
+collider.vars['on_x1vs'] = 123
+collider.vars['on_sep1h'] = 2
+collider.vars['on_x1vs'] = 200
+collider.vars['on_sep1v'] = -3
 
-line = collider.lhcb1
-line_name = 'lhcb1'
-
-two = line.twiss(ele_start='ip7', ele_stop='ip3', ele_init='ip1',
-                 betx=.15, bety=.15)
-
+# tw = collider.lhcb1.twiss()                  # Fails on closed orbit search
+tw = collider.lhcb1.twiss(ele_co_search='ip7') # Successful closed orbit search
 
 import matplotlib.pyplot as plt
 plt.close('all')
 plt.figure(1)
-plt.plot(two.s, two.betx, label='betx')
-plt.plot(two.s, two.bety, label='bety')
+plt.plot(tw.s, tw.x)
+plt.plot(tw.s, tw.y)
 plt.show()

--- a/examples/twiss/000d_twiss_ele_co_search.py
+++ b/examples/twiss/000d_twiss_ele_co_search.py
@@ -16,17 +16,19 @@ collider.lhcb1.twiss_default['method'] = '4d'
 collider.lhcb2.twiss_default['method'] = '4d'
 collider.lhcb2.twiss_default['reverse'] = True
 
-# Twiss B1 and B2 from IP1
-two = collider.twiss(ele_start='ip7', ele_stop='ip3', ele_init='ip1',
+line = collider.lhcb2
+line_name = 'lhcb2'
+
+line = collider.lhcb1
+line_name = 'lhcb1'
+
+two = line.twiss(ele_start='ip7', ele_stop='ip3', ele_init='ip1',
                  betx=.15, bety=.15)
 
-# Twiss B1 only from IP1
-two1 = collider.lhcb1.twiss(ele_start='ip7', ele_stop='ip3', ele_init='ip1',
-                            betx=.15, bety=.15)
 
 import matplotlib.pyplot as plt
 plt.close('all')
 plt.figure(1)
-plt.plot(two.lhcb1.s, two.lhcb1.betx, label='betx')
-plt.plot(two.lhcb2.s, two.lhcb2.betx, label='betx')
+plt.plot(two.s, two.betx, label='betx')
+plt.plot(two.s, two.bety, label='bety')
 plt.show()

--- a/tests/test_match_orbit_bump.py
+++ b/tests/test_match_orbit_bump.py
@@ -112,6 +112,61 @@ def test_match_orbit_bump(test_context):
     assert np.isclose(tw['x', 'mq.33l8.b1'], tw_before['x', 'mq.33l8.b1'], atol=1e-6)
     assert np.isclose(tw['px', 'mq.33l8.b1'], tw_before['px', 'mq.33l8.b1'], atol=1e-7)
 
+    # Same match but with twiss_init provided through a kwargs
+    # I start from scratch
+    line.vars['acbv30.l8b1'] = 0
+    line.vars['acbv28.l8b1'] = 0
+    line.vars['acbv26.l8b1'] = 0
+    line.vars['acbv24.l8b1'] = 0
+
+    tini = tw_before.get_twiss_init(at_element='mq.33l8.b1')
+
+    import pdb; pdb.set_trace()
+    line.match(
+        ele_start='mq.33l8.b1',
+        ele_stop='mq.23l8.b1',
+        betx=1, bety=1,
+        x=tini.x, px=tini.px, y=tini.y, py=tini.py,
+        vary=[
+            xt.Vary(name='acbv30.l8b1', step=1e-10),
+            xt.Vary(name='acbv28.l8b1', step=1e-10),
+            xt.Vary(name='acbv26.l8b1', step=1e-10),
+            xt.Vary(name='acbv24.l8b1', step=1e-10),
+            xt.Vary(name='acbh27.l8b1', step=1e-10),
+            xt.Vary(name='acbh25.l8b1', step=1e-10),
+        ],
+        targets=[
+            # I want the vertical orbit to be at 3 mm at mq.28l8.b1 with zero angle
+            xt.Target('y', at='mb.b28l8.b1', value=3e-3, tol=1e-4, scale=1),
+            xt.Target('py', at='mb.b28l8.b1', value=0, tol=1e-6, scale=1000),
+            # I want the bump to be closed
+            xt.Target('y', at='mq.23l8.b1', value=tw_before['y', 'mq.23l8.b1'],
+                    tol=1e-6, scale=1),
+            xt.Target('py', at='mq.23l8.b1', value=tw_before['py', 'mq.23l8.b1'],
+                    tol=1e-7, scale=1000),
+            xt.Target('x', at='mq.23l8.b1', value=tw_before['x', 'mq.23l8.b1'],
+                    tol=1e-6, scale=1),
+            xt.Target('px', at='mq.23l8.b1', value=tw_before['px', 'mq.23l8.b1'],
+                    tol=1e-7, scale=1000),
+        ]
+    )
+
+    tw = line.twiss()
+    assert np.isclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
+    assert np.isclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
+    assert np.isclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
+    assert np.isclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
+    assert np.isclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
+    assert np.isclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
+
+    # There is a bit of leakage in the horizontal plane (due to feed-down from sextupoles)
+    assert np.isclose(tw['x', 'mb.b28l8.b1'], tw_before['x', 'mb.b28l8.b1'], atol=50e-6)
+    assert np.isclose(tw['px', 'mb.b28l8.b1'], tw_before['px', 'mb.b28l8.b1'], atol=2e-6)
+    assert np.isclose(tw['x', 'mq.23l8.b1'], tw_before['x', 'mq.23l8.b1'], atol=1e-6)
+    assert np.isclose(tw['px', 'mq.23l8.b1'], tw_before['px', 'mq.23l8.b1'], atol=1e-7)
+    assert np.isclose(tw['x', 'mq.33l8.b1'], tw_before['x', 'mq.33l8.b1'], atol=1e-6)
+    assert np.isclose(tw['px', 'mq.33l8.b1'], tw_before['px', 'mq.33l8.b1'], atol=1e-7)
+
 def test_match_orbit_bump_with_weights():
 
     with open(test_data_folder /

--- a/tests/test_match_orbit_bump.py
+++ b/tests/test_match_orbit_bump.py
@@ -121,12 +121,12 @@ def test_match_orbit_bump(test_context):
 
     tini = tw_before.get_twiss_init(at_element='mq.33l8.b1')
 
-    import pdb; pdb.set_trace()
     line.match(
         ele_start='mq.33l8.b1',
         ele_stop='mq.23l8.b1',
         betx=1, bety=1,
         x=tini.x, px=tini.px, y=tini.y, py=tini.py,
+        zeta=tini.zeta, delta=tini.delta,
         vary=[
             xt.Vary(name='acbv30.l8b1', step=1e-10),
             xt.Vary(name='acbv28.l8b1', step=1e-10),

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -535,7 +535,7 @@ def test_twiss_range(test_context):
     atol_default = 1e-11
     rtol_default = 1e-9
 
-    for line_name, line in list(zip(['lhcb1', 'lhcb2'], [collider.lhcb1, collider.lhcb2]))[1:]: #### DEBUUUUUG
+    for line_name, line in zip(['lhcb1', 'lhcb2'], [collider.lhcb1, collider.lhcb2]): #### DEBUUUUUG
 
         for check in ('fw', 'bw', 'fw_kw', 'bw_kw')[2:]: #### DEBUUUUUG
 

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -535,9 +535,9 @@ def test_twiss_range(test_context):
     atol_default = 1e-11
     rtol_default = 1e-9
 
-    for line_name, line in list(zip(['lhcb1', 'lhcb2'], [collider.lhcb1, collider.lhcb2]))[1:]:
+    for line_name, line in list(zip(['lhcb1', 'lhcb2'], [collider.lhcb1, collider.lhcb2])): #### DEBUUUUUG
 
-        for check in ('fw', 'bw', 'fw_kw', 'bw_kw'):
+        for check in ('fw', 'bw', 'fw_kw', 'bw_kw'): #### DEBUUUUUG
 
             print(f'Checking {line_name} {check}')
 

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -478,7 +478,7 @@ def test_periodic_cell_twiss(test_context):
 
 
 @for_all_test_contexts
-@pytest.mark.parametrize('cycle_to', [None, ('s.ds.l6.b1', 's.ds.l6.b2')], ids=['no_cycle', 'with_cycle'])
+@pytest.mark.parametrize('cycle_to', [None, ('s.ds.l6.b1', 's.ds.l6.b2'), ('ip6', 'ip6')], ids=['no_cycle', 'cycle_arc', 'cycle_edge'])
 @pytest.mark.parametrize('line_name', ['lhcb1', 'lhcb2'])
 @pytest.mark.parametrize('check', ['fw', 'bw', 'fw_kw', 'bw_kw'])
 @pytest.mark.parametrize('init_at_edge', [True, False], ids=['init_at_edge', 'init_inside'])

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -477,16 +477,18 @@ def test_periodic_cell_twiss(test_context):
         assert np.isclose(muy_arc_from_cell, muy_arc_target, rtol=1e-6)
 
 @for_all_test_contexts
-def test_twiss_range(test_context):
-
-    loop_around = True
+@pytest.mark.parametrize('cycle_to', [None, ('s.ds.l6.b1', 's.ds.l6.b2')], ids=['no_cycle', 'with_cycle'])
+def test_twiss_range(test_context, cycle_to):
 
     collider = xt.Multiline.from_json(test_data_folder /
                     'hllhc15_collider/collider_00_from_mad.json')
 
-    if loop_around:
-        collider.lhcb1.cycle('s.ds.l6.b1', inplace=True)
-        collider.lhcb2.cycle('s.ds.l6.b2', inplace=True)
+    if cycle_to is not None:
+        collider.lhcb1.cycle(cycle_to[0], inplace=True)
+        collider.lhcb2.cycle(cycle_to[1], inplace=True)
+        loop_around = True
+    else:
+        loop_around = False
 
     collider.build_trackers(_context=test_context)
 

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -535,7 +535,7 @@ def test_twiss_range(test_context):
     atol_default = 1e-11
     rtol_default = 1e-9
 
-    for line_name, line in zip(['lhcb1', 'lhcb2'], [collider.lhcb1, collider.lhcb2]):
+    for line_name, line in list(zip(['lhcb1', 'lhcb2'], [collider.lhcb1, collider.lhcb2]))[1:]:
 
         for check in ('fw', 'bw', 'fw_kw', 'bw_kw'):
 

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -665,7 +665,10 @@ def test_twiss_range(test_context, cycle_to, line_name, check, init_at_edge):
         {'lhcb1': 'proper', 'lhcb2': 'reverse'}[line_name])
     assert tw_init_ip5.element_name == 'ip5'
 
-    if loop_around and not (line_name == 'lhcb2' and estop_user == 'ip6' and  cycle_to[1] == 'ip6'):
+    if (loop_around
+        and not (line_name == 'lhcb2' and estop_user == 'ip6' and  cycle_to[1] == 'ip6')
+        and not (line_name == 'lhcb1' and estart_user == 'ip5' and  cycle_to[1] == 'ip5')
+    ):
         tw_part1 = tw.rows[estart_user:]
         tw_part2 = tw.rows[:estop_user]
         tw_part = xt.TwissTable.concatenate([tw_part1, tw_part2])

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -487,12 +487,10 @@ def test_twiss_range(test_context):
     collider.lhcb2.twiss_default['method'] = '4d'
     collider.lhcb2.twiss_default['reverse'] = True
 
-    # collider.lhcb1['mq.10l3.b1..2'].knl[0] = 2e-6
-    # collider.lhcb1['mq.10l3.b1..2'].ksl[0] = -1.5e-6
-
-    # collider.lhcb2['mq.10l3.b2..2'].knl[0] = 3e-6
-    # collider.lhcb2['mq.10l3.b2..2'].ksl[0] = -1.3e-6
-
+    collider.vars['on_x5hs'] = 200
+    collider.vars['on_x5vs'] = 123
+    collider.vars['on_sep5h'] = 1
+    collider.vars['on_sep5v'] = 2
 
     atols = dict(
         alfx=1e-8, alfy=1e-8,

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -529,6 +529,8 @@ def test_twiss_range(test_context):
         atols['muy'] = 1e-5
         atols['nux'] = 1e-8
         atols['nuy'] = 1e-8
+        atols['dx_zeta'] = 2e-5
+        atols['dy_zeta'] = 2e-5
 
     atol_default = 1e-11
     rtol_default = 1e-9
@@ -649,11 +651,11 @@ def test_twiss_range(test_context):
                 tw_part2 = tw.rows[:'ip6']
                 tw_part = xt.TwissTable.concatenate([tw_part1, tw_part2])
                 n_0 = ('ip5' if check.startswith('fw') else 'ip6')
-                tw_part.s += tw['s', n_0] - tw_part.s[0]
-                tw_part.mux += tw['mux', n_0] - tw_part.mux[0]
-                tw_part.muy += tw['muy', n_0] - tw_part.muy[0]
-                tw_part.muzeta += tw['muzeta', n_0] - tw_part.muzeta[0]
-                tw_part.dzeta += tw['dzeta', n_0] - tw_part.dzeta[0]
+                tw_part.s += tw['s', n_0] - tw_part['s', n_0]
+                tw_part.mux += tw['mux', n_0] - tw_part['mux', n_0]
+                tw_part.muy += tw['muy', n_0] - tw_part['muy', n_0]
+                tw_part.muzeta += tw['muzeta', n_0] - tw_part['muzeta', n_0]
+                tw_part.dzeta += tw['dzeta', n_0] - tw_part['dzeta', n_0]
                 tw_part._data['method'] = '4d'
                 tw_part._data['radiation_method'] = None
                 tw_part._data['orientation'] = (

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -535,9 +535,9 @@ def test_twiss_range(test_context):
     atol_default = 1e-11
     rtol_default = 1e-9
 
-    for line_name, line in list(zip(['lhcb1', 'lhcb2'], [collider.lhcb1, collider.lhcb2])): #### DEBUUUUUG
+    for line_name, line in list(zip(['lhcb1', 'lhcb2'], [collider.lhcb1, collider.lhcb2]))[1:]: #### DEBUUUUUG
 
-        for check in ('fw', 'bw', 'fw_kw', 'bw_kw'): #### DEBUUUUUG
+        for check in ('fw', 'bw', 'fw_kw', 'bw_kw')[2:]: #### DEBUUUUUG
 
             print(f'Checking {line_name} {check}')
 

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -504,6 +504,7 @@ def test_twiss_range(test_context, cycle_to, line_name, check, init_at_edge):
     collider.vars['on_sep5v'] = 2
 
     atols = dict(
+        s=1e-10,
         zeta=5e-5,
         alfx=1e-8, alfy=1e-8,
         dzeta=1e-4, dx=1e-4, dy=1e-4, dpx=1e-5, dpy=1e-5,
@@ -554,7 +555,8 @@ def test_twiss_range(test_context, cycle_to, line_name, check, init_at_edge):
         collider.vars['on_disp'] = 0 # avoid feeddown from sextupoles
 
     if line.element_names[0] == 'ip5':
-        tw = line.twiss(co_guess={'x':1e-3, 'y':2e-3})
+        # Need to avoid the crossing bumps in closed orbit search (convergence issues)
+        tw = line.twiss(ele_co_search='ip3')
     else:
         tw = line.twiss()
 

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -478,7 +478,9 @@ def test_periodic_cell_twiss(test_context):
 
 @for_all_test_contexts
 @pytest.mark.parametrize('cycle_to', [None, ('s.ds.l6.b1', 's.ds.l6.b2')], ids=['no_cycle', 'with_cycle'])
-def test_twiss_range(test_context, cycle_to):
+@pytest.mark.parametrize('line_name', ['lhcb1', 'lhcb2'])
+@pytest.mark.parametrize('check', ['fw', 'bw', 'fw_kw', 'bw_kw'])
+def test_twiss_range(test_context, cycle_to, line_name, check):
 
     collider = xt.Multiline.from_json(test_data_folder /
                     'hllhc15_collider/collider_00_from_mad.json')
@@ -489,8 +491,6 @@ def test_twiss_range(test_context, cycle_to):
         loop_around = True
     else:
         loop_around = False
-
-    collider.build_trackers(_context=test_context)
 
     collider.lhcb1.twiss_default['method'] = '4d'
     collider.lhcb2.twiss_default['method'] = '4d'
@@ -537,173 +537,170 @@ def test_twiss_range(test_context, cycle_to):
     atol_default = 1e-11
     rtol_default = 1e-9
 
-    for line_name, line in zip(['lhcb1', 'lhcb2'], [collider.lhcb1, collider.lhcb2]): #### DEBUUUUUG
+    line = collider[line_name]
+    line.build_tracker(_context=test_context)
 
-        for check in ('fw', 'bw', 'fw_kw', 'bw_kw')[2:]: #### DEBUUUUUG
+    if not check.endswith('_kw'):
+        # Coupling is supported --> we test it
+        collider.vars['kqs.a23b1'] = 1e-4
+        collider.vars['kqs.a23b2'] = -1e-4
+    else:
+        # Coupling is not supported --> we skip it
+        collider.vars['kqs.a23b1'] = 0
+        collider.vars['kqs.a23b2'] = 0
 
-            print(f'Checking {line_name} {check}')
+    tw = line.twiss(r_sigma=0.01)
 
-            if not check.endswith('_kw'):
-                # Coupling is supported --> we test it
-                collider.vars['kqs.a23b1'] = 1e-4
-                collider.vars['kqs.a23b2'] = -1e-4
-            else:
-                # Coupling is not supported --> we skip it
-                collider.vars['kqs.a23b1'] = 0
-                collider.vars['kqs.a23b2'] = 0
+    tw_init_ip5 = tw.get_twiss_init('ip5')
+    tw_init_ip6 = tw.get_twiss_init('ip6')
 
-            tw = line.twiss(r_sigma=0.01)
+    assert np.isclose(tw_init_ip5.betx, tw['betx', 'ip5'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip5.bety, tw['bety', 'ip5'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip5.alfx, tw['alfx', 'ip5'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip5.alfy, tw['alfy', 'ip5'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip5.dx,   tw['dx', 'ip5'],   atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip5.dy,   tw['dy', 'ip5'],   atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip5.dpx,  tw['dpx', 'ip5'],  atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip5.dpy,  tw['dpy', 'ip5'],  atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip5.ax_chrom, tw['ax_chrom', 'ip5'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip5.ay_chrom, tw['ay_chrom', 'ip5'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip5.bx_chrom, tw['bx_chrom', 'ip5'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip5.by_chrom, tw['by_chrom', 'ip5'], atol=0, rtol=1e-7)
 
-            tw_init_ip5 = tw.get_twiss_init('ip5')
-            tw_init_ip6 = tw.get_twiss_init('ip6')
+    assert np.isclose(tw_init_ip6.betx, tw['betx', 'ip6'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip6.bety, tw['bety', 'ip6'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip6.alfx, tw['alfx', 'ip6'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip6.alfy, tw['alfy', 'ip6'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip6.dx,   tw['dx', 'ip6'],   atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip6.dy,   tw['dy', 'ip6'],   atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip6.dpx,  tw['dpx', 'ip6'],  atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip6.dpy,  tw['dpy', 'ip6'],  atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip6.ax_chrom, tw['ax_chrom', 'ip6'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip6.ay_chrom, tw['ay_chrom', 'ip6'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip6.bx_chrom, tw['bx_chrom', 'ip6'], atol=0, rtol=1e-7)
+    assert np.isclose(tw_init_ip6.by_chrom, tw['by_chrom', 'ip6'], atol=0, rtol=1e-7)
 
-            assert np.isclose(tw_init_ip5.betx, tw['betx', 'ip5'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip5.bety, tw['bety', 'ip5'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip5.alfx, tw['alfx', 'ip5'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip5.alfy, tw['alfy', 'ip5'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip5.dx,   tw['dx', 'ip5'],   atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip5.dy,   tw['dy', 'ip5'],   atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip5.dpx,  tw['dpx', 'ip5'],  atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip5.dpy,  tw['dpy', 'ip5'],  atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip5.ax_chrom, tw['ax_chrom', 'ip5'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip5.ay_chrom, tw['ay_chrom', 'ip5'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip5.bx_chrom, tw['bx_chrom', 'ip5'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip5.by_chrom, tw['by_chrom', 'ip5'], atol=0, rtol=1e-7)
+    if check == 'fw':
+        tw_test = line.twiss(ele_start='ip5', ele_stop='ip6',
+                                twiss_init=tw_init_ip5)
+    elif check == 'bw':
+        tw_test = line.twiss(ele_start='ip5', ele_stop='ip6',
+                                    twiss_init=tw_init_ip6)
+    elif check == 'fw_kw':
+        tw_test = line.twiss(ele_start='ip5', ele_stop='ip6',
+                            ele_init='ip5',
+                            x=tw['x', 'ip5'],
+                            px=tw['px', 'ip5'],
+                            y=tw['y', 'ip5'],
+                            py=tw['py', 'ip5'],
+                            zeta=tw['zeta', 'ip5'],
+                            delta=tw['delta', 'ip5'],
+                            betx=tw['betx', 'ip5'],
+                            alfx=tw['alfx', 'ip5'],
+                            bety=tw['bety', 'ip5'],
+                            alfy=tw['alfy', 'ip5'],
+                            dx=tw['dx', 'ip5'],
+                            dpx=tw['dpx', 'ip5'],
+                            dy=tw['dy', 'ip5'],
+                            dpy=tw['dpy', 'ip5'],
+                            dzeta=tw['dzeta', 'ip5'],
+                            mux=tw['mux', 'ip5'],
+                            muy=tw['muy', 'ip5'],
+                            muzeta=tw['muzeta', 'ip5'],
+                            ax_chrom=tw['ax_chrom', 'ip5'],
+                            bx_chrom=tw['bx_chrom', 'ip5'],
+                            ay_chrom=tw['ay_chrom', 'ip5'],
+                            by_chrom=tw['by_chrom', 'ip5'],
+                                )
+    elif check == 'bw_kw':
+        tw_test = line.twiss(ele_start='ip5', ele_stop='ip6',
+                            ele_init='ip6',
+                            x=tw['x', 'ip6'],
+                            px=tw['px', 'ip6'],
+                            y=tw['y', 'ip6'],
+                            py=tw['py', 'ip6'],
+                            zeta=tw['zeta', 'ip6'],
+                            delta=tw['delta', 'ip6'],
+                            betx=tw['betx', 'ip6'],
+                            alfx=tw['alfx', 'ip6'],
+                            bety=tw['bety', 'ip6'],
+                            alfy=tw['alfy', 'ip6'],
+                            dx=tw['dx', 'ip6'],
+                            dpx=tw['dpx', 'ip6'],
+                            dy=tw['dy', 'ip6'],
+                            dpy=tw['dpy', 'ip6'],
+                            dzeta=tw['dzeta', 'ip6'],
+                            mux=tw['mux', 'ip6'],
+                            muy=tw['muy', 'ip6'],
+                            muzeta=tw['muzeta', 'ip6'],
+                            ax_chrom=tw['ax_chrom', 'ip6'],
+                            bx_chrom=tw['bx_chrom', 'ip6'],
+                            ay_chrom=tw['ay_chrom', 'ip6'],
+                            by_chrom=tw['by_chrom', 'ip6'],
+                            )
+    else:
+        raise ValueError(f'Unknown config {check}')
 
-            assert np.isclose(tw_init_ip6.betx, tw['betx', 'ip6'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip6.bety, tw['bety', 'ip6'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip6.alfx, tw['alfx', 'ip6'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip6.alfy, tw['alfy', 'ip6'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip6.dx,   tw['dx', 'ip6'],   atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip6.dy,   tw['dy', 'ip6'],   atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip6.dpx,  tw['dpx', 'ip6'],  atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip6.dpy,  tw['dpy', 'ip6'],  atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip6.ax_chrom, tw['ax_chrom', 'ip6'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip6.ay_chrom, tw['ay_chrom', 'ip6'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip6.bx_chrom, tw['bx_chrom', 'ip6'], atol=0, rtol=1e-7)
-            assert np.isclose(tw_init_ip6.by_chrom, tw['by_chrom', 'ip6'], atol=0, rtol=1e-7)
+    assert tw_init_ip5.reference_frame == (
+        {'lhcb1': 'proper', 'lhcb2': 'reverse'}[line_name])
+    assert tw_init_ip5.element_name == 'ip5'
 
-            if check == 'fw':
-                tw_test = line.twiss(ele_start='ip5', ele_stop='ip6',
-                                        twiss_init=tw_init_ip5)
-            elif check == 'bw':
-                tw_test = line.twiss(ele_start='ip5', ele_stop='ip6',
-                                            twiss_init=tw_init_ip6)
-            elif check == 'fw_kw':
-                tw_test = line.twiss(ele_start='ip5', ele_stop='ip6',
-                                    ele_init='ip5',
-                                    x=tw['x', 'ip5'],
-                                    px=tw['px', 'ip5'],
-                                    y=tw['y', 'ip5'],
-                                    py=tw['py', 'ip5'],
-                                    zeta=tw['zeta', 'ip5'],
-                                    delta=tw['delta', 'ip5'],
-                                    betx=tw['betx', 'ip5'],
-                                    alfx=tw['alfx', 'ip5'],
-                                    bety=tw['bety', 'ip5'],
-                                    alfy=tw['alfy', 'ip5'],
-                                    dx=tw['dx', 'ip5'],
-                                    dpx=tw['dpx', 'ip5'],
-                                    dy=tw['dy', 'ip5'],
-                                    dpy=tw['dpy', 'ip5'],
-                                    dzeta=tw['dzeta', 'ip5'],
-                                    mux=tw['mux', 'ip5'],
-                                    muy=tw['muy', 'ip5'],
-                                    muzeta=tw['muzeta', 'ip5'],
-                                    ax_chrom=tw['ax_chrom', 'ip5'],
-                                    bx_chrom=tw['bx_chrom', 'ip5'],
-                                    ay_chrom=tw['ay_chrom', 'ip5'],
-                                    by_chrom=tw['by_chrom', 'ip5'],
-                                        )
-            elif check == 'bw_kw':
-                tw_test = line.twiss(ele_start='ip5', ele_stop='ip6',
-                                    ele_init='ip6',
-                                    x=tw['x', 'ip6'],
-                                    px=tw['px', 'ip6'],
-                                    y=tw['y', 'ip6'],
-                                    py=tw['py', 'ip6'],
-                                    zeta=tw['zeta', 'ip6'],
-                                    delta=tw['delta', 'ip6'],
-                                    betx=tw['betx', 'ip6'],
-                                    alfx=tw['alfx', 'ip6'],
-                                    bety=tw['bety', 'ip6'],
-                                    alfy=tw['alfy', 'ip6'],
-                                    dx=tw['dx', 'ip6'],
-                                    dpx=tw['dpx', 'ip6'],
-                                    dy=tw['dy', 'ip6'],
-                                    dpy=tw['dpy', 'ip6'],
-                                    dzeta=tw['dzeta', 'ip6'],
-                                    mux=tw['mux', 'ip6'],
-                                    muy=tw['muy', 'ip6'],
-                                    muzeta=tw['muzeta', 'ip6'],
-                                    ax_chrom=tw['ax_chrom', 'ip6'],
-                                    bx_chrom=tw['bx_chrom', 'ip6'],
-                                    ay_chrom=tw['ay_chrom', 'ip6'],
-                                    by_chrom=tw['by_chrom', 'ip6'],
-                                    )
-            else:
-                raise ValueError(f'Unknown config {check}')
+    if loop_around:
+        tw_part1 = tw.rows['ip5':]
+        tw_part2 = tw.rows[:'ip6']
+        tw_part = xt.TwissTable.concatenate([tw_part1, tw_part2])
+        n_0 = ('ip5' if check.startswith('fw') else 'ip6')
+        tw_part.s += tw['s', n_0] - tw_part['s', n_0]
+        tw_part.mux += tw['mux', n_0] - tw_part['mux', n_0]
+        tw_part.muy += tw['muy', n_0] - tw_part['muy', n_0]
+        tw_part.muzeta += tw['muzeta', n_0] - tw_part['muzeta', n_0]
+        tw_part.dzeta += tw['dzeta', n_0] - tw_part['dzeta', n_0]
+        tw_part._data['method'] = '4d'
+        tw_part._data['radiation_method'] = None
+        tw_part._data['orientation'] = (
+            {'lhcb1': 'forward', 'lhcb2': 'backward'}[line_name])
+    else:
+        tw_part = tw.rows['ip5':'ip6']
+    assert tw_part.name[0] == 'ip5'
+    assert tw_part.name[-1] == 'ip6'
 
-            assert tw_init_ip5.reference_frame == (
-                {'lhcb1': 'proper', 'lhcb2': 'reverse'}[line_name])
-            assert tw_init_ip5.element_name == 'ip5'
+    assert tw_test.name[-1] == '_end_point'
 
-            if loop_around:
-                tw_part1 = tw.rows['ip5':]
-                tw_part2 = tw.rows[:'ip6']
-                tw_part = xt.TwissTable.concatenate([tw_part1, tw_part2])
-                n_0 = ('ip5' if check.startswith('fw') else 'ip6')
-                tw_part.s += tw['s', n_0] - tw_part['s', n_0]
-                tw_part.mux += tw['mux', n_0] - tw_part['mux', n_0]
-                tw_part.muy += tw['muy', n_0] - tw_part['muy', n_0]
-                tw_part.muzeta += tw['muzeta', n_0] - tw_part['muzeta', n_0]
-                tw_part.dzeta += tw['dzeta', n_0] - tw_part['dzeta', n_0]
-                tw_part._data['method'] = '4d'
-                tw_part._data['radiation_method'] = None
-                tw_part._data['orientation'] = (
-                    {'lhcb1': 'forward', 'lhcb2': 'backward'}[line_name])
-            else:
-                tw_part = tw.rows['ip5':'ip6']
-            assert tw_part.name[0] == 'ip5'
-            assert tw_part.name[-1] == 'ip6'
+    tw_test = tw_test.rows[:-1]
+    assert np.all(tw_test.name == tw_part.name)
 
-            assert tw_test.name[-1] == '_end_point'
+    for kk in tw_test._data.keys():
+        if kk in ['name', 'W_matrix', 'particle_on_co', 'values_at',
+                    'method', 'radiation_method', 'reference_frame',
+                    'orientation', 'steps_r_matrix', 'line_config',
+                    'loop_around'
+                    ]:
+            continue # some tested separately
+        atol = atols.get(kk, atol_default)
+        rtol = rtols.get(kk, rtol_default)
+        assert np.allclose(
+            tw_test._data[kk], tw_part._data[kk], rtol=rtol, atol=atol)
 
-            tw_test = tw_test.rows[:-1]
-            assert np.all(tw_test.name == tw_part.name)
+    assert tw_test.values_at == tw_part.values_at == 'entry'
+    assert tw_test.method == tw_part.method == '4d'
+    assert tw_test.radiation_method == tw_part.radiation_method == None
+    assert tw_test.reference_frame == tw_part.reference_frame == (
+        {'lhcb1': 'proper', 'lhcb2': 'reverse'}[line_name])
 
-            for kk in tw_test._data.keys():
-                if kk in ['name', 'W_matrix', 'particle_on_co', 'values_at',
-                            'method', 'radiation_method', 'reference_frame',
-                            'orientation', 'steps_r_matrix', 'line_config',
-                            'loop_around'
-                            ]:
-                    continue # some tested separately
-                atol = atols.get(kk, atol_default)
-                rtol = rtols.get(kk, rtol_default)
-                assert np.allclose(
-                    tw_test._data[kk], tw_part._data[kk], rtol=rtol, atol=atol)
+    if not check.endswith('_kw') and not loop_around:
 
-            assert tw_test.values_at == tw_part.values_at == 'entry'
-            assert tw_test.method == tw_part.method == '4d'
-            assert tw_test.radiation_method == tw_part.radiation_method == None
-            assert tw_test.reference_frame == tw_part.reference_frame == (
-                {'lhcb1': 'proper', 'lhcb2': 'reverse'}[line_name])
+        W_matrix_part = tw_part.W_matrix
+        W_matrix_test = tw_test.W_matrix
 
-            if not check.endswith('_kw') and not loop_around:
+        rel_error = []
+        for ss in range(W_matrix_part.shape[0]):
+            this_part = W_matrix_part[ss, :, :]
+            this_test = W_matrix_test[ss, :, :]
 
-                W_matrix_part = tw_part.W_matrix
-                W_matrix_test = tw_test.W_matrix
-
-                rel_error = []
-                for ss in range(W_matrix_part.shape[0]):
-                    this_part = W_matrix_part[ss, :, :]
-                    this_test = W_matrix_test[ss, :, :]
-
-                    for ii in range(this_part.shape[0]):
-                        rel_error.append((np.linalg.norm(this_part[ii, :] - this_test[ii, :])
-                                        /np.linalg.norm(this_part[ii, :])))
-                assert np.max(rel_error) < 1e-3
+            for ii in range(this_part.shape[0]):
+                rel_error.append((np.linalg.norm(this_part[ii, :] - this_test[ii, :])
+                                /np.linalg.norm(this_part[ii, :])))
+        assert np.max(rel_error) < 1e-3
 
 @for_all_test_contexts
 def test_twiss_against_matrix(test_context):

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -1256,7 +1256,8 @@ class Line:
                           continue_on_closed_orbit_error=False,
                           freeze_longitudinal=False,
                           ele_start=None, ele_stop=None,
-                          num_turns=1):
+                          num_turns=1,
+                          ele_co_search=None):
 
         """
         Find the closed orbit of the beamline.
@@ -1290,6 +1291,11 @@ class Line:
         ele_stop : int or str
             Optional. It can be provided to find the periodic solution for
             a portion of the beamline.
+        num_turns : int
+            Number of turns to be used for the closed orbit search.
+        ele_co_search : int or str
+            Element at which the closed orbit search is performed. If None,
+            the closed orbit search is performed at the start of the line.
 
         Returns
         -------
@@ -1323,7 +1329,8 @@ class Line:
                                  particle_ref=particle_ref, delta0=delta0, zeta0=zeta0,
                                  co_search_settings=co_search_settings, delta_zeta=delta_zeta,
                                  continue_on_closed_orbit_error=continue_on_closed_orbit_error,
-                                 ele_start=ele_start, ele_stop=ele_stop, num_turns=num_turns)
+                                 ele_start=ele_start, ele_stop=ele_stop, num_turns=num_turns,
+                                 ele_co_search=ele_co_search)
 
     def compute_T_matrix(self, ele_start=None, ele_stop=None,
                          particle_on_co=None, steps_t_matrix=None):

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -1008,6 +1008,7 @@ class Line:
         dx=None, dpx=None, dy=None, dpy=None, dzeta=None,
         mux=None, muy=None, muzeta=None,
         ax_chrom=None, bx_chrom=None, ay_chrom=None, by_chrom=None,
+        ele_co_search=None,
         _continue_if_lost=None,
         _keep_tracking_data=None,
         _keep_initial_particles=None,

--- a/xtrack/match.py
+++ b/xtrack/match.py
@@ -101,12 +101,10 @@ class ActionTwiss(xd.Action):
             line_list = [line]
             table_for_twinit_list = [self.table_for_twiss_init]
 
-            _keep_ini_particles_list = [False] * len(twinit_list)
             for ii, (twinit, ele_start, ele_stop) in enumerate(zip(
                     twinit_list, ele_start_list, ele_stop_list)):
                 if isinstance(twinit, xt.TwissInit):
                     twinit_list[ii] = twinit.copy()
-                    _keep_ini_particles_list[ii] = True
                 elif isinstance(twinit, str):
                     assert twinit in (
                         ['preserve', 'preserve_start', 'preserve_end', 'periodic'])
@@ -126,7 +124,6 @@ class ActionTwiss(xd.Action):
                             init_at = ele_stop
                         assert not isinstance(tab_twinit, xt.MultiTwiss)
                         twinit_list[ii] = tab_twinit.get_twiss_init(at_element=init_at)
-                        _keep_ini_particles_list[ii] = True
 
         if not ismultiline:
             # Handle case in which twiss init is defined through kwargs
@@ -165,7 +162,14 @@ class ActionTwiss(xd.Action):
                 if kk in kwargs:
                     kwargs.pop(kk)
             twinit_list[0] = twiss_init
-            _keep_ini_particles_list[ii] = True
+
+        _keep_ini_particles_list = []
+        for tt in twinit_list:
+            _keep_ini_particles_list.append(isinstance(tt, xt.TwissInit))
+
+        for ii, tt in enumerate(twinit_list):
+            if isinstance(tt, xt.TwissInit):
+                twinit_list[ii] = tt.copy()
 
         for twini, ln, eest in zip(twinit_list, line_list, ele_start_list):
             if isinstance(twini, xt.TwissInit) and twini._needs_complete():

--- a/xtrack/match.py
+++ b/xtrack/match.py
@@ -75,11 +75,12 @@ class ActionTwiss(xd.Action):
 
         # Handle twiss_init from table or preserve
         if ismultiline:
-            none_list = [None] * len(line.line_names)
+            assert 'lines' in kwargs, ("`lines` must be provided to Multiline.match")
+            line_names = kwargs.get('lines', line.line_names)
+            none_list = [None] * len(line_names)
             twinit_list = kwargs.get('twiss_init', none_list)
             ele_start_list = kwargs.get('ele_start', none_list)
             ele_stop_list = kwargs.get('ele_stop', none_list)
-            line_names = kwargs.get('lines', line.line_names)
             line_list = [line[nn] for nn in line_names]
             assert isinstance(twinit_list, list)
             assert isinstance(ele_start_list, list)

--- a/xtrack/match.py
+++ b/xtrack/match.py
@@ -75,7 +75,6 @@ class ActionTwiss(xd.Action):
 
         # Handle twiss_init from table or preserve
         if ismultiline:
-            assert 'lines' in kwargs, ("`lines` must be provided to Multiline.match")
             line_names = kwargs.get('lines', line.line_names)
             none_list = [None] * len(line_names)
             twinit_list = kwargs.get('twiss_init', none_list)

--- a/xtrack/match.py
+++ b/xtrack/match.py
@@ -62,7 +62,6 @@ class ActionTwiss(xd.Action):
     def prepare(self):
         line = self.line
         kwargs = self.kwargs
-        import pdb; pdb.set_trace()
 
         ismultiline = isinstance(line, xt.Multiline)
 

--- a/xtrack/multiline/multiline.py
+++ b/xtrack/multiline/multiline.py
@@ -541,6 +541,7 @@ class MultiTwiss(dict):
 def _dispatch_twiss_kwargs(kwargs, lines):
     kwargs_per_twiss = {}
     for arg_name in ['ele_start', 'ele_stop', 'twiss_init',
+                        '_keep_initial_particles',
                         '_initial_particles', '_ebe_monitor']:
         if arg_name not in kwargs:
             continue

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -1867,11 +1867,26 @@ def find_closed_orbit_line(line, co_guess=None, particle_ref=None,
                       co_search_settings=None, delta_zeta=0,
                       delta0=None, zeta0=None,
                       ele_start=None, ele_stop=None, num_turns=1,
+                      ele_co_search=None,
                       continue_on_closed_orbit_error=False):
 
     if line.enable_time_dependent_vars:
         raise RuntimeError(
             'Time-dependent vars not supported in closed orbit search')
+
+    if ele_start is not None and ele_stop is not None:
+        ele_co_search = None # needs to be implemented
+
+    if ele_co_search is not None:
+        kwargs = locals().copy()
+        kwargs.pop('ele_start')
+        kwargs.pop('ele_stop')
+        kwargs.pop('ele_co_search')
+        p_co_at_ele_co_search = find_closed_orbit_line(
+            ele_start=ele_co_search, ele_stop=ele_co_search,
+            **kwargs)
+        line.track(p_co_at_ele_co_search, ele_start=ele_co_search, ele_stop=0)
+        return p_co_at_ele_co_search
 
     if isinstance(ele_start, str):
         ele_start = line.element_names.index(ele_start)

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -1179,8 +1179,8 @@ def _compute_chromatic_functions(line, twiss_init, delta_chrom, steps_r_matrix,
         part_chrom = xp.build_particles(
                 _context=line._context,
                 x_norm=0,
-                zeta=tw_init_chrom._xobject.zeta[0],
-                delta=part_co._xobject.delta[0] + dd,
+                zeta=tw_init_chrom.zeta,
+                delta=tw_init_chrom.delta+ dd,
                 particle_on_co=part_co,
                 nemitt_x=nemitt_x, nemitt_y=nemitt_y,
                 W_matrix=tw_init_chrom.W_matrix)

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -2512,11 +2512,13 @@ class TwissInit:
         if name in self.__dict__:
             return self.__dict__[name]
         elif hasattr(self.__dict__['particle_on_co'], name):
-            # e.g. tw_init['x'] returns tw_init.particle_on_co.x[0]
-            pco = self.__dict__['particle_on_co']
-            pctx = pco._context
-            out = pctx.nparray_from_context_array(
-                getattr(self.__dict__['particle_on_co'], name))[0]
+            # e.g. tw_init['x'] returns tw_init.particle_on_co.x
+            out = getattr(self.__dict__['particle_on_co'], name)
+            #always cpu
+            if hasattr(out, 'get'):
+                out = out.get()
+            if hasattr(out, '__iter__'):
+                out = out [0]
             return out
         else:
             raise AttributeError(f'No attribute {name} found in TwissInit')

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -1760,6 +1760,8 @@ def _find_periodic_solution(line, particle_on_co, particle_ref, method,
 
 def _handle_loop_around(kwargs):
 
+    import pdb; pdb.set_trace()
+
     kwargs = kwargs.copy()
 
     twiss_init = kwargs.pop('twiss_init')
@@ -1771,7 +1773,7 @@ def _handle_loop_around(kwargs):
 
     ele_name_init = twiss_init.element_name
 
-    # import pdb; pdb.set_trace()
+    import pdb; pdb.set_trace()
 
     # if reversed, elements in the line are sorted opposite to the twiss table
     if not reverse:
@@ -2371,6 +2373,8 @@ class TwissInit:
 
     def _complete(self, line, element_name):
 
+        import pdb; pdb.set_trace()
+
         if (line is not None and 'reverse' in line.twiss_default
             and line.twiss_default['reverse']):
             input_reversed = True
@@ -2387,7 +2391,10 @@ class TwissInit:
             s_ele_in_line = line.tracker._tracker_data_base.element_s_locations[i_ele_in_line]
 
             if input_reversed:
-                s_ele_twiss = line.tracker._tracker_data_base.element_s_locations[-1] - s_ele_in_line
+                s_ele_twiss = line.tracker._tracker_data_base.line_length - s_ele_in_line
+                first_ele = line[i_ele_in_line]
+                if hasattr(first_ele, 'isthick') and first_ele.isthick:
+                    s_ele_twiss -= first_ele.length
             else:
                 s_ele_twiss = s_ele_in_line
 

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -36,6 +36,14 @@ DEFAULT_MATRIX_STABILITY_TOL = 2e-3
 
 AT_TURN_FOR_TWISS = -10 # # To avoid writing in monitors installed in the line
 
+VARS_FOR_TWISS_INIT_GENERATION = [
+    'x', 'px', 'y', 'py', 'zeta', 'delta',
+    'betx', 'alfx', 'bety', 'alfy', 'bets',
+    'dx', 'dpx', 'dy', 'dpy', 'dzeta',
+    'mux', 'muy', 'muzeta',
+    'ax_chrom', 'bx_chrom', 'ay_chrom', 'by_chrom',
+]
+
 log = logging.getLogger(__name__)
 
 def twiss_line(line, particle_ref=None, method=None,
@@ -2973,14 +2981,16 @@ def _complete_twiss_init(ele_start, ele_stop, ele_init, twiss_init,
                     element_name=(twiss_init.element_name or ele_start))
 
         if twiss_init.reference_frame is None:
-            twiss_init.reference_frame = {True: 'reverse', False: 'proper'}[reverse]
+            twiss_init.reference_frame = {
+                True: 'reverse', False: 'proper', None: None}[reverse]
 
-        if twiss_init.reference_frame == 'proper':
-            assert not(reverse), ('`twiss_init` needs to be given in the '
-                'proper reference frame when `reverse` is False')
-        elif twiss_init is not None and twiss_init.reference_frame == 'reverse':
-            assert reverse is True, ('`twiss_init` needs to be given in the '
-                'reverse reference frame when `reverse` is True')
+        if reverse is not None:
+            if twiss_init.reference_frame == 'proper':
+                assert not(reverse), ('`twiss_init` needs to be given in the '
+                    'proper reference frame when `reverse` is False')
+            elif twiss_init is not None and twiss_init.reference_frame == 'reverse':
+                assert reverse is True, ('`twiss_init` needs to be given in the '
+                    'reverse reference frame when `reverse` is True')
 
     return twiss_init
 

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -289,8 +289,6 @@ def twiss_line(line, particle_ref=None, method=None,
 
     kwargs = locals().copy()
 
-    ele_start_user = ele_start
-
     if num_turns != 1:
         # Untested cases
         assert num_turns > 0
@@ -379,7 +377,7 @@ def twiss_line(line, particle_ref=None, method=None,
         raise RuntimeError('Time dependent variables not supported in Twiss')
 
     twiss_init = _complete_twiss_init(
-        ele_start, ele_stop, ele_init, ele_start_user, twiss_init,
+        ele_start, ele_stop, ele_init, twiss_init,
         line, reverse,
         x, px, y, py, zeta, delta,
         alfx, alfy, betx, bety, bets,
@@ -2926,7 +2924,7 @@ class TwissTable(Table):
 
         return new_table
 
-def _complete_twiss_init(ele_start, ele_stop, ele_init, ele_start_user, twiss_init,
+def _complete_twiss_init(ele_start, ele_stop, ele_init, twiss_init,
                         line, reverse,
                         x, px, y, py, zeta, delta,
                         alfx, alfy, betx, bety, bets,
@@ -2968,11 +2966,11 @@ def _complete_twiss_init(ele_start, ele_stop, ele_init, ele_start_user, twiss_in
     if twiss_init is not None and not isinstance(twiss_init, str):
         twiss_init = twiss_init.copy() # To avoid changing the one provided
         if twiss_init._needs_complete():
-            assert isinstance(ele_start_user, str), (
+            assert isinstance(ele_start, str), (
                 'ele_start must be provided as name when an incomplete '
                 'twiss_init is provided')
             twiss_init._complete(line=line,
-                    element_name=(twiss_init.element_name or ele_start_user))
+                    element_name=(twiss_init.element_name or ele_start))
 
         if twiss_init.reference_frame is None:
             twiss_init.reference_frame = {True: 'reverse', False: 'proper'}[reverse]

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -521,6 +521,8 @@ def twiss_line(line, particle_ref=None, method=None,
 
     if periodic:
 
+        assert not _keep_initial_particles
+
         steps_r_matrix = _complete_steps_r_matrix_with_default(steps_r_matrix)
 
         twiss_init, R_matrix, steps_r_matrix, eigenvalues, Rot, RR_ebe = _find_periodic_solution(
@@ -554,8 +556,6 @@ def twiss_line(line, particle_ref=None, method=None,
     if only_markers and eneloss_and_damping:
         raise NotImplementedError(
             '`only_markers` not implemented for `eneloss_and_damping`')
-
-
 
     twiss_res = _twiss_open(
         line=line,

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -1760,8 +1760,6 @@ def _find_periodic_solution(line, particle_on_co, particle_ref, method,
 
 def _handle_loop_around(kwargs):
 
-    import pdb; pdb.set_trace()
-
     kwargs = kwargs.copy()
 
     twiss_init = kwargs.pop('twiss_init')
@@ -1772,8 +1770,6 @@ def _handle_loop_around(kwargs):
     reverse = kwargs['reverse']
 
     ele_name_init = twiss_init.element_name
-
-    import pdb; pdb.set_trace()
 
     # if reversed, elements in the line are sorted opposite to the twiss table
     if not reverse:
@@ -2372,8 +2368,6 @@ class TwissInit:
         return cls.from_dict(dct)
 
     def _complete(self, line, element_name):
-
-        import pdb; pdb.set_trace()
 
         if (line is not None and 'reverse' in line.twiss_default
             and line.twiss_default['reverse']):

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -1782,7 +1782,7 @@ def _handle_loop_around(kwargs):
     if not reverse:
         assert _str_to_index(line, ele_stop) < _str_to_index(line, ele_start), (
             'This function should not have been called')
-        if _str_to_index(line, ele_name_init) == _str_to_index(line, ele_start):
+        if _str_to_index(line, ele_name_init) >= _str_to_index(line, ele_start):
             tw1 = twiss_line(ele_start=ele_start,
                             ele_stop=len(line) - 1,
                             twiss_init=twiss_init, **kwargs)
@@ -1790,7 +1790,7 @@ def _handle_loop_around(kwargs):
             twini_2.element_name = line.element_names[0]
             tw2 = twiss_line(ele_start=line.element_names[0], ele_stop=ele_stop,
                                     twiss_init=twini_2, **kwargs)
-        elif _str_to_index(line, ele_name_init) == _str_to_index(line, ele_stop):
+        elif _str_to_index(line, ele_name_init) <= _str_to_index(line, ele_stop):
             tw2 = twiss_line(ele_start=line.element_names[0], ele_stop=ele_stop,
                                 twiss_init=twiss_init, **kwargs)
             twini_1 = tw2.get_twiss_init(at_element=line.element_names[0])
@@ -1803,7 +1803,7 @@ def _handle_loop_around(kwargs):
     else: # reversed
         assert _str_to_index(line, ele_stop) > _str_to_index(line, ele_start), (
             'This function should not have been called')
-        if _str_to_index(line, ele_name_init) == _str_to_index(line, ele_start):
+        if _str_to_index(line, ele_name_init) <= _str_to_index(line, ele_start):
             tw1 = twiss_line(ele_start=ele_start,
                             ele_stop=line.element_names[0],
                             twiss_init=twiss_init, **kwargs)
@@ -1811,7 +1811,7 @@ def _handle_loop_around(kwargs):
             twini_2.element_name = line.element_names[-1]
             tw2 = twiss_line(ele_start=line.element_names[-1], ele_stop=ele_stop,
                                     twiss_init=twini_2, **kwargs)
-        elif _str_to_index(line, ele_name_init) == _str_to_index(line, ele_stop):
+        elif _str_to_index(line, ele_name_init) >= _str_to_index(line, ele_stop):
             tw2 = twiss_line(ele_start=line.element_names[-1], ele_stop=ele_stop,
                                 twiss_init=twiss_init, **kwargs)
             twini_1 = tw2.get_twiss_init(at_element=line.element_names[-1])

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -399,8 +399,6 @@ def twiss_line(line, particle_ref=None, method=None,
     if not periodic and (
         rv * _str_to_index(line, ele_start) > rv * _str_to_index(line, ele_stop)):
 
-        raise NotImplementedError # Needs testing
-
         kwargs = _updated_kwargs_from_locals(kwargs, locals().copy())
         tw_res = _handle_loop_around(kwargs)
 
@@ -1775,40 +1773,21 @@ def _handle_loop_around(kwargs):
         estop_tw2 = ele_stop
 
     if rv * _str_to_index(line, ele_name_init) >= rv * _str_to_index(line, ele_start):
-        if estart_tw1 != estop_tw1:
-            tw1 = twiss_line(ele_start=estart_tw1, ele_stop=estop_tw1,
-                                twiss_init=twiss_init, **kwargs)
-            twini_2 = tw1.get_twiss_init(at_element=estop_tw1)
-        else:
-            tw1 = None
-            twini_2 = twiss_init.copy()
+        tw1 = twiss_line(ele_start=estart_tw1, ele_stop=estop_tw1,
+                            twiss_init=twiss_init, **kwargs)
+        twini_2 = tw1.get_twiss_init(at_element=estop_tw1)
         twini_2.element_name = estart_tw2
-        if estart_tw2 != estop_tw2:
-            tw2 = twiss_line(ele_start=estart_tw2, ele_stop=estop_tw2,
+        tw2 = twiss_line(ele_start=estart_tw2, ele_stop=estop_tw2,
                                 twiss_init=twini_2, **kwargs)
-        else:
-            tw2 = None
     else:
-        if estart_tw2 != estop_tw2:
-            tw2 = twiss_line(ele_start=estart_tw2, ele_stop=estop_tw2,
-                                twiss_init=twiss_init, **kwargs)
-            twini_1 = tw2.get_twiss_init(at_element=estart_tw2)
-        else:
-            tw2 = None
-            twini_1 = twiss_init.copy()
+        tw2 = twiss_line(ele_start=estart_tw2, ele_stop=estop_tw2,
+                            twiss_init=twiss_init, **kwargs)
+        twini_1 = tw2.get_twiss_init(at_element=estart_tw2)
         twini_1.element_name = estop_tw1
-        if estart_tw1 != estop_tw1:
-            tw1 = twiss_line(ele_start=estart_tw1, ele_stop=estop_tw1,
-                                twiss_init=twini_1, **kwargs)
-        else:
-            tw1 = None
+        tw1 = twiss_line(ele_start=estart_tw1, ele_stop=estop_tw1,
+                            twiss_init=twini_1, **kwargs)
 
-    if tw1 is None:
-        tw_res = tw2
-    elif tw2 is None:
-        tw_res = tw1
-    else:
-        tw_res = TwissTable.concatenate([tw1, tw2])
+    tw_res = TwissTable.concatenate([tw1, tw2])
 
     tw_res.s -= tw_res['s', ele_name_init] - twiss_init.s
     tw_res.mux -= tw_res['mux', ele_name_init] - twiss_init.mux

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -768,6 +768,8 @@ def _twiss_open(line, twiss_init,
 
     if twiss_init.element_name == line.element_names[ele_start]:
         twiss_orientation = 'forward'
+    elif twiss_init.element_name == '_end_point' and ele_stop == len(line.element_names) - 1:
+        twiss_orientation = 'backward'
     elif ele_stop is not None and twiss_init.element_name == line.element_names[ele_stop]:
         twiss_orientation = 'backward'
         assert isinstance(line.element_dict[line.element_names[ele_stop]], xt.Marker) # to start one downstream without having to track
@@ -802,7 +804,7 @@ def _twiss_open(line, twiss_init,
             part_for_twiss.at_element = ele_start
             part_for_twiss.s = line.tracker._tracker_data_base.element_s_locations[ele_start]
         elif twiss_orientation == 'backward':
-            part_for_twiss.at_element = ele_stop + 1 # to include the last element (assume it is a marker)
+            part_for_twiss.at_element = ele_stop + 1 # to include the last element
             part_for_twiss.s = line.tracker._tracker_data_base.element_s_locations[ele_stop]
         else:
             raise ValueError('Invalid twiss_orientation')
@@ -1778,8 +1780,9 @@ def _handle_loop_around(kwargs):
         estop_tw2 = ele_stop
 
     if rv * _str_to_index(line, ele_name_init) >= rv * _str_to_index(line, ele_start):
-        tw1 = twiss_line(ele_start=estart_tw1, ele_stop=estop_tw1,
-                            twiss_init=twiss_init, **kwargs)
+        tw1 = twiss_line(ele_start=estart_tw1,
+                         ele_stop=(len(line) - 1 if estop_tw1 == '_end_point' else estop_tw1),
+                         twiss_init=twiss_init, **kwargs)
         twini_2 = tw1.get_twiss_init(at_element=estop_tw1)
         twini_2.element_name = estart_tw2
         tw2 = twiss_line(ele_start=estart_tw2, ele_stop=estop_tw2,

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -780,7 +780,6 @@ def _twiss_open(line, twiss_init,
         twiss_orientation = 'backward'
     elif ele_stop is not None and twiss_init.element_name == line.element_names[ele_stop]:
         twiss_orientation = 'backward'
-        # assert isinstance(line.element_dict[line.element_names[ele_stop]], xt.Marker) # to start one downstream without having to track
     else:
         raise ValueError(
             '`twiss_init` must be given at the start or end of the specified element range.')
@@ -1808,12 +1807,11 @@ def _handle_loop_around(kwargs):
             tw2 = twiss_line(ele_start=line.element_names[-1], ele_stop=ele_stop,
                                     twiss_init=twini_2, **kwargs)
         elif _str_to_index(line, ele_name_init) == _str_to_index(line, ele_stop):
-            prrrr
-            tw2 = twiss_line(ele_start=line.element_names[0], ele_stop=ele_stop,
+            tw2 = twiss_line(ele_start=line.element_names[-1], ele_stop=ele_stop,
                                 twiss_init=twiss_init, **kwargs)
-            twini_1 = tw2.get_twiss_init(at_element=line.element_names[0])
-            twini_1.element_name = '_end_point'
-            tw1 = twiss_line(ele_start=ele_start, ele_stop='_end_point',
+            twini_1 = tw2.get_twiss_init(at_element=line.element_names[-1])
+            twini_1.element_name = line.element_names[0]
+            tw1 = twiss_line(ele_start=ele_start, ele_stop=line.element_names[0],
                                 twiss_init=twini_1, **kwargs)
         else:
             raise RuntimeError(

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -780,7 +780,7 @@ def _twiss_open(line, twiss_init,
         twiss_orientation = 'backward'
     elif ele_stop is not None and twiss_init.element_name == line.element_names[ele_stop]:
         twiss_orientation = 'backward'
-        assert isinstance(line.element_dict[line.element_names[ele_stop]], xt.Marker) # to start one downstream without having to track
+        # assert isinstance(line.element_dict[line.element_names[ele_stop]], xt.Marker) # to start one downstream without having to track
     else:
         raise ValueError(
             '`twiss_init` must be given at the start or end of the specified element range.')
@@ -1772,53 +1772,52 @@ def _handle_loop_around(kwargs):
 
     ele_name_init = twiss_init.element_name
 
-    import pdb; pdb.set_trace()
+    # import pdb; pdb.set_trace()
 
     # if reversed, elements in the line are sorted opposite to the twiss table
     if not reverse:
-        estart_tw1 = ele_start
-        estop_tw1 = '_end_point'
-        estart_tw2 = line.element_names[0]
-        estop_tw2 = ele_stop
+        assert _str_to_index(line, ele_stop) < _str_to_index(line, ele_start), (
+            'This function should not have been called')
         if _str_to_index(line, ele_name_init) == _str_to_index(line, ele_start):
-            tw1 = twiss_line(ele_start=estart_tw1,
-                            ele_stop=(len(line) - 1 if estop_tw1 == '_end_point' else estop_tw1),
+            tw1 = twiss_line(ele_start=ele_start,
+                            ele_stop=len(line) - 1,
                             twiss_init=twiss_init, **kwargs)
-            twini_2 = tw1.get_twiss_init(at_element=estop_tw1)
-            twini_2.element_name = estart_tw2
-            tw2 = twiss_line(ele_start=estart_tw2, ele_stop=estop_tw2,
+            twini_2 = tw1.get_twiss_init(at_element='_end_point')
+            twini_2.element_name = line.element_names[0]
+            tw2 = twiss_line(ele_start=line.element_names[0], ele_stop=ele_stop,
                                     twiss_init=twini_2, **kwargs)
         elif _str_to_index(line, ele_name_init) == _str_to_index(line, ele_stop):
-            tw2 = twiss_line(ele_start=estart_tw2, ele_stop=estop_tw2,
+            tw2 = twiss_line(ele_start=line.element_names[0], ele_stop=ele_stop,
                                 twiss_init=twiss_init, **kwargs)
-            twini_1 = tw2.get_twiss_init(at_element=estart_tw2)
-            twini_1.element_name = estop_tw1
-            tw1 = twiss_line(ele_start=estart_tw1, ele_stop=estop_tw1,
+            twini_1 = tw2.get_twiss_init(at_element=line.element_names[0])
+            twini_1.element_name = '_end_point'
+            tw1 = twiss_line(ele_start=ele_start, ele_stop='_end_point',
                                 twiss_init=twini_1, **kwargs)
         else:
-            raise RuntimeError('Initial twiss not at start or end of the specified range')
+            raise RuntimeError(
+                'Boundary conditions not at start or end of the specified range')
     else: # reversed
-        raise ValueError('Not yet supported')
-        estart_tw1 = ele_start
-        estop_tw1 = line.element_names[0]
-        estart_tw2 = '_start_point'
-        estop_tw2 = ele_stop
-        rv = -1
-        if rv * _str_to_index(line, ele_name_init) >= rv * _str_to_index(line, ele_start):
-            tw1 = twiss_line(ele_start=estart_tw1,
-                            ele_stop=(len(line) - 1 if estop_tw1 == '_end_point' else estop_tw1),
+        assert _str_to_index(line, ele_stop) > _str_to_index(line, ele_start), (
+            'This function should not have been called')
+        if _str_to_index(line, ele_name_init) == _str_to_index(line, ele_start):
+            tw1 = twiss_line(ele_start=ele_start,
+                            ele_stop=line.element_names[0],
                             twiss_init=twiss_init, **kwargs)
-            twini_2 = tw1.get_twiss_init(at_element=estop_tw1)
-            twini_2.element_name = estart_tw2
-            tw2 = twiss_line(ele_start=estart_tw2, ele_stop=estop_tw2,
+            twini_2 = tw1.get_twiss_init(at_element='_end_point')
+            twini_2.element_name = line.element_names[-1]
+            tw2 = twiss_line(ele_start=line.element_names[-1], ele_stop=ele_stop,
                                     twiss_init=twini_2, **kwargs)
-        else:
-            tw2 = twiss_line(ele_start=estart_tw2, ele_stop=estop_tw2,
+        elif _str_to_index(line, ele_name_init) == _str_to_index(line, ele_stop):
+            prrrr
+            tw2 = twiss_line(ele_start=line.element_names[0], ele_stop=ele_stop,
                                 twiss_init=twiss_init, **kwargs)
-            twini_1 = tw2.get_twiss_init(at_element=estart_tw2)
-            twini_1.element_name = estop_tw1
-            tw1 = twiss_line(ele_start=estart_tw1, ele_stop=estop_tw1,
+            twini_1 = tw2.get_twiss_init(at_element=line.element_names[0])
+            twini_1.element_name = '_end_point'
+            tw1 = twiss_line(ele_start=ele_start, ele_stop='_end_point',
                                 twiss_init=twini_1, **kwargs)
+        else:
+            raise RuntimeError(
+                'Boundary conditions not at start or end of the specified range')
 
     tw_res = TwissTable.concatenate([tw1, tw2])
 

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -2512,8 +2512,12 @@ class TwissInit:
         if name in self.__dict__:
             return self.__dict__[name]
         elif hasattr(self.__dict__['particle_on_co'], name):
-            # e.g. tw_init['x'] returns tw_init.particle_on_co.x
-            return getattr(self.__dict__['particle_on_co'], name)
+            # e.g. tw_init['x'] returns tw_init.particle_on_co.x[0]
+            pco = self.__dict__['particle_on_co']
+            pctx = pco._context
+            out = pctx.nparray_from_context_array(
+                getattr(self.__dict__['particle_on_co'], name))[0]
+            return out
         else:
             raise AttributeError(f'No attribute {name} found in TwissInit')
 

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -405,7 +405,7 @@ def twiss_line(line, particle_ref=None, method=None,
     mux=None; muy=None; muzeta=None
     ax_chrom=None; bx_chrom=None; ay_chrom=None; by_chrom=None
 
-    # Twiss goes throgh the start of the line
+    # Twiss goes through the start of the line
     rv = (-1 if reverse else 1)
     if not periodic and (
         rv * _str_to_index(line, ele_start) > rv * _str_to_index(line, ele_stop)):
@@ -419,8 +419,6 @@ def twiss_line(line, particle_ref=None, method=None,
     if (not periodic and not isinstance(twiss_init, str)
             and twiss_init.element_name != ele_start
             and twiss_init.element_name != ele_stop):
-
-        raise NotImplementedError # Needs testing
 
         ele_name_init =  twiss_init.element_name
         if reverse:
@@ -452,6 +450,12 @@ def twiss_line(line, particle_ref=None, method=None,
         if 'dmuy' in tw_res.keys():
             tw_res._data.pop('dmuy')
             tw_res._col_names.remove('dmuy')
+
+        for kk in ['method', 'radiation_method', 'reference_frame']:
+            if tw1[kk] == tw2[kk]:
+                tw_res._data[kk] = tw1[kk]
+            else:
+                tw_res._data[kk] = (tw1[kk], tw2[kk])
 
         return tw_res
 

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -82,6 +82,7 @@ def twiss_line(line, particle_ref=None, method=None,
         dx=None, dpx=None, dy=None, dpy=None, dzeta=None,
         mux=None, muy=None, muzeta=None,
         ax_chrom=None, bx_chrom=None, ay_chrom=None, by_chrom=None,
+        ele_co_search=None,
         _continue_if_lost=None,
         _keep_tracking_data=None,
         _keep_initial_particles=None,
@@ -508,6 +509,7 @@ def twiss_line(line, particle_ref=None, method=None,
             matrix_stability_tol=matrix_stability_tol,
             ele_start=ele_start, ele_stop=ele_stop,
             num_turns=num_turns,
+            ele_co_search=ele_co_search,
             nemitt_x=nemitt_x, nemitt_y=nemitt_y, r_sigma=r_sigma,
             compute_R_element_by_element=compute_R_element_by_element,
             only_markers=only_markers,
@@ -1592,6 +1594,7 @@ def _find_periodic_solution(line, particle_on_co, particle_ref, method,
                             nemitt_x, nemitt_y, r_sigma,
                             ele_start=None, ele_stop=None,
                             num_turns=1,
+                            ele_co_search=None,
                             compute_R_element_by_element=False,
                             only_markers=False):
 
@@ -1620,7 +1623,8 @@ def _find_periodic_solution(line, particle_on_co, particle_ref, method,
                                 zeta0=zeta0,
                                 ele_start=ele_start,
                                 ele_stop=ele_stop,
-                                num_turns=num_turns)
+                                num_turns=num_turns,
+                                ele_co_search=ele_co_search,)
 
     if W_matrix is not None:
         W = W_matrix

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -394,6 +394,14 @@ def twiss_line(line, particle_ref=None, method=None,
         ax_chrom, bx_chrom, ay_chrom, by_chrom,
         )
 
+    # clean quantities embedded in twiss_init
+    ele_init=None
+    x=None; px=None; y=None; py=None; zeta=None; delta=None
+    alfx=None; alfy=None; betx=None; bety=None; bets=None
+    dx=None; dpx=None; dy=None; dpy=None; dzeta=None
+    mux=None; muy=None; muzeta=None
+    ax_chrom=None; bx_chrom=None; ay_chrom=None; by_chrom=None
+
     # Twiss goes throgh the start of the line
     rv = (-1 if reverse else 1)
     if not periodic and (
@@ -1765,8 +1773,7 @@ def _handle_loop_around(kwargs):
     reverse = kwargs['reverse']
     rv = -1 if reverse else 1
 
-    # Need to loop around
-    ele_name_init =  twiss_init.element_name
+    ele_name_init = twiss_init.element_name
 
     if not reverse:
         estart_tw1 = ele_start

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -295,6 +295,9 @@ def twiss_line(line, particle_ref=None, method=None,
     if only_orbit:
         raise NotImplementedError # Tested only experimentally
 
+    if isinstance(twiss_init, TwissInit):
+        twiss_init = twiss_init.copy()
+
     kwargs = locals().copy()
 
     if num_turns != 1:

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -442,7 +442,7 @@ def twiss_line(line, particle_ref=None, method=None,
 
     if reverse:
         if ele_start is not None and ele_stop is not None:
-            assert _str_to_index(line, ele_start) > _str_to_index(line, ele_stop), (
+            assert _str_to_index(line, ele_start) >= _str_to_index(line, ele_stop), (
                 'ele_start must be smaller than ele_stop in reverse mode')
         ele_start, ele_stop = ele_stop, ele_start
         if twiss_init == 'preserve' or twiss_init == 'preserve_start':
@@ -451,7 +451,7 @@ def twiss_line(line, particle_ref=None, method=None,
             twiss_init = 'preserve_start'
     else:
         if ele_start is not None and ele_stop is not None:
-            assert _str_to_index(line, ele_start) < _str_to_index(line, ele_stop), (
+            assert _str_to_index(line, ele_start) <= _str_to_index(line, ele_stop), (
                 'ele_start must be larger than ele_stop in forward mode')
 
     if ele_start is not None and twiss_init is None:


### PR DESCRIPTION
**Changes:**
 - New features in `Line.twiss`:
     - Initial conditions can be provided at any point in the selected range.
     - Initial conditions can be provided as keyword arguments, e.g. `line.twiss(ele_start='ip8', ele_stop='ip2', ele_init='ip1', betx=1., bety=2.)`.
     - Twiss range can extend across the end of the line (useful to avoid unnecessary line cycle).
     - `ele_co_search` can be provided to periodic twiss to perform the closed orbit search at a given point in the line (instead of start line). Useful to avoid failures when large orbit bumps extend across the start of the line.