### PR TITLE
fix a bug in madloader when importing octagon with expressions

### DIFF
--- a/tests/test_madloader.py
+++ b/tests/test_madloader.py
@@ -331,6 +331,7 @@ def test_mad_elements_import():
                 pnl:={a*0.3, a*0.4}, psl:={a*0.5, a*0.6};
     crab0: crabcavity, volt:=a*2, lag:=a*0.5, freq:=a*100.;
     crab1: crabcavity, volt:=a*2, lag:=a*0.5, freq:=a*100., tilt:=a*pi/2;
+    oct0: marker, apertype=octagon, aperture:={a * 3, a * 6, a * pi/6, a * pi/3};
     """)
 
     matrix_m0 = np.random.randn(6)*1E-6
@@ -377,6 +378,7 @@ def test_mad_elements_import():
     cb1: crab1, at=0.42;
     w: wire1, at=1;
     mat0:mat, at=2+0.003/2;
+    oct: oct0, at=3;
     endsequence;
     """
     )
@@ -393,7 +395,8 @@ def test_mad_elements_import():
 
     for test_expressions in [True, False]:
         line = xt.Line.from_madx_sequence(sequence=seq,
-                                          deferred_expressions=test_expressions)
+                                          deferred_expressions=test_expressions,
+                                          install_apertures=True)
         line.particle_ref = xp.Particles(mass0=xp.PROTON_MASS_EV, gamma0=1.05)
 
         line = xt.Line.from_dict(line.to_dict()) # This calls the to_dict method fot all
@@ -525,6 +528,15 @@ def test_mad_elements_import():
         assert line.get_s_position('mat0') == 2
         assert np.allclose(line['mat0'].m0,matrix_m0,rtol=0.0,atol=1E-12)
         assert np.allclose(line['mat0'].m1,matrix_m1,rtol=0.0,atol=1E-12)
+
+        assert isinstance(line['oct_aper'], xt.LimitPolygon)
+        assert line.get_s_position('oct_aper') == 3
+        x_1, x_2, y_1, y_2 = 3, 2 * np.sqrt(3), np.sqrt(3), 6
+        expected_x_vertices = [x_1, x_2,  -x_2, -x_1, -x_1, -x_2, x_2, x_1]
+        expected_y_vertices = [y_1, y_2, y_2, y_1, -y_1, -y_2, -y_2, -y_1]
+        assert np.allclose(line['oct_aper'].x_vertices, expected_x_vertices)
+        assert np.allclose(line['oct_aper'].y_vertices, expected_y_vertices)
+
 
 def test_selective_expr_import_and_replace_in_expr():
 

--- a/xtrack/mad_loader.py
+++ b/xtrack/mad_loader.py
@@ -1030,12 +1030,13 @@ class MadLoader:
         ]
 
     def convert_octagon(self, ee):
-        a0 = ee.aperture[0]
-        a1 = ee.aperture[1]
-        a2 = ee.aperture[2]
-        a3 = ee.aperture[3]
-        V1 = (a0, a0 * np.tan(a2))  # expression will fail
-        V2 = (a1 / np.tan(a3), a1)  # expression will fail
+        # MAD-X assumes X and Y symmetry, defines 2 points per quadrant
+        a0 = ee.aperture[0]  # half-width
+        a1 = ee.aperture[1]  # half-height
+        a2 = ee.aperture[2]  # angle between the lower point and the X axis
+        a3 = ee.aperture[3]  # angle between the other point and the X axis
+        V1 = (a0, a0 * self.math.tan(a2))
+        V2 = (a1 / self.math.tan(a3), a1)
         el = self.Builder(
             ee.name + "_aper",
             self.classes.LimitPolygon,


### PR DESCRIPTION
## Description

Fix an issue in the madloader which caused octagonal apertures with expressions to not be loaded correctly. Use `tan` provided as an expression function, instead of the one from `numpy`.

Closes xsuite/xsuite#452.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
