### PR TITLE
Implement the IBS kicks configuration API from Line

### DIFF
--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -2362,7 +2362,6 @@ class Line:
     def configure_intrabeam_scattering(
         self, element = None,
         update_every: int = None,
-        _context: xo.context.XContext = None,
         **kwargs,
     ) -> None:
         """
@@ -2387,11 +2386,6 @@ class Line:
             The frequency at which to recompute the kick coefficients, in
             number of turns. They will be computed at the first turn of
             tracking, and then every `update_every` turns afterwards.
-        _context : xo.context.XContext, optional
-            If `element` is provided and `_context` is provided, then this
-            is used when rebuilding the line tracker. If one has specific
-            needs for the built tracker, they should rebuild it themselves
-            after calling this function.
         **kwargs : dict, optional
             Required if an element is provided. Keyword arguments are
             passed to the `line.insert_element()` method according to
@@ -2415,7 +2409,7 @@ class Line:
         except ImportError as error:
             raise ImportError("Please install xfields to use this feature.") from error
         configure_intrabeam_scattering(
-            self, element=element, update_every=update_every, _context=_context, **kwargs
+            self, element=element, update_every=update_every, **kwargs
         )
 
     def compensate_radiation_energy_loss(self, delta0=0, rtol_eneloss=1e-10,

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -2360,7 +2360,10 @@ class Line:
         self.config.XFIELDS_BB3D_NO_BHABHA = (bhabha_flag == 0)
 
     def configure_intrabeam_scattering(
-        self, element = None, update_every: int = None, **kwargs
+        self, element = None,
+        update_every: int = None,
+        _context: xo.context.XContext = None,
+        **kwargs,
     ) -> None:
         """
         Configures the IBS kick element in the line for tracking.
@@ -2384,6 +2387,11 @@ class Line:
             The frequency at which to recompute the kick coefficients, in
             number of turns. They will be computed at the first turn of
             tracking, and then every `update_every` turns afterwards.
+        _context : xo.context.XContext, optional
+            If `element` is provided and `_context` is provided, then this
+            is used when rebuilding the line tracker. If one has specific
+            needs for the built tracker, they should rebuild it themselves
+            after calling this function.
         **kwargs : dict, optional
             Required if an element is provided. Keyword arguments are
             passed to the `line.insert_element()` method according to
@@ -2391,6 +2399,9 @@ class Line:
 
         Raises
         ------
+        ImportError
+            If the xfields package is not installed, with a sufficiently
+            recent version.
         AssertionError
             If the provided `update_every` is not a positive integer.
         AssertionError
@@ -2401,10 +2412,10 @@ class Line:
         """
         try:
             from xfields.ibs import configure_intrabeam_scattering
-        except ImportError:
-            raise ImportError("Please install xfields to use this feature.")
+        except ImportError as error:
+            raise ImportError("Please install xfields to use this feature.") from error
         configure_intrabeam_scattering(
-            self, element=element, update_every=update_every, **kwargs
+            self, element=element, update_every=update_every, _context=_context, **kwargs
         )
 
     def compensate_radiation_energy_loss(self, delta0=0, rtol_eneloss=1e-10,

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -2359,7 +2359,9 @@ class Line:
         self.config.XFIELDS_BB3D_NO_BEAMSTR = (beamstrahlung_flag == 0)
         self.config.XFIELDS_BB3D_NO_BHABHA = (bhabha_flag == 0)
 
-    def configure_intrabeam_scattering(self, update_every: int) -> None:
+    def configure_intrabeam_scattering(
+        self, element = None, update_every: int = None, **kwargs
+    ) -> None:
         """
         Configures the IBS kick element in the line for tracking.
 
@@ -2374,10 +2376,18 @@ class Line:
         ----------
         line : xtrack.Line
             The line in which the IBS kick element was inserted.
+        element : IBSKick, optional
+            If provided, the element is first inserted in the line,
+            before proceeding to configuration. In this case the keyword
+            arguments are passed on to the `line.insert_element` method.
         update_every : int
             The frequency at which to recompute the kick coefficients, in
             number of turns. They will be computed at the first turn of
             tracking, and then every `update_every` turns afterwards.
+        **kwargs : dict, optional
+            Required if an element is provided. Keyword arguments are
+            passed to the `line.insert_element()` method according to
+            `line.insert_element(element=element, **kwargs)`.
 
         Raises
         ------
@@ -2385,12 +2395,17 @@ class Line:
             If the provided `update_every` is not a positive integer.
         AssertionError
             If more than one IBS kick element is found in the line.
+        AssertionError
+            If the element is an `IBSSimpleKick` and the line is operating
+            below transition energy.
         """
         try:
             from xfields.ibs import configure_intrabeam_scattering
         except ImportError:
             raise ImportError("Please install xfields to use this feature.")
-        configure_intrabeam_scattering(self, update_every=update_every)
+        configure_intrabeam_scattering(
+            self, element=element, update_every=update_every, **kwargs
+        )
 
     def compensate_radiation_energy_loss(self, delta0=0, rtol_eneloss=1e-10,
                                     max_iter=100, **kwargs):

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -2359,6 +2359,39 @@ class Line:
         self.config.XFIELDS_BB3D_NO_BEAMSTR = (beamstrahlung_flag == 0)
         self.config.XFIELDS_BB3D_NO_BHABHA = (bhabha_flag == 0)
 
+    def configure_intrabeam_scattering(self, update_every: int) -> None:
+        """
+        Configures the IBS kick element in the line for tracking.
+
+        Notes
+        -----
+            This **should be** one of the last steps taken before tracking.
+            At the very least, if steps are taken that change the lattice's
+            optics after this configuration, then this function should be
+            called once again.
+
+        Parameters
+        ----------
+        line : xtrack.Line
+            The line in which the IBS kick element was inserted.
+        update_every : int
+            The frequency at which to recompute the kick coefficients, in
+            number of turns. They will be computed at the first turn of
+            tracking, and then every `update_every` turns afterwards.
+
+        Raises
+        ------
+        AssertionError
+            If the provided `update_every` is not a positive integer.
+        AssertionError
+            If more than one IBS kick element is found in the line.
+        """
+        try:
+            from xfields.ibs import configure_intrabeam_scattering
+        except ImportError:
+            raise ImportError("Please install xfields to use this feature.")
+        configure_intrabeam_scattering(self, update_every=update_every)
+
     def compensate_radiation_energy_loss(self, delta0=0, rtol_eneloss=1e-10,
                                     max_iter=100, **kwargs):
 

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -2839,7 +2839,7 @@ class TwissTable(Table):
         **kwargs,
     ):
         """
-        Computes IntraBeam Scattering growth rates from the provided `xtrack.Line`.
+        Computes IntraBeam Scattering growth rates.
 
         Parameters
         ----------


### PR DESCRIPTION
## Description

REQUIRES https://github.com/xsuite/xfields/pull/116

This adds a simple method to the `xtrack.Line` configure the IBS kick element (and potentially also install it first, if provided). It mimicks the API introduced in `xfields.ibs` and passes itself as the line, while transmitting all other parameters.

Users would need to upgrade `xfields` to version `>=0.17.0` to use this.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
