### PR TITLE
Allow (limited) passing of xt.{START, END} to twiss start/end

### DIFF
--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -1671,3 +1671,54 @@ def test_twiss_strength_reverse_vs_madx(test_context):
 
     assert_allclose(twm1['k5sl', 'mctsxf.3r1:1'], tw.lhcb1['k5sl', 'mctsxf.3r1'], rtol=0, atol=1e-14)
     assert_allclose(twm2['k5sl', 'mctsxf.3r1:1'], tw.lhcb2['k5sl', 'mctsxf.3r1'], rtol=0, atol=1e-14)
+
+
+@for_all_test_contexts
+@pytest.mark.parametrize('line_name', ['lhcb1'])
+@pytest.mark.parametrize('reverse', [False, True])
+@pytest.mark.parametrize('section', [
+    (xt.START, xt.END),
+    (xt.START, '_end_point'),
+])
+def test_twiss_range_start_end(test_context, line_name, reverse, section, collider_for_test_twiss_range):
+    collider = collider_for_test_twiss_range
+    init_at = 'ip5'
+
+    collider.vars['on_x5hs'] = 200
+    collider.vars['on_x5vs'] = 123
+    collider.vars['on_sep5h'] = 1
+    collider.vars['on_sep5v'] = 2
+
+    line = collider[line_name]
+
+    if isinstance(test_context, xo.ContextCpu) and (
+        test_context.omp_num_threads != line._context.omp_num_threads):
+        buffer = test_context.new_buffer()
+    elif isinstance(test_context, line._context.__class__):
+        buffer = line._buffer
+    else:
+        buffer = test_context.new_buffer()
+
+    line.build_tracker(_buffer=buffer)
+
+    tw = line.twiss()
+    tw_init = tw.get_twiss_init(init_at)
+
+    start = section[0]
+    end = section[1]
+    if not reverse:
+        tw_test = line.twiss(start=start, end=end, init=tw_init, reverse=reverse)
+    else:
+        with pytest.raises(ValueError) as excinfo:
+            line.twiss(start=start, end=end, init=tw_init, reverse=reverse)
+        assert 'reverse' in str(excinfo.value)
+        return
+
+    start_el = line.element_names[0]
+    end_el = line.element_names[-1]
+    tw_ref = line.twiss(start=start_el, end=end_el, init=tw_init, reverse=reverse)
+
+    for kk in tw_test._data.keys():
+        if kk in ('particle_on_co', '_action'):
+            continue
+        assert np.all(tw_test._data[kk] == tw_ref._data[kk])

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -511,7 +511,7 @@ def test_periodic_cell_twiss(test_context):
         assert np.isclose(tw_cell_periodic.dqx, dqx_expected, rtol=0, atol=1e-4)
         assert np.isclose(tw_cell_periodic.dqy, dqy_expected, rtol=0, atol=1e-4)
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def collider_for_test_twiss_range():
 
     collider = xt.Multiline.from_json(test_data_folder /

--- a/xtrack/__init__.py
+++ b/xtrack/__init__.py
@@ -3,7 +3,7 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
-from .general import _pkg_root, _print
+from .general import _pkg_root, _print, START, END
 
 from .particles import (Particles, PROTON_MASS_EV, ELECTRON_MASS_EV,
                         enable_pyheadtail_interface, disable_pyheadtail_interface)
@@ -15,8 +15,8 @@ from .tracker_data import TrackerData
 from .line import Line, Node, freeze_longitudinal, _temp_knobs, EnergyProgram
 from .tracker import Tracker, Log
 from .match import (Vary, Target, TargetList, VaryList, TargetInequality, Action,
-                    TargetRelPhaseAdvance, TargetSet, START, END,
-                    GreaterThan, LessThan, TargetRmatrixTerm, TargetRmatrix)
+                    TargetRelPhaseAdvance, TargetSet, GreaterThan, LessThan,
+                    TargetRmatrixTerm, TargetRmatrix)
 from .targets import (TargetLuminosity, TargetSeparationOrthogonalToCrossing,
                       TargetSeparation)
 from .twiss import TwissInit, TwissTable

--- a/xtrack/general.py
+++ b/xtrack/general.py
@@ -3,7 +3,20 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
+from enum import Enum
 from pathlib import Path
-from xobjects.general import _print
+from xobjects.general import _print  # noqa: F401
 
 _pkg_root = Path(__file__).parent.absolute()
+
+
+class _LOC:
+    def __init__(self, name=None):
+        self.name = name
+
+    def __repr__(self):
+        return self.name
+
+
+START = _LOC('START')
+END = _LOC('END')

--- a/xtrack/match.py
+++ b/xtrack/match.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy.optimize import fsolve, minimize
 
 from .twiss import TwissInit, VARS_FOR_TWISS_INIT_GENERATION, _complete_twiss_init
-from .general import _print
+from .general import _print, START, END, _LOC
 import xtrack as xt
 import xdeps as xd
 
@@ -44,15 +44,6 @@ ALLOWED_TARGET_KWARGS= ['x', 'px', 'y', 'py', 'zeta', 'delta', 'pzata', 'ptau',
                         'eq_nemitt_x', 'eq_nemitt_y', 'eq_nemitt_zeta']
 
 Action = xd.Action
-
-class _LOC:
-    def __init__(self, name=None):
-        self.name = name
-    def __repr__(self):
-        return self.name
-
-START = _LOC('START')
-END = _LOC('END')
 
 class ActionTwiss(xd.Action):
 

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -330,10 +330,26 @@ def twiss_line(line, particle_ref=None, method=None,
         assert reverse is False
 
     if start is not None:
-        assert isinstance(start, str) # index not supported anymore
+        if isinstance(start, xt.match._LOC):
+            if reverse:
+                raise ValueError('If reverse=True, `start` must be a name of'
+                                 'an element in the line.')
+            if start is not xt.START:
+                raise ValueError('The value of `start` must be an element name '
+                                 'or xt.START.')
+            start = line.element_names[0]
+        assert isinstance(start, str)  # index not supported anymore
 
     if end is not None:
-        assert isinstance(end, str) # index not supported anymore
+        if isinstance(end, xt.match._LOC):
+            if reverse:
+                raise ValueError('If reverse=True, `end` must be a name of'
+                                 'an element in the line.')
+            if end is not xt.END:
+                raise ValueError('The value of `end` must be an element name '
+                                 'or xt.END.')
+            end = line.element_names[-1]
+        assert isinstance(end, str)  # index not supported anymore
 
     if (init is not None and init != 'periodic'
         or betx is not None or bety is not None):


### PR DESCRIPTION
## Description

Allow passing `xt.START` to the twiss parameter `start` and `xt.END` to the twiss parameter `end`, provided `reverse=False`.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
