### PR TITLE
Add non-linear chromaticity to LineSegmentMap

### DIFF
--- a/examples/small_rings/t001_check_ps.py
+++ b/examples/small_rings/t001_check_ps.py
@@ -95,7 +95,7 @@ assert np.isclose(tw.dqy, dq2_ptc, atol=1e-2, rtol=0)
 assert np.isclose(tw.dqx, dq1_ptc, atol=1e-2, rtol=0)
 assert np.isclose(tw.dqy, dq2_ptc, atol=1e-2, rtol=0)
 
-nlchr = line.get_non_linear_chromaticity(method='4d')
+nlchr = line.get_non_linear_chromaticity()
 assert np.isclose(nlchr['ddqx'], ddq1_ptc, atol=0, rtol=5e-3)
 assert np.isclose(nlchr['ddqy'], ddq2_ptc, atol=0, rtol=5e-3)
 

--- a/examples/transfer_matrix/002_check_with_twiss.py
+++ b/examples/transfer_matrix/002_check_with_twiss.py
@@ -15,8 +15,8 @@ dy = [0, 20]
 dpx = [0.7, -0.3]
 dpy = [0.4, -0.6]
 bets = 1e-3
-dqx = [2, 30, 400]
-dqy = [3, 40, 500]
+dnqx = [0.21, 2, 30, 400]
+dnqy = [0.32, 3, 40, 500]
 
 segm_1 = xt.LineSegmentMap(
         qx=0.4, qy=0.3, qs=0.0001,
@@ -34,9 +34,9 @@ segm_1 = xt.LineSegmentMap(
         y_ref=[y_co[0], y_co[1]],
         py_ref=[py_co[0], py_co[1]])
 segm_2 = xt.LineSegmentMap(
-        qx=0.21, qy=0.32, qs=0.0003,
+        qs=0.0003,
         bets=bets, length=0.2,
-        dqx=dqx, dqy=dqy,
+        dnqx=dnqx, dnqy=dnqy,
         betx=[betx[1], betx[0]],
         bety=[bety[1], bety[0]],
         alfx=[alfx[1], alfx[0]],
@@ -88,5 +88,5 @@ for tw in [tw4d, tw6d]:
 
     chroma_table = line.get_non_linear_chromaticity((-1e-2, 1e-2),
                                                     num_delta=25)
-    assert np.allclose(chroma_table.dnqx[1:], dqx, atol=1e-5, rtol=0)
-    assert np.allclose(chroma_table.dnqy[1:], dqy, atol=1e-5, rtol=0)
+    assert np.allclose(chroma_table.dnqx[1:], dnqx[1:], atol=1e-5, rtol=0)
+    assert np.allclose(chroma_table.dnqy[1:], dnqy[1:], atol=1e-5, rtol=0)

--- a/examples/transfer_matrix/002_check_with_twiss.py
+++ b/examples/transfer_matrix/002_check_with_twiss.py
@@ -15,10 +15,12 @@ dy = [0, 20]
 dpx = [0.7, -0.3]
 dpy = [0.4, -0.6]
 bets = 1e-3
+dqx = [2, 30, 400]
+dqy = [3, 40, 500]
 
 segm_1 = xt.LineSegmentMap(
         qx=0.4, qy=0.3, qs=0.0001,
-        bets = bets, length=0.1,
+        bets=bets, length=0.1,
         betx=[betx[0], betx[1]],
         bety=[bety[0], bety[1]],
         alfx=[alfx[0], alfx[1]],
@@ -33,8 +35,8 @@ segm_1 = xt.LineSegmentMap(
         py_ref=[py_co[0], py_co[1]])
 segm_2 = xt.LineSegmentMap(
         qx=0.21, qy=0.32, qs=0.0003,
-        bets = bets, length=0.2,
-        dqx=2., dqy=3.,
+        bets=bets, length=0.2,
+        dqx=dqx, dqy=dqy,
         betx=[betx[1], betx[0]],
         bety=[bety[1], bety[0]],
         alfx=[alfx[1], alfx[0]],
@@ -58,7 +60,6 @@ assert np.isclose(tw6d.qs, 0.0004, atol=1e-7, rtol=0)
 assert np.isclose(tw6d.bets0, 1e-3, atol=1e-7, rtol=0)
 
 for tw in [tw4d, tw6d]:
-
     assert np.isclose(tw.qx, 0.4 + 0.21, atol=1e-7, rtol=0)
     assert np.isclose(tw.qy, 0.3 + 0.32, atol=1e-7, rtol=0)
 
@@ -84,3 +85,8 @@ for tw in [tw4d, tw6d]:
     assert np.allclose(tw.px, [2e-6, -3e-6, 2e-6], atol=1e-12, rtol=0)
     assert np.allclose(tw.y, [3e-3, 4e-3, 3e-3], atol=1e-7, rtol=0)
     assert np.allclose(tw.py, [4e-6, -5e-6, 4e-6], atol=1e-12, rtol=0)
+
+    chroma_table = line.get_non_linear_chromaticity((-1e-2, 1e-2),
+                                                    num_delta=25)
+    assert np.allclose(chroma_table.dnqx[1:], dqx, atol=1e-5, rtol=0)
+    assert np.allclose(chroma_table.dnqy[1:], dqy, atol=1e-5, rtol=0)

--- a/examples/twiss/028_ddx_ddqx.py
+++ b/examples/twiss/028_ddx_ddqx.py
@@ -30,7 +30,7 @@ line.particle_ref = xt.Particles(mass0=mad.sequence.lhcb1.beam.mass*1e9,
 
 tw = line.twiss(method='4d')
 nlchr = line.get_non_linear_chromaticity(delta0_range=(-1e-4, 1e-4),
-                                        num_delta=21, fit_order=1, method='4d')
+                                         num_delta=21, fit_order=1)
 tw_fw = line.twiss(start='ip4', end='ip6', init_at='ip4',
               x=tw['x', 'ip4'], px=tw['px', 'ip4'],
               y=tw['y', 'ip4'], py=tw['py', 'ip4'],
@@ -69,7 +69,7 @@ ddy_mad = np.interp(tw_fw.s, twm.s, twm.ddy)
 ddx_mad = np.interp(tw_fw.s, twm.s, twm.ddx)
 
 nlchr = line.get_non_linear_chromaticity(delta0_range=(-1e-4, 1e-4),
-                                        num_delta=21, fit_order=2, method='4d')
+                                         num_delta=21, fit_order=2)
 
 tw_mad = []
 for dd in nlchr.delta0:

--- a/tests/test_ps_against_ptc.py
+++ b/tests/test_ps_against_ptc.py
@@ -106,7 +106,7 @@ def test_ps_against_ptc(test_context):
     assert np.isclose(tw.dqx, dq1_ptc, atol=1e-2, rtol=0)
     assert np.isclose(tw.dqy, dq2_ptc, atol=1e-2, rtol=0)
 
-    nlchr = line.get_non_linear_chromaticity(method='4d')
+    nlchr = line.get_non_linear_chromaticity()
     assert np.isclose(nlchr['ddqx'], ddq1_ptc, atol=0, rtol=5e-3)
     assert np.isclose(nlchr['ddqy'], ddq2_ptc, atol=0, rtol=5e-3)
 

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -1737,7 +1737,7 @@ def test_second_order_chromaticity_and_dispersion(test_context):
 
     tw = line.twiss(method='4d')
     nlchr = line.get_non_linear_chromaticity(delta0_range=(-1e-4, 1e-4),
-                                            num_delta=21, fit_order=1, method='4d')
+                                             num_delta=21, fit_order=1)
     tw_fw = line.twiss(start='ip4', end='ip6', init_at='ip4',
                 x=tw['x', 'ip4'], px=tw['px', 'ip4'],
                 y=tw['y', 'ip4'], py=tw['py', 'ip4'],
@@ -1761,7 +1761,7 @@ def test_second_order_chromaticity_and_dispersion(test_context):
                 compute_chromatic_properties=True)
 
     nlchr = line.get_non_linear_chromaticity(delta0_range=(-1e-4, 1e-4),
-                                            num_delta=21, fit_order=2, method='4d')
+                                             num_delta=21, fit_order=2)
 
     location = 'ip3'
 

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -824,6 +824,8 @@ def test_twiss_against_matrix(test_context):
     dpx = [0.7, -0.3]
     dpy = [0.4, -0.6]
     bets = 1e-3
+    dqx = [2, 30, 400]
+    dqy = [3, 40, 500]
 
     segm_1 = xt.LineSegmentMap(
             qx=0.4, qy=0.3, qs=0.0001,
@@ -843,7 +845,7 @@ def test_twiss_against_matrix(test_context):
     segm_2 = xt.LineSegmentMap(
             qx=0.21, qy=0.32, qs=0.0003,
             bets=bets, length=0.2,
-            dqx=2., dqy=3.,
+            dqx=dqx, dqy=dqy,
             betx=[betx[1], betx[0]],
             bety=[bety[1], bety[0]],
             alfx=[alfx[1], alfx[0]],
@@ -893,6 +895,12 @@ def test_twiss_against_matrix(test_context):
         assert np.allclose(tw.px, [2e-6, -3e-6, 2e-6], atol=1e-12, rtol=0)
         assert np.allclose(tw.y, [3e-3, 4e-3, 3e-3], atol=1e-7, rtol=0)
         assert np.allclose(tw.py, [4e-6, -5e-6, 4e-6], atol=1e-12, rtol=0)
+
+        chroma_table = line.get_non_linear_chromaticity((-1e-2, 1e-2),
+                                                        num_delta=25)
+        assert np.allclose(chroma_table.dnqx[1:], dqx, atol=1e-5, rtol=0)
+        assert np.allclose(chroma_table.dnqy[1:], dqy, atol=1e-5, rtol=0)
+
 
 @for_all_test_contexts
 @pytest.mark.parametrize('machine', ['sps', 'psb'])

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -1923,7 +1923,7 @@ class LineSegmentMap(BeamElement):
             assert qy == 0 and dqy == 0 and ddqy == 0
             qy = dnqy[0]
         else:
-            dnqy = [qx]
+            dnqy = [qy]
             if dqy != 0:
                 dnqx.append(dqy)
             if ddqy != 0:

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -1673,8 +1673,8 @@ class LineSegmentMap(BeamElement):
         'qx': xo.Float64,
         'qy': xo.Float64,
 
-        'dqx': xo.Float64,
-        'dqy': xo.Float64,
+        'coeffs_dqx': xo.Float64[:],
+        'coeffs_dqy': xo.Float64[:],
         'det_xx': xo.Float64,
         'det_xy': xo.Float64,
         'det_yy': xo.Float64,
@@ -1895,8 +1895,15 @@ class LineSegmentMap(BeamElement):
 
         nargs['qx'] = qx
         nargs['qy'] = qy
-        nargs['dqx'] = dqx
-        nargs['dqy'] = dqy
+
+        dqx = np.atleast_1d(dqx)
+        dqy = np.atleast_1d(dqy)
+
+        coeffs_dqx = [dqx[i] / float(factorial(i + 1)) for i in range(len(dqx))]
+        coeffs_dqy = [dqy[i] / float(factorial(i + 1)) for i in range(len(dqy))]
+
+        nargs['coeffs_dqx'] = coeffs_dqx
+        nargs['coeffs_dqy'] = coeffs_dqy
         nargs['det_xx'] = det_xx
         nargs['det_xy'] = det_xy
         nargs['det_yy'] = det_yy

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -1925,9 +1925,9 @@ class LineSegmentMap(BeamElement):
         else:
             dnqy = [qy]
             if dqy != 0:
-                dnqx.append(dqy)
+                dnqy.append(dqy)
             if ddqy != 0:
-                dnqx.append(ddqy)
+                dnqy.append(ddqy)
 
         coeffs_dqx = [dnqx[i] / float(factorial(i)) for i in range(len(dnqx))]
         coeffs_dqy = [dnqy[i] / float(factorial(i)) for i in range(len(dnqy))]

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -1833,10 +1833,14 @@ class LineSegmentMap(BeamElement):
         lag_rf : list of float
             List of lag of the RF kicks in the segment. Only used if
             ``longitudinal_mode`` is ``'nonlinear'`` or ``'linear_fixed_rf'``.
-        dqx : float
-            Horizontal chromaticity of the segment.
-        dqy : float
-            Vertical chromaticity of the segment.
+        dqx : float or list of float
+            Horizontal chromaticity of the segment. It can be a single value for
+            the linear chromaticity or an array of chromaticities up to any
+            order
+        dqy : float or list of float
+            Vertical chromaticity of the segment. It can be a single value for
+            the linear chromaticity or an array of chromaticities up to any
+            order
         det_xx : float
             Anharmonicity xx coefficient (i.e. dqx / dJx, where Jx is the horizontal
             action). Optional, default is ``0``.

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -1742,7 +1742,7 @@ class LineSegmentMap(BeamElement):
             momentum_compaction_factor=None,
             slippage_length=None,
             voltage_rf=None, frequency_rf=None, lag_rf=None,
-            dqx=0.0, dqy=0.0,
+            dqx=0.0, dqy=0.0, ddqx=0.0, ddqy=0.0, dnqx=None, dnqy=None,
             det_xx=0.0, det_xy=0.0, det_yy=0.0, det_yx=0.0,
             energy_increment=0.0, energy_ref_increment=0.0,
             damping_rate_x = 0.0, damping_rate_y = 0.0, damping_rate_s = 0.0,
@@ -1834,13 +1834,25 @@ class LineSegmentMap(BeamElement):
             List of lag of the RF kicks in the segment. Only used if
             ``longitudinal_mode`` is ``'nonlinear'`` or ``'linear_fixed_rf'``.
         dqx : float or list of float
-            Horizontal chromaticity of the segment. It can be a single value for
-            the linear chromaticity or an array of chromaticities up to any
-            order
+            Horizontal linear chromaticity of the segment.
         dqy : float or list of float
-            Vertical chromaticity of the segment. It can be a single value for
-            the linear chromaticity or an array of chromaticities up to any
-            order
+            Vertical linear chromaticity of the segment.
+        ddqx: float
+            Horizontal second order chromaticity of the segment
+        ddqy: float
+            Vertical second order chromaticity of the segment
+        dnqx: list of float
+            List of horizontal chromaticities up to any order. The first element
+            of the list is the horizontal tune, the second element is the
+            horizontal linear chromaticity, the third element the horizontal
+            second order chromaticity and so on. It can be specified only if the
+            horizontal tune, and chromaticities are not specified.
+        dnqy: list of float
+            List of vertical chromaticities up to any order. The first element
+            of the list is the vertical tune, the second element is the
+            vertical linear chromaticity, the third element the vertical
+            second order chromaticity and so on. It can be specified only if the
+            vertical tune, and chromaticities are not specified.
         det_xx : float
             Anharmonicity xx coefficient (i.e. dqx / dJx, where Jx is the horizontal
             action). Optional, default is ``0``.
@@ -1897,15 +1909,31 @@ class LineSegmentMap(BeamElement):
         assert longitudinal_mode in [
             'linear_fixed_qs', 'nonlinear', 'linear_fixed_rf', 'frozen', None]
 
+        if dnqx is not None:
+            assert qx == 0 and dqx == 0 and ddqx == 0
+            qx = dnqx[0]
+        else:
+            dnqx = [qx]
+            if dqx != 0:
+                dnqx.append(dqx)
+            if ddqx != 0:
+                dnqx.append(ddqx)
+
+        if dnqy is not None:
+            assert qy == 0 and dqy == 0 and ddqy == 0
+            qy = dnqy[0]
+        else:
+            dnqy = [qx]
+            if dqy != 0:
+                dnqx.append(dqy)
+            if ddqy != 0:
+                dnqx.append(ddqy)
+
+        coeffs_dqx = [dnqx[i] / float(factorial(i)) for i in range(len(dnqx))]
+        coeffs_dqy = [dnqy[i] / float(factorial(i)) for i in range(len(dnqy))]
+
         nargs['qx'] = qx
         nargs['qy'] = qy
-
-        dqx = np.atleast_1d(dqx)
-        dqy = np.atleast_1d(dqy)
-
-        coeffs_dqx = [dqx[i] / float(factorial(i + 1)) for i in range(len(dqx))]
-        coeffs_dqy = [dqy[i] / float(factorial(i + 1)) for i in range(len(dqy))]
-
         nargs['coeffs_dqx'] = coeffs_dqx
         nargs['coeffs_dqy'] = coeffs_dqy
         nargs['det_xx'] = det_xx

--- a/xtrack/beam_elements/elements_src/linesegmentmap.h
+++ b/xtrack/beam_elements/elements_src/linesegmentmap.h
@@ -158,17 +158,17 @@ void transverse_motion(LocalParticle *part0, LineSegmentMapData el){
                 + bety_0
                     * LocalParticle_get_py(part)*LocalParticle_get_py(part));
             double phase = 2*PI*(qx + det_xx * J_x + det_xy * J_y);
-            for (int i_dqx=0; i_dqx<ndqx; i_dqx++){
+            for (int i_dqx=1; i_dqx<ndqx; i_dqx++){
                 phase += 2*PI*(LineSegmentMapData_get_coeffs_dqx(el, i_dqx) *
-                               pow(LocalParticle_get_delta(part), i_dqx+1));
+                               pow(LocalParticle_get_delta(part), i_dqx));
             }
 
             cos_x = cos(phase);
             sin_x = sin(phase);
             phase = 2*PI*(qy + det_yx * J_x + det_yy * J_y);
-            for (int i_dqy=0; i_dqy<ndqy; i_dqy++){
+            for (int i_dqy=1; i_dqy<ndqy; i_dqy++){
                 phase += 2*PI*(LineSegmentMapData_get_coeffs_dqy(el, i_dqy) *
-                               pow(LocalParticle_get_delta(part), i_dqy+1));
+                               pow(LocalParticle_get_delta(part), i_dqy));
             }
 
             cos_y = cos(phase);

--- a/xtrack/beam_elements/elements_src/linesegmentmap.h
+++ b/xtrack/beam_elements/elements_src/linesegmentmap.h
@@ -87,19 +87,42 @@ void add_dispersion(
 }
 
 /*gpufun*/
-void transverse_motion(LocalParticle *part0,
-    double const qx, double const qy,
-    double const dqx, double const dqy,
-    double const det_xx, double const det_xy, double const det_yx, double const det_yy,
-    double const alfx_0, double const betx_0, double const alfy_0, double const bety_0,
-    double const alfx_1, double const betx_1, double const alfy_1, double const bety_1){
+void transverse_motion(LocalParticle *part0, LineSegmentMapData el){
+
+    double const qx = LineSegmentMapData_get_qx(el);
+    double const qy = LineSegmentMapData_get_qy(el);
+    double const det_xx = LineSegmentMapData_get_det_xx(el);
+    double const det_xy = LineSegmentMapData_get_det_xy(el);
+    double const det_yx = LineSegmentMapData_get_det_yx(el);
+    double const det_yy = LineSegmentMapData_get_det_yy(el);
+    double const alfx_0 = LineSegmentMapData_get_alfx(el, 0);
+    double const betx_0 = LineSegmentMapData_get_betx(el, 0);
+    double const alfy_0 = LineSegmentMapData_get_alfy(el, 0);
+    double const bety_0 = LineSegmentMapData_get_bety(el, 0);
+    double const alfx_1 = LineSegmentMapData_get_alfx(el, 1);
+    double const betx_1 = LineSegmentMapData_get_betx(el, 1);
+    double const alfy_1 = LineSegmentMapData_get_alfy(el, 1);
+    double const bety_1 = LineSegmentMapData_get_bety(el, 1);
+    int64_t const ndqx = LineSegmentMapData_len_coeffs_dqx(el);
+    int64_t const ndqy = LineSegmentMapData_len_coeffs_dqy(el);
 
     int64_t detuning;
     double sin_x = 0;
     double cos_x = 0;
     double sin_y = 0;
     double cos_y = 0;
-    if (dqx != 0.0 || dqy != 0.0 ||
+
+    int64_t any_chroma = 0;
+
+    for (int i_dqx=0; i_dqx<ndqx; i_dqx++){
+        any_chroma = LineSegmentMapData_get_coeffs_dqx(el, 0) != 0;
+    }
+
+    for (int i_dqy=0; i_dqy<ndqy; i_dqy++){
+        any_chroma = LineSegmentMapData_get_coeffs_dqy(el, 0) != 0;
+    }
+
+    if (any_chroma ||
         det_xx != 0.0 || det_xy != 0.0 || det_yx != 0.0 || det_yy != 0.0){
         detuning = 1;
     }
@@ -134,12 +157,20 @@ void transverse_motion(LocalParticle *part0,
                     * LocalParticle_get_y(part)*LocalParticle_get_py(part)
                 + bety_0
                     * LocalParticle_get_py(part)*LocalParticle_get_py(part));
-            double phase = 2*PI*(qx + dqx * LocalParticle_get_delta(part)
-                                +det_xx * J_x + det_xy * J_y);
+            double phase = 2*PI*(qx + det_xx * J_x + det_xy * J_y);
+            for (int i_dqx=0; i_dqx<ndqx; i_dqx++){
+                phase += 2*PI*(LineSegmentMapData_get_coeffs_dqx(el, i_dqx) *
+                               pow(LocalParticle_get_delta(part), i_dqx+1));
+            }
+
             cos_x = cos(phase);
             sin_x = sin(phase);
-            phase = 2*PI*(qy + dqy * LocalParticle_get_delta(part)
-                            +det_yx * J_x + det_yy * J_y);
+            phase = 2*PI*(qy + det_yx * J_x + det_yy * J_y);
+            for (int i_dqy=0; i_dqy<ndqy; i_dqy++){
+                phase += 2*PI*(LineSegmentMapData_get_coeffs_dqy(el, i_dqy) *
+                               pow(LocalParticle_get_delta(part), i_dqy+1));
+            }
+
             cos_y = cos(phase);
             sin_y = sin(phase);
         }
@@ -367,23 +398,7 @@ void LineSegmentMap_track_local_particle(LineSegmentMapData el, LocalParticle* p
         LineSegmentMapData_get_dy(el, 0),
         LineSegmentMapData_get_dpy(el, 0));
 
-    transverse_motion(part0,
-        LineSegmentMapData_get_qx(el),
-        LineSegmentMapData_get_qy(el),
-        LineSegmentMapData_get_dqx(el),
-        LineSegmentMapData_get_dqy(el),
-        LineSegmentMapData_get_det_xx(el),
-        LineSegmentMapData_get_det_xy(el),
-        LineSegmentMapData_get_det_yx(el),
-        LineSegmentMapData_get_det_yy(el),
-        LineSegmentMapData_get_alfx(el, 0),
-        LineSegmentMapData_get_betx(el, 0),
-        LineSegmentMapData_get_alfy(el, 0),
-        LineSegmentMapData_get_bety(el, 0),
-        LineSegmentMapData_get_alfx(el, 1),
-        LineSegmentMapData_get_betx(el, 1),
-        LineSegmentMapData_get_alfy(el, 1),
-        LineSegmentMapData_get_bety(el, 1));
+    transverse_motion(part0, el);
 
     longitudinal_motion(part0, el);
 

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -3528,6 +3528,9 @@ def _add_action_in_res(res, kwargs):
 
 def get_non_linear_chromaticity(line, delta0_range, num_delta, fit_order=3, **kwargs):
 
+    assert 'method' not in kwargs.keys()
+    kwargs['method'] = '4d'
+
     delta0 = np.linspace(delta0_range[0], delta0_range[1], num_delta)
 
     twiss = []


### PR DESCRIPTION
## Description
We add the possibility to specify non-linear chromaticities up to any order in LineSegmentMap.

On top of that we remove the possibility to specify the twiss method in `twiss.get_non_linear_chromaticity`, since the method should always be `'4d'`

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
