### PR TITLE
Renamed loop variables inside the per-particle block

### DIFF
--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -17,20 +17,20 @@ from .internal_record import RecordIdentifier, RecordIndex, generate_get_record
 
 start_per_part_block = """
     {
-    const int64_t start_idx = part0->ipart; //only_for_context cpu_openmp
-    const int64_t end_idx = part0->endpart; //only_for_context cpu_openmp
+    const int64_t XT_part_block_start_idx = part0->ipart; //only_for_context cpu_openmp
+    const int64_t XT_part_block_end_idx = part0->endpart; //only_for_context cpu_openmp
 
-    const int64_t start_idx = 0;                                            //only_for_context cpu_serial
-    const int64_t end_idx = LocalParticle_get__num_active_particles(part0); //only_for_context cpu_serial
+    const int64_t XT_part_block_start_idx = 0;                                            //only_for_context cpu_serial
+    const int64_t XT_part_block_end_idx = LocalParticle_get__num_active_particles(part0); //only_for_context cpu_serial
 
     //#pragma omp simd // TODO: currently does not work, needs investigating
-    for (int64_t ii=start_idx; ii<end_idx; ii++) { //only_for_context cpu_openmp cpu_serial
+    for (int64_t XT_part_block_ii=XT_part_block_start_idx; XT_part_block_ii<XT_part_block_end_idx; XT_part_block_ii++) { //only_for_context cpu_openmp cpu_serial
 
-        LocalParticle lpart = *part0;  //only_for_context cpu_serial cpu_openmp
-        LocalParticle* part = &lpart;  //only_for_context cpu_serial cpu_openmp
-        part->ipart = ii;              //only_for_context cpu_serial cpu_openmp
+        LocalParticle lpart = *part0;    //only_for_context cpu_serial cpu_openmp
+        LocalParticle* part = &lpart;    //only_for_context cpu_serial cpu_openmp
+        part->ipart = XT_part_block_ii;  //only_for_context cpu_serial cpu_openmp
 
-        LocalParticle* part = part0;   //only_for_context opencl cuda
+        LocalParticle* part = part0;     //only_for_context opencl cuda
 
         if (LocalParticle_get_state(part) > 0) {  //only_for_context cpu_openmp
 """


### PR DESCRIPTION
Renamed loop variables inside the per-particle block when using ContextCPU. The current names, i.e `start_idx`, `end_idx`, and `ii`, are very common names that might accidentally be used inside the per-particle code. This creates a bug that is difficult to trace (for anyone accept the three core developers :-p).

Case to prove the point: this bug is already present inside `LimitPolygon`, where on [line 22](https://github.com/xsuite/xtrack/blob/b232ed2f824a185659222131bffb0b0422f16f3c/xtrack/beam_elements/apertures_src/limitpolygon.h#L22) `int64_t ii = 0;` is redeclared inside the per-particle block. This gives a compiler error (which is how I discovered it, by compiling `xboinc`). Note that it seems a C compiler is more forgiving, as I believe it automatically renames the shadowed variable. This is not true for a C++ compiler, which will halt compilation because of this (and I need C++ compilation to include the BOINC API).

The changes are minimal (just a renaming), and should not influence anyone.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
