### PR TITLE
Fix loading compounds from Madx for repeated element names

### DIFF
--- a/tests/test_compounds.py
+++ b/tests/test_compounds.py
@@ -161,6 +161,34 @@ def test_slicing_preserve_thick_compound_if_unsliced():
     ]
 
 
+def test_madloader_compounds_repeated_elements():
+    mad = Madx(stdout=False)
+    mad.options.rbarc = False
+    mad.input(f"""
+    mb: sbend, l:=1, angle:=0.1, k0:=0.2, k1=0.1;
+    ss: sequence, l:=2, refer=entry;
+        mb, at=0;
+        mb, at=1;
+    endsequence;
+    """)
+    mad.beam()
+    mad.use(sequence='ss')
+
+    line = xt.Line.from_madx_sequence(
+        sequence=mad.sequence.ss,
+        deferred_expressions=True,
+        allow_thick=True,
+    )
+
+    mb_compound_expected = ['mb_entry', 'mb_den', 'mb', 'mb_dex', 'mb_exit']
+    mb_compound_result = line.get_compound_subsequence('mb')
+    assert mb_compound_result == mb_compound_expected
+
+    mb0_compound_expected = ['mb_entry:0', 'mb_den:0', 'mb:0', 'mb_dex:0', 'mb_exit:0']
+    mb0_compound_result = line.get_compound_subsequence('mb:0')
+    assert mb0_compound_result == mb0_compound_expected
+
+
 @pytest.fixture(scope='function')
 def line_with_compounds(temp_context_default_func):
     # The fixture `temp_context_default_func` is defined in conftest.py and is


### PR DESCRIPTION
## Description

When loading a lattice from Madx where names of elements repeat, only the first compound is loaded properly. This fixes the issue and loads the compounds properly.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
