### PR TITLE
Update linear_normal_form.py docstring

### DIFF
--- a/xtrack/linear_normal_form.py
+++ b/xtrack/linear_normal_form.py
@@ -89,6 +89,8 @@ def compute_linear_normal_form(M, symplectify=False, only_4d_block=False,
         6x6 matrix
     Rot : np.ndarray
         6x6 matrix
+    eigenvalues : np.ndarray
+        3x1 vector
     '''
 
     if only_4d_block:


### PR DESCRIPTION
4th return was missing from documentation

## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
