### PR TITLE
Fix bug where Tracker._init_io_buffer set buffer to None

### DIFF
--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -151,7 +151,8 @@ class Tracker:
 
     def _init_io_buffer(self, io_buffer=None):
         if io_buffer is None:
-            io_bufs = [ee.io_buffer for ee in self.line.elements if hasattr(ee, 'io_buffer')]
+            io_bufs = [ee.io_buffer for ee in self.line.elements
+                       if getattr(ee, 'io_buffer', None) is not None]
             if len(io_bufs) == 0:
                 io_buffer = new_io_buffer(_context=self._context)
             elif len(np.unique([id(buf) for buf in io_bufs])) > 1:


### PR DESCRIPTION
## Description

Fix a bug where `Tracker._init_io_buffer` would set the tracker's `io_buffer` to `None`.

Closes xsuite/xsuite#502.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
