### PR TITLE
Missing prebuilt kernel for aperture interpolation

### DIFF
--- a/xtrack/prebuilt_kernels/kernel_definitions.py
+++ b/xtrack/prebuilt_kernels/kernel_definitions.py
@@ -166,6 +166,7 @@ try:
     DEFAULT_XCOLL_ELEMENTS = [
         *ONLY_XTRACK_ELEMENTS,
         *NO_SYNRAD_ELEMENTS,
+        ZetaShift,
         xc.BlackAbsorber,
         xc.EverestBlock,
         xc.EverestCollimator,

--- a/xtrack/prebuilt_kernels/kernel_definitions.py
+++ b/xtrack/prebuilt_kernels/kernel_definitions.py
@@ -78,6 +78,13 @@ kernel_definitions = [
         'config': BASE_CONFIG,
         'classes': ONLY_XTRACK_ELEMENTS + NO_SYNRAD_ELEMENTS,
     }),
+    ('default_only_xtrack_no_limit', {
+        'config': {
+            **{k: v for k, v in BASE_CONFIG.items()
+                if k != 'XTRACK_GLOBAL_XY_LIMIT'}
+        },
+        'classes': ONLY_XTRACK_ELEMENTS + NO_SYNRAD_ELEMENTS,
+    }),
     ('only_xtrack_non_tracking_kernels', {
         'config': BASE_CONFIG,
         'classes': [],
@@ -172,6 +179,13 @@ try:
         }),
         ('default_xcoll_no_config', {
             'config': {},
+            'classes': DEFAULT_XCOLL_ELEMENTS,
+        }),
+        ('default_xcoll_no_limit', {
+            'config': {
+                **{k: v for k, v in BASE_CONFIG.items()
+                    if k != 'XTRACK_GLOBAL_XY_LIMIT'}
+            },
             'classes': DEFAULT_XCOLL_ELEMENTS,
         }),
         ('default_xcoll_frozen_longitudinal', {


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Added two more kernel definitions, `default_only_xtrack_no_limit` and `default_xcoll_no_limit`, that are needed during the losses interpolation.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
