### PR TITLE
Particles.from_pandas() was not loading random generator seeds

### DIFF
--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -487,7 +487,7 @@ class Particles(xo.HybridClass):
         return dct
 
     @classmethod
-    def from_pandas(cls, df, _context=None, _buffer=None, _offset=None):
+    def from_pandas(cls, df, _context=None, _buffer=None, _offset=None, load_rng_state=True, **kwargs):
 
         """
         Create a new Particles object from a pandas DataFrame.
@@ -513,7 +513,9 @@ class Particles(xo.HybridClass):
         for tt, nn in cls.scalar_vars + cls.size_vars:
             if nn in dct.keys() and not np.isscalar(dct[nn]):
                 dct[nn] = dct[nn][0]
-        return cls(**dct, _context=_context, _buffer=_buffer, _offset=_offset)
+        return cls.from_dict(dct, load_rng_state=load_rng_state,
+                             _context=_context, _buffer=_buffer,
+                             _offset=_offset, **kwargs)
 
     def to_pandas(self,
                   remove_underscored=None,


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

When calling `xt.Particles.from_pandas()` the code internally initialises the class as `cls(**dct)`, however, this does not pass the random generator seeds. If it instead calls  `xt.Particles.from_dict()` this is solved.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
