### PR TITLE
Fix: transforms not showing in table; add examples for transforms

### DIFF
--- a/examples/compounds/001_compound_transform.py
+++ b/examples/compounds/001_compound_transform.py
@@ -1,0 +1,70 @@
+import xtrack as xt
+from cpymad.madx import Madx
+
+# Load a very simple sequence from MAD-X
+mad = Madx()
+mad.input("""
+    seq: sequence, l=4;
+    b1: sbend, at=0.5, angle=0.2, l=1;
+    b2: sbend, at=2.5, angle=0.3, l=1;
+    endsequence;
+    
+    beam;
+    use,sequence=seq;
+""")
+
+line = xt.Line.from_madx_sequence(mad.sequence.seq)
+
+# The MAD-X elements b1 and b2 will be exploded into smaller more specialised
+# elements in Xsuite: i.e. edges, the core of the bend, markers, etc.
+print('The line as imported from MAD-X:')
+print(line.get_table())
+
+print('Specified transformations are added to the compound:')
+line.transform_compound('b1', x_shift=-0.1, s_rotation=0.8)
+line.transform_compound('b2', y_shift=0.2, s_rotation=-0.8)
+
+print(line.get_table())
+# Table: 23 rows, 5 cols
+# name            s element_type isthick compound_name
+# seq$start       0 Marker         False
+# b1_offset_entry 0 XYShift        False b1  <- added shift
+# b1_tilt_entry   0 SRotation      False b1  <- added tilt
+# b1_entry        0 Marker         False b1
+# b1_den          0 DipoleEdge     False b1
+# b1              0 Bend            True b1
+# b1_dex          1 DipoleEdge     False b1
+# b1_exit         1 Marker         False b1
+# b1_tilt_exit    1 SRotation      False b1  <- undo tilt
+# b1_offset_exit  1 XYShift        False b1  <- undo shift
+# drift_0         1 Drift           True
+# b2_offset_entry 2 XYShift        False b2  <- added shift
+# b2_tilt_entry   2 SRotation      False b2  <- added tilt
+# b2_entry        2 Marker         False b2
+# b2_den          2 DipoleEdge     False b2
+# b2              2 Bend            True b2
+# b2_dex          3 DipoleEdge     False b2
+# b2_exit         3 Marker         False b2
+# b2_tilt_exit    3 SRotation      False b2  <- undo tilt
+# b2_offset_exit  3 XYShift        False b2  <- undo shift
+# drift_1         3 Drift           True
+# seq$end         4 Marker         False
+# _end_point      4                False
+
+print('Further transformations are added on top of the current ones:')
+line.transform_compound('b1', y_shift=0.1)
+
+print(line.get_table().rows['b1':'b1':'compound_name'])
+# Table: 11 rows, 5 cols
+# name              s element_type isthick compound_name
+# b1_offset_entry_1 0 XYShift        False b1  <- added new shift
+# b1_offset_entry   0 XYShift        False b1
+# b1_tilt_entry     0 SRotation      False b1
+# b1_entry          0 Marker         False b1
+# b1_den            0 DipoleEdge     False b1
+# b1                0 Bend            True b1
+# b1_dex            1 DipoleEdge     False b1
+# b1_exit           1 Marker         False b1
+# b1_tilt_exit      1 SRotation      False b1
+# b1_offset_exit    1 XYShift        False b1
+# b1_offset_exit_1  1 XYShift        False b1  <- undo new shift

