### PR TITLE
Cut the line at specified s coordinates

### DIFF
--- a/examples/lhc_thick/004_slice_every_x_meters.py
+++ b/examples/lhc_thick/004_slice_every_x_meters.py
@@ -1,0 +1,29 @@
+import matplotlib.pyplot as plt
+from pathlib import Path
+from time import time
+
+import xtrack as xt
+import numpy as np
+
+all_num_cuts = np.logspace(np.log2(10), np.log2(50_000), base=2, num=15)
+time_to_cut = []
+
+line0 = xt.Line.from_json(
+    Path(__file__).parent /
+    '../../test_data/hllhc15_thick/lhc_thick_with_knobs.json'
+)
+
+for num_cuts in all_num_cuts:
+    ss = np.linspace(0, line0.get_length(), num=int(num_cuts))
+    line = line0.copy()
+    start = time()
+    line.cut_at_s(s=list(ss))
+    end = time()
+    time_to_cut.append(end - start)
+
+fig, ax = plt.subplots()
+ax.plot(all_num_cuts, time_to_cut)
+ax.set_title("Slicing time vs number of cuts")
+ax.set_ylabel('time [s]')
+ax.set_xlabel('number of cuts [1]')
+plt.show()

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -1135,7 +1135,7 @@ def test_compound_transformations(compound_type):
         assert len(line.get_compound_by_name('c').exit_transform) == 5
 
 
-def test_get_elements_intersected_by_s():
+def test_elements_intersecting_s():
     elements = {
         'e1': xt.Drift(length=1),  # at 0
         'e2': xt.Drift(length=2),  # at 1
@@ -1170,7 +1170,7 @@ def test_get_elements_intersected_by_s():
         'e4': [0.5],
         'e6': [0.8, 0.9],
     }
-    result = line._get_elements_for_cutting(cuts)
+    result = line._elements_intersecting_s(cuts)
     for kk in expected.keys() | result.keys():
         assert np.allclose(expected[kk], result[kk], atol=1e-16)
 

--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -7,15 +7,17 @@ import pytest
 import math
 
 import xtrack as xt
-from xtrack.slicing import Strategy, Teapot, Uniform
+from xtrack.slicing import Strategy, Teapot, Uniform, Custom
 
 
 def test_slicing_uniform():
     # Test for one slice
-    slicing_3 = Uniform(1)
-    assert slicing_3.element_weights() == [1.0]
-    assert slicing_3.drift_weights() == [0.5] * 2
-    assert [w for w in slicing_3] == [(0.5, True), (1.0, False), (0.5, True)]
+    slicing_1 = Uniform(1)
+    assert slicing_1.element_weights() == [1.0]
+    assert slicing_1.drift_weights() == [0.5] * 2
+    expected_1 = [w for w in slicing_1.iter_weights(None)]
+    result_1 = [(0.5, True), (1.0, False), (0.5, True)]
+    assert expected_1 == result_1
 
     # Test for three slices
     slicing_3 = Uniform(3)
@@ -23,12 +25,14 @@ def test_slicing_uniform():
     assert slicing_3.drift_weights() == [0.25] * 4
 
     elem_info, drift_info = (1./3., False), (0.25, True)
