### PR TITLE
Fix prebuilt kernels

### DIFF
--- a/tests/test_prebuild_kernels.py
+++ b/tests/test_prebuild_kernels.py
@@ -7,7 +7,6 @@ import json
 import cffi
 
 import xobjects as xo
-import xpart as xp
 import xtrack as xt
 from xtrack.prebuild_kernels import regenerate_kernels
 
@@ -61,8 +60,58 @@ def test_prebuild_kernels(mocker, tmp_path, temp_context_default_func):
     # Build the tracker on a fresh context, so that the kernel comes from a file
     line.build_tracker(_context=xo.ContextCpu())
 
-    p = xp.Particles(p0c=1e9, px=3e-6)
+    p = xt.Particles(p0c=1e9, px=3e-6)
     line.track(p)
+
+    assert p.x == 6e-6
+    assert p.y == 0.0
+    cffi_compile.assert_not_called()
+
+
+def test_per_element_prebuild_kernels(mocker, tmp_path, temp_context_default_func):
+    # Set up the temporary kernels directory
+    kernel_definitions = {
+        "test_module": {
+            "config": {},
+            "classes": [
+                xt.Drift,
+                xt.Cavity,
+                xt.XYShift,
+            ]
+        },
+    }
+
+    patch_defs = 'xtrack.prebuilt_kernels.kernel_definitions.kernel_definitions'
+    mocker.patch(patch_defs, kernel_definitions)
+
+    mocker.patch('xtrack.prebuild_kernels.XT_PREBUILT_KERNELS_LOCATION',
+                 tmp_path)
+    mocker.patch('xtrack.tracker.XT_PREBUILT_KERNELS_LOCATION', tmp_path)
+    mocker.patch('xtrack.base_element.XT_PREBUILT_KERNELS_LOCATION', tmp_path)
+
+    # Try regenerating the kernels
+    regenerate_kernels()
+
+    # Check if the expected files were created
+    so_file_exists = False
+    for path in tmp_path.iterdir():
+        if not path.name.startswith('test_module.'):
+            continue
+        if path.suffix not in ('.so', '.dll', '.dylib', '.pyd'):
+            continue
+        so_file_exists = True
+    assert so_file_exists
+
+    assert (tmp_path / 'test_module.c').exists()
+    assert (tmp_path / 'test_module.json').exists()
+
+    # Test that reloading the kernel works
+    cffi_compile = mocker.patch.object(cffi.FFI, 'compile')
+
+    drift = xt.Drift(length=2.0)
+
+    p = xt.Particles(p0c=1e9, px=3e-6)
+    drift.track(p)
 
     assert p.x == 6e-6
     assert p.y == 0.0

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -377,7 +377,7 @@ class PerParticlePyMethod:
 
     def __call__(self, particles, increment_at_element=False, **kwargs):
         instance = self.element
-        context = instance.context
+        context = instance._context
 
         only_if_needed = kwargs.pop('only_if_needed', True)
         BeamElement.compile_kernels(
@@ -386,12 +386,11 @@ class PerParticlePyMethod:
             only_if_needed=only_if_needed,
 
         )
-        kernel = getattr(context.kernels, self.kernel_name)
+        kernel = context.kernels[self.kernel_name]
 
         if hasattr(self.element, 'io_buffer') and self.element.io_buffer is not None:
             io_buffer_arr = self.element.io_buffer.buffer
         else:
-            context = kernel.context
             io_buffer_arr = context.zeros(1, dtype=np.int8)  # dummy
 
         kernel.description.n_threads = particles._capacity
@@ -434,7 +433,7 @@ class PyMethod:
             only_if_needed=only_if_needed,
 
         )
-        kernel = getattr(context.kernels, self.kernel_name)
+        kernel = context.kernels[self.kernel_name]
 
         el_var_name = None
         for arg in instance._kernels[self.kernel_name].args:

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -292,7 +292,8 @@ class BeamElement(xo.HybridClass, metaclass=MetaBeamElement):
                     local_particle_src=Particles.gen_local_particle_api()))
         context = self._context
         cls = type(self)
-        prebuilt_kernels_path = kwargs.pop('prebuilt_kernels_path')
+        prebuilt_kernels_path = kwargs.pop('prebuilt_kernels_path',
+                                           XT_PREBUILT_KERNELS_LOCATION)
         if context.allow_prebuilt_kernels:
             from xtrack.prebuild_kernels import get_suitable_kernel
             # Default config is empty (all flags default to not defined, which