--- a/examples/compounds/002_sliced_compound_transform.py
+++ b/examples/compounds/002_sliced_compound_transform.py
@@ -1,0 +1,84 @@
+import xtrack as xt
+from cpymad.madx import Madx
+
+# Carry on with the same example as in 001
+mad = Madx()
+mad.input("""
+    seq: sequence, l=4;
+    b1: sbend, at=0.5, angle=0.2, l=1;
+    b2: sbend, at=2.5, angle=0.3, l=1;
+    endsequence;
+    
+    beam;
+    use,sequence=seq;
+""")
+
+line = xt.Line.from_madx_sequence(mad.sequence.seq)
+
+# Add a transformations
+line.transform_compound('b1', x_shift=-0.1, s_rotation=0.8)
+
+# Note that the type of our compound is simply 'Compound' for now, and it has
+# the knowledge of the character of the different elements that compose the
+# compound:
+print(line.get_compound_by_name('b1'))
+# Compound(
+#     core={'b1_den', 'b1_dex', 'b1'},
+#     aperture=set(),
+#     entry_transform={'b1_tilt_entry', 'b1_offset_entry'},
+#     exit_transform={'b1_tilt_exit', 'b1_offset_exit'},
+#     entry={'b1_entry'},
+#     exit={'b1_exit'},
+# )
+
+# Slice the line
+slicing_strategies = [
+    xt.Strategy(slicing=None),  # Default catch-all
+    xt.Strategy(slicing=xt.Teapot(3), element_type=xt.Bend),
+]
+line.slice_thick_elements(slicing_strategies)
+
+print(line.get_table())
+# Table: 47 rows, 5 cols
+# name                   s element_type isthick compound_name
+# seq$start              0 Marker         False
+# b1_entry               0 Marker         False b1
+# b1_offset_entry..0     0 XYShift        False b1 <- Transformations are moved
+# b1_tilt_entry..0       0 SRotation      False b1 <- ...to each of the slices
+# b1_den                 0 DipoleEdge     False b1
+# b1_tilt_exit..0        0 SRotation      False b1 <- ...and undone after
+# b1_offset_exit..0      0 XYShift        False b1 <- (here for the edge).
+# drift_b1..0            0 Drift           True b1
+# b1_offset_entry..1 0.125 XYShift        False b1 <- And here
+# b1_tilt_entry..1   0.125 SRotation      False b1 <- ..for the slice
+# b1..0              0.125 Multipole      False b1
+# b1_tilt_exit..1    0.125 SRotation      False b1 <- ...of the
+# b1_offset_exit..1  0.125 XYShift        False b1 <- ...actual bend
+# drift_b1..1        0.125 Drift           True b1
+#   etc...
+
+# After slicing the compound becomes a 'SlicedCompound' and loses memory of
+# its logical structure
+print(line.get_compound_by_name('b1'))
+# SlicedCompound({'b1_tilt_exit..2', 'drift_b1..0', 'b1..1', ...)
+
+# If we add a transformation of a sliced compound it will now be added around
+# it, as is the case for the 'Compound':
+line.transform_compound('b2', s_rotation=0.1)
+
+print(line.get_table().rows['b2':'b2':'compound_name'])
+# Table: 13 rows, 5 cols
+# name                   s element_type isthick compound_name
+# b2_tilt_entry          2 SRotation      False b2  <- add the rotation
+# b2_entry               2 Marker         False b2
+# b2_den                 2 DipoleEdge     False b2
+# drift_b2..0            2 Drift           True b2
+# b2..0              2.125 Multipole      False b2
+# drift_b2..1        2.125 Drift           True b2
+# b2..1                2.5 Multipole      False b2
+# drift_b2..2          2.5 Drift           True b2
+# b2..2              2.875 Multipole      False b2
+# drift_b2..3        2.875 Drift           True b2
+# b2_dex                 3 DipoleEdge     False b2
+# b2_exit                3 Marker         False b2
+# b2_tilt_exit           3 SRotation      False b2 <- undo the rotation

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -1133,3 +1133,9 @@ def test_compound_transformations(compound_type):
         assert len(line.get_compound_by_name('c').core) == 2
         assert len(line.get_compound_by_name('c').entry_transform) == 5
         assert len(line.get_compound_by_name('c').exit_transform) == 5
+
+    # Check that the table shows the compound correctly
+    subtable = line.get_table().rows['c_offset_entry_1':'c_offset_exit_1']
+    expected = ['c'] * 12
+    result = subtable.compound_name
+    np.all(expected == result)

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -2039,6 +2039,8 @@ class Line:
             names_after = [_generate_name('tilt_exit')] + names_after
 
         # Commit the transformations to the line
+        self.compound_container.remove_compound(compound_name)
+
         for idx, element in enumerate(reversed(after)):
             new_name = names_after[-idx - 1]
             self.insert_element(index=idx_end, element=element, name=new_name)
@@ -2048,6 +2050,8 @@ class Line:
             new_name = names_before[-idx - 1]
             self.insert_element(index=idx_begin, element=element, name=new_name)
             compound.add_transform(new_name, side='entry')
+
+        self.compound_container.define_compound(compound_name, compound)
 
     def _enumerate_top_level(self):
         idx = 0


### PR DESCRIPTION
## Description

Add examples of transforming compounds. Fix a bug where tilts/shifts were not showing as part of the compound it the line table.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
