### PR TITLE
Corrected overflow with ele_stop <= ele_start

### DIFF
--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -291,14 +291,19 @@ def _ele_start_to_ele_stop(line, particles_init):
                 assert line.record_last_track.x.shape==(len(particles.x), expected_num_monitor)
 
 
-# Track from any ele_start until any ele_stop that is smaller than or equal to ele_start (turn increses by one)
+# Track from any ele_start until any ele_stop that is smaller than or equal to ele_start
 # for one, two, and ten turns
 def _ele_start_to_ele_stop_with_overflow(line, particles_init):
     n_elem = len(line.element_names)
     for turns in [1, 2, 10]:
         for start in range(n_elem):
             for stop in range(start+1):
-                expected_end_turn = turns
+                if stop == 0:
+                    # last turn is a complete turn
+                    expected_end_turn = turns
+                else:
+                    # last turn is incomplete, but overflow if turns == 1
+                    expected_end_turn = turns if turns==1 else turns - 1
                 expected_end_element = stop
                 expected_num_monitor = expected_end_turn if expected_end_element==0 else expected_end_turn+1
 

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -322,7 +322,7 @@ class Tracker:
                 if ele_stop is None:
                     ele_stop = len(self.line)
 
-                if ele_start >= ele_stop:
+                if ele_start >= ele_stop and num_turns == 1:
                     # we need an additional turn and space in the monitor for
                     # the incomplete turn
                     num_turns += 1
@@ -726,7 +726,7 @@ class Tracker:
             if ele_stop == 0:
                 ele_stop = None
 
-            if ele_stop is not None and ele_stop <= ele_start:
+            if ele_stop is not None and ele_stop <= ele_start and num_turns == 1:
                 num_turns += 1
 
         if ele_stop is not None:
@@ -1156,6 +1156,10 @@ class Tracker:
 
         else:
             # We are using ele_start, ele_stop, and num_turns
+            if isinstance(ele_stop, str):
+                ele_stop = self.line.element_names.index(ele_stop)
+            if ele_stop == 0:
+                ele_stop = None
             if num_turns is None:
                 num_turns = 1
             else:
@@ -1166,11 +1170,9 @@ class Tracker:
                 num_elements_first_turn = self.num_elements - ele_start
                 num_middle_turns = num_turns - 1
             else:
-                if isinstance(ele_stop, str):
-                    ele_stop = self.line.element_names.index(ele_stop)
                 assert ele_stop >= 0
                 assert ele_stop <= self.num_elements
-                if ele_stop <= ele_start:
+                if ele_stop <= ele_start and num_turns == 1:
                     # Correct for overflow:
                     num_turns += 1
                 if num_turns == 1:


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Using `ele_stop` in `track()` implies that the last turn will be incomplete (unless `ele_stop=0`); hence no extra turns should be added.

I.e. if we do `track(num_turns=2, ele_start=10, ele_stop=20)` the first turn tracks from element 10 to the end, and the second turn from the start until element 20 (and similarly for e.g. `num_turns=3` where the middle turn is a complete one).

In this case, nothing changes when `ele_stop <= ele_start`:
If we do `track(num_turns=2, ele_start=20, ele_stop=10)` the first turn tracks from element 20 to the end, and the second turn from the start until element 10.

There is one important exception: when `ele_stop <= ele_start` and `num_turns=1`. This is in principle impossible, but writing `track(ele_start=20, ele_stop=10)` should be a convenient way to track only a part of the line (that passes through the origin) without having to worry about increasing `num_turns` manually. Hence, for this very specific overflow case, and only for this one, the tracker changes `num_turns` to 2.

This was the original idea, however, the overflow was applied to all values of `num_turns` which creates a discrepancy in physical interpretation between the cases `ele_stop <= ele_start` and `ele_start < ele_stop`.

## Checklist

Mandatory: 

- [X] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [X] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
