### PR TITLE
Smarter OpenMP

### DIFF
--- a/xtrack/base_element.py
+++ b/xtrack/base_element.py
@@ -105,16 +105,17 @@ def _generate_per_particle_kernel_from_local_particle_function(
 '''
                              int64_t flag_increment_at_element,
                 /*gpuglmem*/ int8_t* io_buffer){
-            const int num_threads = omp_get_max_threads();                                 //only_for_context cpu_openmp
-            const int64_t capacity = ParticlesData_get__capacity(particles);               //only_for_context cpu_openmp
-            const int64_t chunk_size = (capacity + num_threads - 1)/num_threads; // ceil division  //only_for_context cpu_openmp
-            #pragma omp parallel for                                                       //only_for_context cpu_openmp
-            for (int64_t batch_id = 0; batch_id < num_threads; batch_id++) {               //only_for_context cpu_openmp
+            const int num_threads = omp_get_max_threads();                                     //only_for_context cpu_openmp
+            const int64_t capacity = ParticlesData_get__capacity(particles);                   //only_for_context cpu_openmp
+            const int64_t alive = ParticlesData_get__num_active_particles(particles);          //only_for_context cpu_openmp
+            const int64_t chunk_size = (alive + num_threads - 1)/num_threads; // ceil division //only_for_context cpu_openmp
+            #pragma omp parallel for                                                           //only_for_context cpu_openmp
+            for (int64_t batch_id = 0; batch_id < num_threads; batch_id++) {                   //only_for_context cpu_openmp
                 LocalParticle lpart;
                 lpart.io_buffer = io_buffer;
                 int64_t part_id = batch_id * chunk_size;                                       //only_for_context cpu_openmp
                 int64_t end_id = (batch_id + 1) * chunk_size;                                  //only_for_context cpu_openmp
-                if (end_id > capacity) end_id = capacity;                                      //only_for_context cpu_openmp
+                if (end_id > alive) end_id = alive;                                            //only_for_context cpu_openmp
 
                 int64_t part_id = 0;                    //only_for_context cpu_serial
                 int64_t part_id = blockDim.x * blockIdx.x + threadIdx.x; //only_for_context cuda

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -466,19 +466,20 @@ class Tracker:
                              int64_t offset_tbt_monitor,
                 /*gpuglmem*/ int8_t* io_buffer){
 
-            const int64_t capacity = ParticlesData_get__capacity(particles);               //only_for_context cpu_openmp
-            const int num_threads = omp_get_max_threads();                                 //only_for_context cpu_openmp
-            const int64_t chunk_size = (capacity + num_threads - 1)/num_threads; // ceil division  //only_for_context cpu_openmp
-            #pragma omp parallel for                                                       //only_for_context cpu_openmp
-            for (int chunk = 0; chunk < num_threads; chunk++) {                            //only_for_context cpu_openmp
-            int64_t part_id = chunk * chunk_size;                                          //only_for_context cpu_openmp
-            int64_t end_id = (chunk + 1) * chunk_size;                                     //only_for_context cpu_openmp
-            if (end_id > capacity) end_id = capacity;                                      //only_for_context cpu_openmp
+            const int64_t capacity = ParticlesData_get__capacity(particles);                   //only_for_context cpu_openmp
+            const int64_t alive = ParticlesData_get__num_active_particles(particles);          //only_for_context cpu_openmp
+            const int num_threads = omp_get_max_threads();                                     //only_for_context cpu_openmp
+            const int64_t chunk_size = (alive + num_threads - 1)/num_threads; // ceil division //only_for_context cpu_openmp
+            #pragma omp parallel for                                                           //only_for_context cpu_openmp
+            for (int chunk = 0; chunk < num_threads; chunk++) {                                //only_for_context cpu_openmp
+            int64_t part_id = chunk * chunk_size;                                              //only_for_context cpu_openmp
+            int64_t end_id = (chunk + 1) * chunk_size;                                         //only_for_context cpu_openmp
+            if (end_id > alive) end_id = alive;                                                //only_for_context cpu_openmp
 
             int64_t part_id = 0;                                      //only_for_context cpu_serial
             int64_t part_id = blockDim.x * blockIdx.x + threadIdx.x;  //only_for_context cuda
             int64_t part_id = get_global_id(0);                       //only_for_context opencl
-            int64_t end_id = 0; // unused outside of openmp  //only_for_context cpu_serial cuda opencl
+            int64_t end_id = 0; // unused outside of openmp           //only_for_context cpu_serial cuda opencl
 
             LocalParticle lpart;
             lpart.io_buffer = io_buffer;


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

For simulations where particles can die early on (and where this happens often), like in loss map simulations, the current Open MP implementation is not optimal, as in some threads more particles will have died than others, and the freed resources are not re-assigned (as we are in a big loop over threads, outside of the loop over turns).

It is probably possible to rewrite the logic completely in order to address this smartly, with the particles in a stack where each thread tracks a single particle for all turns (or only over the non-collective parts in case of a collective tracker), and when finished or dead, the thread takes the next particle from the stack to be tracked. This would also be a smart implementation for tracking with GPUs in this scenario.

But for now, there is a very simple fix that is almost as good:
- track turn-by-turn (or track with `with_progress=1`)
- at the start of tracking, assign the OpenMP threads based on the number of alive particles instead of the total capacity.

This PR implements the latter with, as said, very minimal changes. But the total gain in a standard loss map simulation is almost a factor 4 in tracking (29s instead of 110s for 50.000 particles and 200 turns), which absolutely makes it worth it (especially for such a small change).

I'm running the tests now, and so far they all passed.

EDIT: all tests pass

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [X] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