-    assert [w for w in slicing_3] == [
+    expected_3 = [
         drift_info, elem_info,
         drift_info, elem_info,
         drift_info, elem_info,
         drift_info,
     ]
+    result_3 = [w for w in slicing_3.iter_weights(None)]
+    assert expected_3 == result_3
 
     # Test error handling
     with pytest.raises(ValueError):
@@ -37,10 +41,12 @@ def test_slicing_uniform():
 
 def test_slicing_teapot():
     # Test for one slice
-    slicing_3 = Teapot(1)
-    assert slicing_3.element_weights() == [1.0]
-    assert slicing_3.drift_weights() == [0.5] * 2
-    assert [w for w in slicing_3] == [(0.5, True), (1.0, False), (0.5, True)]
+    slicing_1 = Teapot(1)
+    assert slicing_1.element_weights() == [1.0]
+    assert slicing_1.drift_weights() == [0.5] * 2
+    expected_1 = [(0.5, True), (1.0, False), (0.5, True)]
+    result_1 = [w for w in slicing_1.iter_weights()]
+    assert expected_1 == result_1
 
     # Test for three slices
     slicing_3 = Teapot(3)
@@ -48,12 +54,14 @@ def test_slicing_teapot():
     assert slicing_3.drift_weights() == [0.125, 0.375, 0.375, 0.125]
 
     elem_info = (1./3., False)
-    assert [w for w in slicing_3] == [
+    expected_3 = [
         (0.125, True), elem_info,
         (0.375, True), elem_info,
         (0.375, True), elem_info,
         (0.125, True),
     ]
+    result_3 = [w for w in slicing_3.iter_weights()]
+    assert expected_3 == result_3
 
     # Test error handling
     with pytest.raises(ValueError):
@@ -62,24 +70,80 @@ def test_slicing_teapot():
 
 def test_slicing_teapot_mode_thick():
     # Test for two slices
-    slicing_3 = Teapot(2, mode='thick')
-    assert slicing_3.drift_weights() == [0.5] * 2
-    assert [w for w in slicing_3] == [(0.5, True), (0.5, True)]
+    slicing_2 = Teapot(2, mode='thick')
+    assert slicing_2.drift_weights() == [0.5] * 2
+    expected_2 = [(0.5, True), (0.5, True)]
+    result_2 = [w for w in slicing_2.iter_weights()]
+    assert expected_2 == result_2
 
     # Test for four slices
     slicing_3 = Teapot(4, mode='thick')
     assert slicing_3.drift_weights() == [0.125, 0.375, 0.375, 0.125]
 
-    assert [w for w in slicing_3] == [
+    expected = [
         (0.125, True),
         (0.375, True),
         (0.375, True),
         (0.125, True),
     ]
+    result = [w for w in slicing_3.iter_weights()]
+    assert expected == result
 
     # Test error handling
     with pytest.raises(ValueError):
         Teapot(0)
+
+
+def test_slicing_custom():
+    elem_len_3 = 16
+    slicing_3 = Custom(at_s=[0.8, 2, 8], mode='thin')
+    expected_dr_3 = [0.8/16, 1.2/16, 6/16, 8/16]
+    result_dr_3 = slicing_3.drift_weights(element_length=elem_len_3)
+    assert np.allclose(expected_dr_3, result_dr_3, atol=1e-30)
+
+    expected_el_3 = [1/3] * 3
+    result_el_3 = slicing_3.element_weights(element_length=elem_len_3)
+    assert np.allclose(expected_el_3, result_el_3, atol=1e-30)
+
+    elem_info = (1/3, False)
+    expected_3 = [
+        (0.8/16, True), elem_info,
+        (1.2/16, True), elem_info,
+        (6/16, True), elem_info,
+        (8/16, True),
+    ]
+    result_3 = [w for w in slicing_3.iter_weights(element_length=elem_len_3)]
+    assert expected_3 == result_3  # ditto
+
+
+def test_slicing_custom_thick():
+    elem_len_1 = 1.1
+    slicing_1 = Custom(at_s=[0.3], mode='thick')
+    expected_dr_1 = [0.3 / 1.1, 0.8 / 1.1]
+    result_dr_1 = slicing_1.drift_weights(element_length=elem_len_1)
+    assert np.allclose(expected_dr_1, result_dr_1, atol=1e-30)
+
+    expected_1 = [
+        (0.3 / 1.1, True),
+        (0.8 / 1.1, True),
+    ]
+    result_1 = [w for w in slicing_1.iter_weights(element_length=elem_len_1)]
+    assert expected_1 == result_1  # for now exact comparison works
+
+    elem_len_3 = 16
+    slicing_3 = Custom(at_s=[0.8, 2, 8])
+    expected_dr_3 = [0.8/16, 1.2/16, 6/16, 8/16]
+    result_dr_3 = slicing_3.drift_weights(element_length=elem_len_3)
+    assert np.allclose(expected_dr_3, result_dr_3, atol=1e-30)
+
+    expected_3 = [
+        (0.8/16, True),
+        (1.2/16, True),
+        (6/16, True),
+        (8/16, True),
+    ]
+    result_3 = [w for w in slicing_3.iter_weights(element_length=elem_len_3)]
+    assert expected_3 == result_3  # ditto
 
 
 def test_slicing_strategy_matching():

--- a/tests/test_thick_lhc.py
+++ b/tests/test_thick_lhc.py
@@ -68,6 +68,7 @@ def test_madloader_lhc_thick(test_context):
     assert np.isclose(tw0['betx', 'ip5'], tmad['betx', 'ip5:1'], atol=0, rtol=1e-5)
     assert np.isclose(tw0['bety', 'ip5'], tmad['bety', 'ip5:1'], atol=0, rtol=1e-5)
 
+
 @for_all_test_contexts
 def test_slicing_lhc_thick(test_context):
     line = xt.Line.from_json(test_data_folder /

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -999,6 +999,16 @@ class Sextupole(BeamElement):
 
         ref.order = 2
 
+    @classmethod
+    def add_thick_slice(cls, weight, container, name, slice_name, _buffer=None):
+        self_or_ref = container[name]
+        container[slice_name] = cls(_buffer=_buffer)
+        ref = container[slice_name]
+
+        ref.length = _get_expr(self_or_ref.length) * weight
+        ref.k2 = _get_expr(self_or_ref.k2)
+        ref.k2s = _get_expr(self_or_ref.k2s)
+
     @staticmethod
     def delete_element_ref(ref):
         # Remove the scalar fields

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -83,6 +83,15 @@ class Drift(BeamElement):
         container[slice_name] = Drift(_buffer=_buffer)
         container[slice_name].length = _get_expr(container[thick_name].length) * weight
 
+    @classmethod
+    def add_thick_slice(cls, weight, container, name, slice_name, _buffer=None):
+        cls.add_slice(weight, container, name, slice_name, _buffer=_buffer)
+
+    @staticmethod
+    def delete_element_ref(ref):
+        _unregister_if_preset(ref.length)
+        _unregister_if_preset(ref)
+
 
 class Cavity(BeamElement):
     '''Beam element modeling an RF cavity.

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -1733,11 +1733,28 @@ class Line:
         else:
             return s
 
-    def _get_elements_for_cutting(
+    def _elements_intersecting_s(
             self,
             s: List[float],
             tol=1e-16,
     ) -> Dict[str, List[float]]:
+        """Given a list of s positions, return a list of elements 'cut' by s.
+
+        Arguments
+        ---------
+        s
+            A list of s positions.
+        tol
+            Tolerance used when checking if s falls inside an element, or
+            at its edge. Defaults to 1e-16.
+
+        Returns
+        -------
+        A dictionary, where the keys are the names of the intersected elements,
+        and the value for each key is a list of s positions (offset to be
+        relative to the start of the element) corresponding to the 'cuts'.
+        The structure is ordered such that the cuts are sequential.
+        """
         cuts_for_element = defaultdict(list)
 
         all_s_positions = self.get_s_elements()
@@ -1781,7 +1798,8 @@ class Line:
         return cuts_for_element
 
     def cut_at_s(self, s: List[float]):
-        cuts_for_element = self._get_elements_for_cutting(s)
+        """Slice the line so that positions in s never fall inside an element."""
+        cuts_for_element = self._elements_intersecting_s(s)
         strategies = [Strategy(None)]  # catch-all, ignore unaffected elements
         for name, cuts in cuts_for_element.items():
             scheme = Custom(at_s=cuts, mode='thick')

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -1742,12 +1742,12 @@ class Line:
 
         all_s_positions = self.get_s_elements()
         all_s_iter = iter(zip(all_s_positions, self.element_names))
-        start, name = next(all_s_iter)
-
         current_s_iter = iter(sorted(set(s)))
-        current_s = next(current_s_iter)
 
         try:
+            start, name = next(all_s_iter)
+            current_s = next(current_s_iter)
+
             while True:
                 element = self[name]
                 if not _is_thick(element):
@@ -1782,10 +1782,10 @@ class Line:
 
     def cut_at_s(self, s: List[float]):
         cuts_for_element = self._get_elements_for_cutting(s)
-        strategies = [Strategy(None, name=r'.*')]
+        strategies = [Strategy(None)]  # catch-all, ignore unaffected elements
         for name, cuts in cuts_for_element.items():
             scheme = Custom(at_s=cuts, mode='thick')
-            strategy = Strategy(scheme, name=name)
+            strategy = Strategy(scheme, name=name, exact=True)
             strategies.append(strategy)
 
         slicer = Slicer(self, slicing_strategies=strategies)

--- a/xtrack/slicing.py
+++ b/xtrack/slicing.py
@@ -205,6 +205,9 @@ class Slicer:
         self._slicing_strategies = slicing_strategies
         self._has_expressions = line.vars is not None
 
+        # If all strategies are exact matches (no regex), instead of performing
+        # sequential matching against them all, we can use dictionary lookup to
+        # immediately find the right strategy.
         self._use_cache = True
         strategy_cache = {}
         for score, strategy in enumerate(reversed(slicing_strategies)):

--- a/xtrack/slicing.py
+++ b/xtrack/slicing.py
@@ -240,6 +240,12 @@ class Slicer:
         if not slicing_was_performed:
             return None
 
+        aperture = self._order_set_by_line(compound.aperture)
+        entry_transform = self._order_set_by_line(compound.entry_transform)
+        exit_transform = self._order_set_by_line(compound.exit_transform)
+        compound_entry = self._order_set_by_line(compound.entry)
+        compound_exit = self._order_set_by_line(compound.exit)
+
         updated_core = []
         slice_idx = 0
         for slice_name in sliced_core:
@@ -247,12 +253,6 @@ class Slicer:
             if isinstance(element, xt.Drift):
                 updated_core.append(slice_name)
                 continue
-
-            aperture = self._order_set_by_line(compound.aperture)
-            entry_transform = self._order_set_by_line(compound.entry_transform)
-            exit_transform = self._order_set_by_line(compound.exit_transform)
-            compound_entry = self._order_set_by_line(compound.entry)
-            compound_exit = self._order_set_by_line(compound.exit)
 
             # Copy the apertures and transformations with a new name
             updated_core += (

--- a/xtrack/slicing.py
+++ b/xtrack/slicing.py
@@ -147,19 +147,26 @@ class Custom(ElementSlicingScheme):
 
 
 class Strategy:
-    def __init__(self, slicing, name=None, element_type=None):
-        if name is not None and isinstance(name, str):
-            self.name_regex = re.compile(name)
+    def __init__(self, slicing, name=None, element_type=None, exact=False):
+        if name is None and element_type is None:
+            exact = True
+
+        self.regex = not exact
+
+        if name is not None and isinstance(name, str) and self.regex:
+            self.match_name = re.compile(name)
         else:
-            self.name_regex = None
+            self.match_name = name
 
         self.element_type = element_type
         self.slicing = slicing
 
     def _match_on_name(self, name):
-        if self.name_regex is None:
+        if self.match_name is None:
             return True
-        return self.name_regex.match(name)
+        if self.regex:
+            return self.match_name.match(name)
+        return self.match_name == name
 
     def _match_on_type(self, element):
         if self.element_type is None:
@@ -173,7 +180,7 @@ class Strategy:
         params = {
             'slicing': self.slicing,
             'element_type': self.element_type,
-            'name': self.name_regex.pattern if self.name_regex else None,
+            'name': self.match_name.pattern if self.regex else self.match_name,
         }
         formatted_params = ', '.join(
             f'{kk}={vv!r}' for kk, vv in params.items() if vv is not None
@@ -194,26 +201,43 @@ class Slicer:
         slicing_strategies : List[Strategy]
             A list of slicing strategies to apply to the line.
         """
-        self.line = line
-        self.slicing_strategies = slicing_strategies
-        self.has_expresions = line.vars is not None
+        self._line = line
+        self._slicing_strategies = slicing_strategies
+        self._has_expressions = line.vars is not None
+
+        self._use_cache = True
+        strategy_cache = {}
+        for score, strategy in enumerate(reversed(slicing_strategies)):
+            if strategy.regex:
+                self._use_cache = False
+                break
+
+            name, type_ = strategy.match_name, strategy.element_type
+
+            # Skip the current strategy if it is redundant
+            if ((name, None) in strategy_cache or
+                    (None, type_) in strategy_cache):
+                continue
+
+            strategy_cache[name, type_] = (strategy.slicing, score)
+        self._strategy_cache = strategy_cache
 
     def slice_in_place(self):
         thin_names = []
 
-        collapsed_names = self.line.get_collapsed_names()
+        collapsed_names = self._line.get_collapsed_names()
         for ii, name in enumerate(progress(collapsed_names, desc='Slicing line')):
-            compound = self.line.get_compound_by_name(name)
+            compound = self._line.get_compound_by_name(name)
             if compound is not None:
                 subsequence = self._slice_compound(name, compound)
             else:
-                element = self.line.element_dict[name]
+                element = self._line.element_dict[name]
                 subsequence = self._slice_element(name, element)
 
             # Create a new compound with the sliced elements
             if subsequence is not None:
                 thin_compound = SlicedCompound(elements=subsequence)
-                self.line.compound_container.define_compound(name, thin_compound)
+                self._line.compound_container.define_compound(name, thin_compound)
             elif compound:
                 subsequence = self._order_set_by_line(compound.elements)
             else:
@@ -222,14 +246,14 @@ class Slicer:
             thin_names += subsequence
 
         # Commit the changes to the line
-        self.line.element_names = thin_names
+        self._line.element_names = thin_names
 
     def _slice_compound(self, name, compound) -> Optional[List[str]]:
         """Slice compound and return slice names, or None if no slicing."""
         sliced_core = []
         slicing_was_performed = False
         for core_el_name in self._order_set_by_line(compound.core):
-            element = self.line.element_dict[core_el_name]
+            element = self._line.element_dict[core_el_name]
             slice_names = self._slice_element(core_el_name, element)
             if slice_names is None:
                 slice_names = [core_el_name]
@@ -249,7 +273,7 @@ class Slicer:
         updated_core = []
         slice_idx = 0
         for slice_name in sliced_core:
-            element = self.line.element_dict[slice_name]
+            element = self._line.element_dict[slice_name]
             if isinstance(element, xt.Drift):
                 updated_core.append(slice_name)
                 continue
@@ -266,7 +290,7 @@ class Slicer:
         subsequence = compound_entry + updated_core + compound_exit
 
         # Remove the existing compound
-        self.line.compound_container.remove_compound(name)
+        self._line.compound_container.remove_compound(name)
 
         return subsequence
 
@@ -294,26 +318,46 @@ class Slicer:
         )
 
         # Remove the thick element and its expressions
-        if self.has_expresions:
-            type(element).delete_element_ref(self.line.element_refs[name])
-        del self.line.element_dict[name]
+        if self._has_expressions:
+            type(element).delete_element_ref(self._line.element_refs[name])
+        del self._line.element_dict[name]
 
         entry_marker, exit_marker = f'{name}_entry', f'{name}_exit'
-        if entry_marker not in self.line.element_dict:
-            self.line.element_dict[entry_marker] = xt.Marker()
+        if entry_marker not in self._line.element_dict:
+            self._line.element_dict[entry_marker] = xt.Marker()
             slices_to_add = [entry_marker] + slices_to_add
 
-        if exit_marker not in self.line.element_dict:
-            self.line.element_dict[exit_marker] = xt.Marker()
+        if exit_marker not in self._line.element_dict:
+            self._line.element_dict[exit_marker] = xt.Marker()
             slices_to_add += [exit_marker]
 
         return slices_to_add
 
     def _scheme_for_element(self, element, name):
         """Choose a slicing strategy for the element"""
+        if self._use_cache:
+            cache = self._strategy_cache
+            try:
+                scheme, _ = cache[name, type(element)]
+                return scheme
+            except KeyError:
+                entry_name = cache.get((name, None), (None, np.inf))
+                entry_type = cache.get((None, type(element)), (None, np.inf))
+                default = cache.get((None, None), (None, np.inf))
+                scheme, score = min(
+                    [entry_name, entry_type, default],
+                    key=lambda x: x[1],
+                )
+                if score < np.inf:
+                    return scheme
+
+            raise ValueError(f'No slicing strategy found for the element '
+                             f'{name}: {element}.')
+
         slicing_found = False
         chosen_slicing = None
-        for strategy in reversed(self.slicing_strategies):
+
+        for strategy in reversed(self._slicing_strategies):
             if strategy.match_element(name, element):
                 slicing_found = True
                 chosen_slicing = strategy.slicing
@@ -356,10 +400,10 @@ class Slicer:
                 obj_to_slice = element
                 element_idx += 1
 
-            if self.has_expresions:
-                container = self.line.element_refs
+            if self._has_expressions:
+                container = self._line.element_refs
             else:
-                container = self.line.element_dict
+                container = self._line.element_dict
 
             if chosen_slicing.mode == 'thin':
                 type(obj_to_slice).add_slice(
@@ -367,7 +411,7 @@ class Slicer:
                     container=container,
                     thick_name=name,
                     slice_name=slice_name,
-                    _buffer=self.line.element_dict[name]._buffer,
+                    _buffer=self._line.element_dict[name]._buffer,
                 )
             else:
                 type(obj_to_slice).add_thick_slice(
@@ -375,7 +419,7 @@ class Slicer:
                     container=container,
                     name=name,
                     slice_name=slice_name,
-                    _buffer=self.line.element_dict[name]._buffer,
+                    _buffer=self._line.element_dict[name]._buffer,
                 )
             slices_to_append.append(slice_name)
 
@@ -384,9 +428,9 @@ class Slicer:
     def _make_copies(self, element_names, index):
         new_names = []
         for element_name in element_names:
-            element = self.line.element_dict[element_name]
+            element = self._line.element_dict[element_name]
             new_element_name = f'{element_name}..{index}'
-            self.line.element_dict[new_element_name] = element.copy()
+            self._line.element_dict[new_element_name] = element.copy()
             new_names.append(new_element_name)
 
         return new_names
@@ -394,4 +438,4 @@ class Slicer:
     def _order_set_by_line(self, set_to_order: set):
         """Order a set of element names by their order in the line."""
         assert isinstance(set_to_order, set)
-        return sorted(set_to_order, key=self.line.element_names.index)
+        return sorted(set_to_order, key=self._line.element_names.index)


### PR DESCRIPTION
## Description

Given a list of $s$ coordinates, make cuts in the line at those positions. This uses the slicing module as to not repeat the logic used to preserve compounds. A new slicing scheme called `Custom` is introduces, which allows to cut elements at $s$ positions relative to the start of the element.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