--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -273,6 +273,8 @@ class BeamElement(xo.HybridClass, metaclass=MetaBeamElement):
     allow_backtrack = False
     skip_in_loss_location_refinement = False
     prebuilt_kernels_path = XT_PREBUILT_KERNELS_LOCATION
+    needs_rng = False
+
 
     def __init__(self, *args, **kwargs):
         xo.HybridClass.__init__(self, *args, **kwargs)
@@ -326,6 +328,9 @@ class BeamElement(xo.HybridClass, metaclass=MetaBeamElement):
                              + f"has no valid track method.")
         elif particles is None:
             raise RuntimeError("Please provide particles to track!")
+
+        if self.needs_rng and not particles._has_valid_rng_state():
+            particles._init_random_number_generator()
 
         context = self._buffer.context
 

--- a/xtrack/prebuild_kernels.py
+++ b/xtrack/prebuild_kernels.py
@@ -206,6 +206,10 @@ def get_suitable_kernel(
     requested_class_names = [cls for cls in requested_class_names
                              if cls != 'Particles' and cls != 'ParticlesBase']
 
+    # Get a default config
+    if config == {}:
+        config  = xt.Line().config
+
     for module_name, kernel_metadata in enumerate_kernels():
         if verbose:
             _print(f"==> Considering the precompiled kernel `{module_name}`...")

--- a/xtrack/prebuild_kernels.py
+++ b/xtrack/prebuild_kernels.py
@@ -206,10 +206,6 @@ def get_suitable_kernel(
     requested_class_names = [cls for cls in requested_class_names
                              if cls != 'Particles' and cls != 'ParticlesBase']
 
-    # Get a default config
-    if config == {}:
-        config  = xt.Line().config
-
     for module_name, kernel_metadata in enumerate_kernels():
         if verbose:
             _print(f"==> Considering the precompiled kernel `{module_name}`...")

--- a/xtrack/prebuilt_kernels/kernel_definitions.py
+++ b/xtrack/prebuilt_kernels/kernel_definitions.py
@@ -71,12 +71,16 @@ NON_TRACKING_ELEMENTS = [
 # These will be enumerated in order of appearance in the dict, so in this case
 # (for optimization purposes) the order is important.
 kernel_definitions = {
+    'default_only_xtrack_no_config': {
+        'config': {},
+        'classes': ONLY_XTRACK_ELEMENTS + NO_SYNRAD_ELEMENTS,
+    },
     'default_only_xtrack': {
         'config': BASE_CONFIG,
         'classes': ONLY_XTRACK_ELEMENTS + NO_SYNRAD_ELEMENTS,
     },
     'only_xtrack_non_tracking_kernels': {
-        'config': BASE_CONFIG,
+        'config': {},
         'classes': [],
         'extra_classes': NON_TRACKING_ELEMENTS
     },
@@ -122,6 +126,7 @@ kernel_definitions = {
     }
 }
 
+
 try:
     import xfields as xf
     DEFAULT_BB3D_ELEMENTS = [
@@ -134,48 +139,55 @@ try:
         'config': BASE_CONFIG,
         'classes': [*DEFAULT_BB3D_ELEMENTS, LineSegmentMap],
     }
+    kernel_definitions['default_bb3d_no_config'] = {
+        'config': {},
+        'classes': [*DEFAULT_BB3D_ELEMENTS, LineSegmentMap],
+    }
 except ImportError:
     LOGGER.warning('Xfields not installed, skipping BB3D elements')
 
+
 try:
     import xcoll as xc
+    DEFAULT_XCOLL_ELEMENTS = [
+        *ONLY_XTRACK_ELEMENTS,
+        *NO_SYNRAD_ELEMENTS,
+        xc.BlackAbsorber,
+        xc.EverestBlock,
+        xc.EverestCollimator,
+        xc.EverestCrystal
+    ]
+
     kernel_definitions['default_xcoll'] = {
         'config': BASE_CONFIG,
-        'classes': ONLY_XTRACK_ELEMENTS + NO_SYNRAD_ELEMENTS \
-                + [xc.BlackAbsorber, xc.EverestBlock, \
-                   xc.EverestCollimator, xc.EverestCrystal]
+        'classes': DEFAULT_XCOLL_ELEMENTS
+    }
+    kernel_definitions['default_xcoll_no_config'] = {
+        'config': {},
+        'classes': DEFAULT_XCOLL_ELEMENTS
     }
     kernel_definitions['default_xcoll_frozen_longitudinal'] = {
         'config': {**BASE_CONFIG, **FREEZE_LONGITUDINAL},
-        'classes': ONLY_XTRACK_ELEMENTS + NO_SYNRAD_ELEMENTS \
-                + [xc.BlackAbsorber, xc.EverestBlock, \
-                   xc.EverestCollimator, xc.EverestCrystal]
+        'classes': DEFAULT_XCOLL_ELEMENTS
     }
     kernel_definitions['default_xcoll_frozen_energy'] = {
         'config': {**BASE_CONFIG, **FREEZE_ENERGY},
-        'classes': ONLY_XTRACK_ELEMENTS + NO_SYNRAD_ELEMENTS \
-                + [xc.BlackAbsorber, xc.EverestBlock, \
-                   xc.EverestCollimator, xc.EverestCrystal]
+        'classes': DEFAULT_XCOLL_ELEMENTS
     }
     kernel_definitions['default_xcoll_backtrack'] = {
         'config': {**BASE_CONFIG, 'XSUITE_BACKTRACK': True},
-        'classes': ONLY_XTRACK_ELEMENTS + NO_SYNRAD_ELEMENTS \
-                + [xc.BlackAbsorber, xc.EverestBlock, \
-                   xc.EverestCollimator, xc.EverestCrystal]
+        'classes': DEFAULT_XCOLL_ELEMENTS
     }
     kernel_definitions['default_xcoll_backtrack_no_limit'] = {
         'config': {**{k: v for k,v in BASE_CONFIG.items()
                       if k != 'XTRACK_GLOBAL_XY_LIMIT'},
                    'XSUITE_BACKTRACK': True},
-        'classes': ONLY_XTRACK_ELEMENTS + NO_SYNRAD_ELEMENTS \
-                + [xc.BlackAbsorber, xc.EverestBlock, \
-                   xc.EverestCollimator, xc.EverestCrystal]
+        'classes': DEFAULT_XCOLL_ELEMENTS
     }
     kernel_definitions['default_xcoll_backtrack_frozen_energy'] = {
         'config': {**BASE_CONFIG, **FREEZE_ENERGY, 'XSUITE_BACKTRACK': True},
-        'classes': ONLY_XTRACK_ELEMENTS + NO_SYNRAD_ELEMENTS \
-                + [xc.BlackAbsorber, xc.EverestBlock, \
-                   xc.EverestCollimator, xc.EverestCrystal]
+        'classes': DEFAULT_XCOLL_ELEMENTS
     }
 except ImportError:
     LOGGER.warning('Xcoll not installed, skipping collimator elements')
+

--- a/xtrack/random/random_generators.py
+++ b/xtrack/random/random_generators.py
@@ -21,9 +21,6 @@ class RandomUniform(BeamElement):
     allow_track = False
 
     _extra_c_sources = [
-        # The base (bitwise) rng is in xtrack, as this is where the
-        # seeds are stored. This is needed to avoid circular imports
-        # in xtrack.Particles
         _pkg_root.joinpath('particles', 'rng_src', 'base_rng.h'),
         _pkg_root.joinpath('random', 'random_src', 'uniform.h')
     ]

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -120,6 +120,9 @@ class Tracker:
             _buffer=_buffer)
         line._freeze()
 
+        if np.any([hasattr(ee, 'needs_rng') and ee.needs_rng for ee in line.elements]):
+            line._needs_rng = True
+
         _buffer = tracker_data_base._buffer
 
         # Make a "marker" element to increase at_element


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

The current implementation of prebuilding kernels for (non-tracker) kernels and the attaching of non-particle kernels to a `BeamElement` do not work (the former will not use prebuilt kernels, and the latter will even raise an error when trying to instantiate such an object). This fix addresses that.

Changes:
- The variable `prebuilt_kernels_path` was not passed correctly to `BeamElement.compile_kernels`, making it fail (as it was then passed to `xo.Struct` which doesn't know the variable).
- The `PerParticlePyMethod` did not have this flag at all, making it skip prebuilt kernels
- When looking for a suitable kernel, an empty config would not find anything, as the prebuilt kernels are always stored with a specific config. Now it defaults to the default config of a `Line`.
- Added `Particles._init_random_number_generator` to prebuilt kernels.
- Added a flag `needs_rng` to a `BeamElement`, such that element classes can impose the need for a random generator (like is the case for an `EverestCollimator`). This removes the need for the user to call `Particles._init_random_number_generator()` which feels a bit hacky.

The latest version of `Xcoll` (to be released after this PR is merged)  has a few elements that rely on these changes, hence the `Xcoll` tests act implicitly as tests for this behaviour.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
