### PR TITLE
In test_twiss_range_start_end use a tight but inexact assert; use xo.assert_... everywhere

### DIFF
--- a/tests/test_acceleration.py
+++ b/tests/test_acceleration.py
@@ -3,17 +3,18 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
-import pathlib
 import json
+import pathlib
+
 import numpy as np
 import pandas as pd
+from cpymad.madx import Madx
 from scipy.constants import c as clight
 
+import xobjects as xo
 import xpart as xp
 import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
-
-from cpymad.madx import Madx
 
 test_data_folder = pathlib.Path(
     __file__).parent.joinpath('../test_data').absolute()
@@ -44,7 +45,7 @@ def test_acceleration(test_context):
     p_co = line.find_closed_orbit(particle_ref=xp.Particles.from_dict(
         input_data['particle']))
 
-    assert np.isclose(p_co._xobject.zeta[0], stable_z, atol=0, rtol=1e-2)
+    xo.assert_allclose(p_co._xobject.zeta[0], stable_z, atol=0, rtol=1e-2)
 
 
 @for_all_test_contexts
@@ -115,36 +116,36 @@ def test_energy_program(test_context):
     t_check = np.linspace(0, 20e-3, 1000)
     E_check = np.interp(t_check, t_turn_ref, E_kin_turn)
     E_check_ref = np.interp(t_check, t_s, E_kin_GeV*1e9)
-    assert np.allclose(E_check, E_check_ref, atol=0, rtol=2e-3)
+    xo.assert_allclose(E_check, E_check_ref, atol=0, rtol=2e-3)
 
     t_turn_check = line.energy_program.get_t_s_at_turn(np.arange(n_turn_test))
-    assert np.allclose(t_turn_check, t_turn_ref, atol=0, rtol=6e-4)
+    xo.assert_allclose(t_turn_check, t_turn_ref, atol=0, rtol=6e-4)
 
     p0c_check = line.energy_program.get_p0c_at_t_s(t_check)
     p0c_ref = np.interp(t_check,
                         t_turn_check,
                         line.particle_ref.mass0 * gamma_at_turn * beta_at_turn)
-    assert np.allclose(p0c_check, p0c_ref, atol=0, rtol=1e-3)
+    xo.assert_allclose(p0c_check, p0c_ref, atol=0, rtol=1e-3)
 
     kinetic_energy0_check = line.energy_program.get_kinetic_energy0_at_t_s(t_check)
     kinetic_energy0_ref = np.interp(t_check,
                         t_turn_check,
                         line.particle_ref.mass0 * (gamma_at_turn - 1))
-    assert np.allclose(kinetic_energy0_check, kinetic_energy0_ref, atol=0, rtol=2e-3)
+    xo.assert_allclose(kinetic_energy0_check, kinetic_energy0_ref, atol=0, rtol=2e-3)
 
     beta0_check = line.energy_program.get_beta0_at_t_s(t_check)
     beta0_ref = np.interp(t_check, t_turn_check, beta_at_turn)
-    assert np.allclose(beta0_check, beta0_ref, atol=0, rtol=1e-3)
+    xo.assert_allclose(beta0_check, beta0_ref, atol=0, rtol=1e-3)
 
     frev_check = line.energy_program.get_frev_at_t_s(t_check)
     frev_ref = np.interp(t_check, t_turn_check[:-1], 1/np.diff(t_turn_ref))
-    assert np.allclose(frev_check, frev_ref, atol=0, rtol=4e-5)
+    xo.assert_allclose(frev_check, frev_ref, atol=0, rtol=4e-5)
 
     p0c_increse_per_turn_check = line.energy_program.get_p0c_increse_per_turn_at_t_s(
         t_check)
     p0c_increse_per_turn_ref = np.interp(
         t_check, t_turn_check[:-1], np.diff(monitor.p0c[0, :]))
-    assert np.allclose(p0c_increse_per_turn_check - p0c_increse_per_turn_ref, 0,
+    xo.assert_allclose(p0c_increse_per_turn_check - p0c_increse_per_turn_ref, 0,
                        atol=5e-5 * p0c_ref[0], rtol=0)
 
     line.enable_time_dependent_vars = False
@@ -152,20 +153,20 @@ def test_energy_program(test_context):
 
     E_kin_expected = np.interp(line.vv['t_turn_s'], t_s, E_kin_GeV*1e9)
     E_tot_expected = E_kin_expected + line.particle_ref.mass0
-    assert np.isclose(
+    xo.assert_allclose(
         E_tot_expected, line.particle_ref.energy0[0], rtol=1e-4, atol=0)
-    assert np.isclose(
+    xo.assert_allclose(
         E_kin_expected, line.particle_ref.kinetic_energy0[0], rtol=1e-4, atol=0)
 
     tw = line.twiss(method='6d')
     # To check that it does not change
-    assert np.isclose(tw.zeta[0], -13.48, rtol=0, atol=1e-4)
-    assert np.isclose(line.particle_ref.mass0 * tw.gamma0, E_tot_expected,
+    xo.assert_allclose(tw.zeta[0], -13.48, rtol=0, atol=1e-4)
+    xo.assert_allclose(line.particle_ref.mass0 * tw.gamma0, E_tot_expected,
                       atol=0, rtol=1e-12)
 
     line.vars['t_turn_s'] = 0
     line.vars['on_chicane_k0'] = 0
     tw = line.twiss(method='6d')
-    assert np.allclose(tw.zeta[0], 0, rtol=0, atol=1e-12)
-    assert np.allclose(line.particle_ref.mass0 * tw.gamma0, line.particle_ref.mass0 + E_kin_turn[0],
+    xo.assert_allclose(tw.zeta[0], 0, rtol=0, atol=1e-12)
+    xo.assert_allclose(line.particle_ref.mass0 * tw.gamma0, line.particle_ref.mass0 + E_kin_turn[0],
                        rtol=1e-10, atol=0)

--- a/tests/test_amplitude_detuning.py
+++ b/tests/test_amplitude_detuning.py
@@ -1,4 +1,4 @@
-import numpy as np
+import xobjects as xo
 import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
@@ -11,8 +11,7 @@ def test_amplitude_detuning(test_context):
 
     det = line.get_amplitude_detuning_coefficients()
 
-    assert np.isclose(det['det_xx'], 1000, atol=1e-1, rtol=0)
-    assert np.isclose(det['det_yy'], 2000, atol=1e-1, rtol=0)
-    assert np.isclose(det['det_xy'], 10, atol=1e-1, rtol=0)
-    assert np.isclose(det['det_yx'], 20, atol=1e-1, rtol=0)
-
+    xo.assert_allclose(det['det_xx'], 1000, atol=1e-1, rtol=0)
+    xo.assert_allclose(det['det_yy'], 2000, atol=1e-1, rtol=0)
+    xo.assert_allclose(det['det_xy'], 10, atol=1e-1, rtol=0)
+    xo.assert_allclose(det['det_yx'], 20, atol=1e-1, rtol=0)

--- a/tests/test_aperture_turn_ele_and_monitor.py
+++ b/tests/test_aperture_turn_ele_and_monitor.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 
+import xobjects as xo
 import xtrack as xt
 import xpart as xp
 from xobjects.test_helpers import for_all_test_contexts
@@ -79,13 +80,13 @@ def test_aperture_turn_ele_and_monitor(test_context):
     at_element_expected = np.int_(np.clip(at_element_expected, 0,
                                           n_slices-1))
 
-    assert np.allclose(part_s + at_turn_expected*line.get_length(), s_expected,
+    xo.assert_allclose(part_s + at_turn_expected*line.get_length(), s_expected,
                        atol=1e-3)
-    assert np.allclose(at_turn_expected, part_at_turn)
+    xo.assert_allclose(at_turn_expected, part_at_turn)
 
     # I need to add a tolerance of one element as a mismatch is visible
     # on a few slices due to rounding
-    assert np.allclose(at_element_expected, part_at_element, atol=1.1)
+    xo.assert_allclose(at_element_expected, part_at_element, atol=1.1)
 
     # Test monitor
     mon = line.record_last_track
@@ -192,13 +193,13 @@ def test_custom_monitor(test_context):
     at_element_expected = np.int_(np.clip(at_element_expected, 0,
                                           n_slices-1))
 
-    assert np.allclose(part_s + at_turn_expected * line.get_length(),
+    xo.assert_allclose(part_s + at_turn_expected * line.get_length(),
                        s_expected, atol=1e-3)
-    assert np.allclose(at_turn_expected, part_at_turn)
+    xo.assert_allclose(at_turn_expected, part_at_turn)
 
     # I need to add a tolerance of one element as a mismatch is visible
     # on a few slices due to rounding
-    assert np.allclose(at_element_expected, part_at_element, atol=1.1)
+    xo.assert_allclose(at_element_expected, part_at_element, atol=1.1)
 
     # Test monitor
     mon = monitor

--- a/tests/test_apertures.py
+++ b/tests/test_apertures.py
@@ -104,7 +104,7 @@ def test_aperture_polygon(test_context):
                     x=x_vertices*0.99,
                     y=y_vertices*0.99)
     aper.track(parttest)
-    assert np.allclose(ctx2np(parttest.state), 1)
+    xo.assert_allclose(ctx2np(parttest.state), 1)
 
     # Try some particles outside
     parttest = xp.Particles(
@@ -113,7 +113,7 @@ def test_aperture_polygon(test_context):
                     x=x_vertices*1.01,
                     y=y_vertices*1.01)
     aper.track(parttest)
-    assert np.allclose(ctx2np(parttest.state), 0)
+    xo.assert_allclose(ctx2np(parttest.state), 0)
 
 
 def test_mad_import():
@@ -152,13 +152,13 @@ def test_mad_import():
 
     circ = apertures[0]
     assert circ.__class__.__name__ == 'LimitEllipse'
-    assert np.isclose(circ.a_squ, .2**2, atol=1e-13, rtol=0)
-    assert np.isclose(circ.b_squ, .2**2, atol=1e-13, rtol=0)
+    xo.assert_allclose(circ.a_squ, .2**2, atol=1e-13, rtol=0)
+    xo.assert_allclose(circ.b_squ, .2**2, atol=1e-13, rtol=0)
 
     ellip = apertures[1]
     assert ellip.__class__.__name__ == 'LimitEllipse'
-    assert np.isclose(ellip.a_squ, .2**2, atol=1e-13, rtol=0)
-    assert np.isclose(ellip.b_squ, .1**2, atol=1e-13, rtol=0)
+    xo.assert_allclose(ellip.a_squ, .2**2, atol=1e-13, rtol=0)
+    xo.assert_allclose(ellip.b_squ, .1**2, atol=1e-13, rtol=0)
 
     rect = apertures[2]
     assert rect.__class__.__name__ == 'LimitRect'
@@ -170,8 +170,8 @@ def test_mad_import():
     rectellip = apertures[3]
     assert rectellip.max_x == .2
     assert rectellip.max_y == .4
-    assert np.isclose(rectellip.a_squ, .25**2, atol=1e-13, rtol=0)
-    assert np.isclose(rectellip.b_squ, .45**2, atol=1e-13, rtol=0)
+    xo.assert_allclose(rectellip.a_squ, .25**2, atol=1e-13, rtol=0)
+    xo.assert_allclose(rectellip.b_squ, .45**2, atol=1e-13, rtol=0)
 
     racetr = apertures[4]
     assert racetr.__class__.__name__ == 'LimitRacetrack'
@@ -185,26 +185,26 @@ def test_mad_import():
     octag = apertures[5]
     assert octag.__class__.__name__ == 'LimitPolygon'
     assert octag._xobject.x_vertices[0] == 0.4
-    assert np.isclose(octag._xobject.y_vertices[0], 0.4*np.tan(0.5), atol=1e-14, rtol=0)
+    xo.assert_allclose(octag._xobject.y_vertices[0], 0.4*np.tan(0.5), atol=1e-14, rtol=0)
     assert octag._xobject.y_vertices[1] == 0.5
-    assert np.isclose(octag._xobject.x_vertices[1], 0.5/np.tan(1.), atol=1e-14, rtol=0)
+    xo.assert_allclose(octag._xobject.x_vertices[1], 0.5/np.tan(1.), atol=1e-14, rtol=0)
 
     assert octag._xobject.y_vertices[2] == 0.5
-    assert np.isclose(octag._xobject.x_vertices[2], -0.5/np.tan(1.), atol=1e-14, rtol=0)
+    xo.assert_allclose(octag._xobject.x_vertices[2], -0.5/np.tan(1.), atol=1e-14, rtol=0)
     assert octag._xobject.x_vertices[3] == -0.4
-    assert np.isclose(octag._xobject.y_vertices[3], 0.4*np.tan(0.5), atol=1e-14, rtol=0)
+    xo.assert_allclose(octag._xobject.y_vertices[3], 0.4*np.tan(0.5), atol=1e-14, rtol=0)
 
 
     assert octag._xobject.x_vertices[4] == -0.4
-    assert np.isclose(octag._xobject.y_vertices[4], -0.4*np.tan(0.5), atol=1e-14, rtol=0)
+    xo.assert_allclose(octag._xobject.y_vertices[4], -0.4*np.tan(0.5), atol=1e-14, rtol=0)
     assert octag._xobject.y_vertices[5] == -0.5
-    assert np.isclose(octag._xobject.x_vertices[5], -0.5/np.tan(1.), atol=1e-14, rtol=0)
+    xo.assert_allclose(octag._xobject.x_vertices[5], -0.5/np.tan(1.), atol=1e-14, rtol=0)
 
 
     assert octag._xobject.y_vertices[6] == -0.5
-    assert np.isclose(octag._xobject.x_vertices[6], 0.5/np.tan(1.), atol=1e-14, rtol=0)
+    xo.assert_allclose(octag._xobject.x_vertices[6], 0.5/np.tan(1.), atol=1e-14, rtol=0)
     assert octag._xobject.x_vertices[7] == 0.4
-    assert np.isclose(octag._xobject.y_vertices[7], -0.4*np.tan(0.5), atol=1e-14, rtol=0)
+    xo.assert_allclose(octag._xobject.y_vertices[7], -0.4*np.tan(0.5), atol=1e-14, rtol=0)
 
     polyg = apertures[6]
     assert polyg.__class__.__name__ == 'LimitPolygon'

--- a/tests/test_cavity_absolute_time.py
+++ b/tests/test_cavity_absolute_time.py
@@ -1,8 +1,8 @@
-import numpy as np
+import pathlib
+
+import xobjects as xo
 import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
-
-import pathlib
 
 test_data_folder = pathlib.Path(
     __file__).parent.joinpath('../test_data').absolute()
@@ -39,9 +39,9 @@ def test_cavity_absolute_time(test_context):
 
     f_rev_expected = f_rf / h_rf
 
-    assert np.isclose(f_rev_expected, 1/tw1.T_rev, atol=1e-5, rtol=0)
-    assert np.allclose(tw1.delta, tw1.delta[0], atol=1e-5, rtol=0) # Check that it is flat
+    xo.assert_allclose(f_rev_expected, 1/tw1.T_rev, atol=1e-5, rtol=0)
+    xo.assert_allclose(tw1.delta, tw1.delta[0], atol=1e-5, rtol=0) # Check that it is flat
     delta_expected = -df_rev / f_rev / eta
-    assert np.allclose(tw1.delta, delta_expected, atol=2e-6, rtol=0)
+    xo.assert_allclose(tw1.delta, delta_expected, atol=2e-6, rtol=0)
     tw_off_mom = line.twiss(method='4d', delta0=tw1.delta[0])
-    assert np.allclose(tw1.x, tw_off_mom.x, atol=1e-5, rtol=0)
+    xo.assert_allclose(tw1.x, tw_off_mom.x, atol=1e-5, rtol=0)

--- a/tests/test_chromatic_functions_vs_madx.py
+++ b/tests/test_chromatic_functions_vs_madx.py
@@ -1,5 +1,8 @@
 import pathlib
+
 from cpymad.madx import Madx
+
+import xobjects as xo
 import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
@@ -61,12 +64,12 @@ def test_chromatic_functions_vs_madx(test_context):
         bx_ref = np.real(zx_ref)
         by_ref = np.real(zy_ref)
 
-        assert np.allclose(tw_test.wx_chrom, wx_ref, rtol=0, atol=2e-3 * np.max(wx_ref))
-        assert np.allclose(tw_test.wy_chrom, wy_ref, rtol=0, atol=2e-3 * np.max(wy_ref))
-        assert np.allclose(tw_test.ax_chrom, ax_ref, rtol=0, atol=2e-3 * np.max(ax_ref))
-        assert np.allclose(tw_test.ay_chrom, ay_ref, rtol=0, atol=2e-3 * np.max(ay_ref))
-        assert np.allclose(tw_test.bx_chrom, bx_ref, rtol=0, atol=2e-3 * np.max(bx_ref))
-        assert np.allclose(tw_test.by_chrom, by_ref, rtol=0, atol=2e-3 * np.max(by_ref))
+        xo.assert_allclose(tw_test.wx_chrom, wx_ref, rtol=0, atol=2e-3 * np.max(wx_ref))
+        xo.assert_allclose(tw_test.wy_chrom, wy_ref, rtol=0, atol=2e-3 * np.max(wy_ref))
+        xo.assert_allclose(tw_test.ax_chrom, ax_ref, rtol=0, atol=2e-3 * np.max(ax_ref))
+        xo.assert_allclose(tw_test.ay_chrom, ay_ref, rtol=0, atol=2e-3 * np.max(ay_ref))
+        xo.assert_allclose(tw_test.bx_chrom, bx_ref, rtol=0, atol=2e-3 * np.max(bx_ref))
+        xo.assert_allclose(tw_test.by_chrom, by_ref, rtol=0, atol=2e-3 * np.max(by_ref))
 
         # Open twiss
         init = tw.get_twiss_init('ip3')
@@ -74,13 +77,13 @@ def test_chromatic_functions_vs_madx(test_context):
                             compute_chromatic_properties=True)
 
         tw_ref_open = tw.rows['ip3':'ip6']
-        assert np.allclose(tw_open.wx_chrom[:-1], tw_ref_open.wx_chrom,
+        xo.assert_allclose(tw_open.wx_chrom[:-1], tw_ref_open.wx_chrom,
                         rtol=0, atol=2e-3 * np.max(tw_ref_open.wx_chrom))
-        assert np.allclose(tw_open.wy_chrom[:-1], tw_ref_open.wy_chrom,
+        xo.assert_allclose(tw_open.wy_chrom[:-1], tw_ref_open.wy_chrom,
                         rtol=0, atol=2e-3 * np.max(tw_ref_open.wy_chrom))
-        assert np.allclose(tw_open.ax_chrom[:-1], tw_ref_open.ax_chrom,
+        xo.assert_allclose(tw_open.ax_chrom[:-1], tw_ref_open.ax_chrom,
                             rtol=0, atol=2e-3 * np.max(tw_ref_open.ax_chrom))
-        assert np.allclose(tw_open.ay_chrom[:-1], tw_ref_open.ay_chrom,
+        xo.assert_allclose(tw_open.ay_chrom[:-1], tw_ref_open.ay_chrom,
                                 rtol=0, atol=2e-3 * np.max(tw_ref_open.ay_chrom))
-        assert np.allclose(tw_open.bx_chrom[:-1], tw_ref_open.bx_chrom,
+        xo.assert_allclose(tw_open.bx_chrom[:-1], tw_ref_open.bx_chrom,
                                 rtol=0, atol=2e-3 * np.max(tw_ref_open.bx_chrom))

--- a/tests/test_coasting.py
+++ b/tests/test_coasting.py
@@ -1,8 +1,9 @@
-import numpy as np
-import xtrack as xt
 import pathlib
 
+import numpy as np
 from scipy.constants import c as clight
+
+import xtrack as xt
 
 test_data_folder = pathlib.Path(
     __file__).parent.joinpath('../test_data').absolute()
@@ -138,9 +139,9 @@ def test_coasting():
     print('f_measured: ', f_measured, ' Hz')
     print('Error:      ', f_measured - f_expected, 'Hz')
 
-    assert np.isclose(f_expected, f_measured, rtol=0, atol=5.) # 5 Hz tolerance (to account for random fluctuations)
-    assert np.isclose(np.mean(inten), inten_exp, rtol=1e-2, atol=0)
-    assert np.allclose(p.at_turn, num_turns*0.9, rtol=3e-2, atol=0) #beta1 defaults to 0.1
+    xo.assert_allclose(f_expected, f_measured, rtol=0, atol=5.) # 5 Hz tolerance (to account for random fluctuations)
+    xo.assert_allclose(np.mean(inten), inten_exp, rtol=1e-2, atol=0)
+    xo.assert_allclose(p.at_turn, num_turns*0.9, rtol=3e-2, atol=0) #beta1 defaults to 0.1
 
     tt = line.get_table()
     tt_synch = tt.rows[tt.element_type=='SyncTime']

--- a/tests/test_collective_tracker.py
+++ b/tests/test_collective_tracker.py
@@ -3,17 +3,10 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
-import pathlib
-import json
-import numpy as np
-
 import xobjects as xo
-import xtrack as xt
-import xfields as xf
 import xpart as xp
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
-
-import ducktrack as dtk
 
 
 @for_all_test_contexts
@@ -92,7 +85,7 @@ def test_get_non_collective_line(test_context):
     assert nc_line['e7'] is line['e7']
     assert nc_line.tracker.line is nc_line
 
-    assert np.allclose(nc_line.get_s_elements(), line.get_s_elements(),
+    xo.assert_allclose(nc_line.get_s_elements(), line.get_s_elements(),
                     rtol=0, atol=1e-15)
 
     assert nc_line.tracker is not line.tracker

--- a/tests/test_collimation.py
+++ b/tests/test_collimation.py
@@ -4,13 +4,14 @@
 # ######################################### #
 
 import logging
-import pytest
 
 import numpy as np
+import pytest
 
 import xobjects as xo
-import xtrack as xt
 import xpart as xp
+import xtrack as xt
+
 
 def test_collimation_infrastructure():
 
@@ -218,7 +219,7 @@ def test_aperture_refinement(sandwitch_aper):
     r1 = np.sqrt(aper_1.a_squ)
     s_expected = s0 + (r_calc-r0)/(r1 - r0)*(s1 - s0)
     # TODO This threshold is a bit large
-    assert np.allclose(particles.s[mask_lost], s_expected[mask_lost], atol=0.11)
+    xo.assert_allclose(particles.s[mask_lost], s_expected[mask_lost], atol=0.11)
 
 
 def test_losslocationrefinement_thick_collective_collimator():
@@ -323,7 +324,7 @@ def test_losslocationrefinement_thick_collective_collimator():
 
     loss_loc_refinement.refine_loss_location(particles)
 
-    assert np.allclose(particles.s[mask_lost], 9.00,
+    xo.assert_allclose(particles.s[mask_lost], 9.00,
                        rtol=0, atol=loss_loc_refinement.ds*1.0001)
 
 def test_losslocationrefinement_skip_refinement_for_collimators():

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -5,15 +5,13 @@
 
 import numpy as np
 import pytest
-import xobjects as xo
-import xpart as xp
 from cpymad.madx import Madx
-from scipy.stats import linregress
-from xobjects.test_helpers import for_all_test_contexts
 
 import ducktrack as dtk
+import xobjects as xo
+import xpart as xp
 import xtrack as xt
-from xtrack import MadLoader
+from xobjects.test_helpers import for_all_test_contexts
 from xtrack.beam_elements.elements import _angle_from_trig
 
 
@@ -108,7 +106,7 @@ def test__angle_from_trig(cos, sin, tan, angle):
         if tan is not None:
             assert tan == tan_res
 
-        assert np.isclose(angle, result, atol=1e-13)
+        xo.assert_allclose(angle, result, atol=1e-13)
 
 
 @for_all_test_contexts
@@ -158,7 +156,7 @@ def test_backtrack(test_context):
 
         # assert that nothing changed
         for k in 'x,px,y,py,zeta,delta'.split(','):
-            assert np.isclose(test_context.nparray_from_context_array(
+            xo.assert_allclose(test_context.nparray_from_context_array(
                       getattr(new_particles, k))[0],
                       getattr(dtk_particle, k), rtol=1e-14, atol=1e-14)
 
@@ -201,11 +199,11 @@ def test_drift(test_context):
     dtk_drift = dtk.elements.Drift(length=10.)
     dtk_drift.track(dtk_particle)
 
-    assert np.isclose(test_context.nparray_from_context_array(particles.x)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.x)[0],
                       dtk_particle.x, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.y)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.y)[0],
                       dtk_particle.y, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.zeta)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.zeta)[0],
                       dtk_particle.zeta,
                       rtol=1e-14, atol=1e-14)
 
@@ -233,11 +231,11 @@ def test_drift_exact(test_context):
     dtk_drift = dtk.elements.DriftExact(length=10.)
     dtk_drift.track(dtk_particle)
 
-    assert np.isclose(test_context.nparray_from_context_array(particles.x)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.x)[0],
                       dtk_particle.x, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.y)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.y)[0],
                       dtk_particle.y, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.zeta)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.zeta)[0],
                       dtk_particle.zeta,
                       rtol=1e-14, atol=1e-14)
 
@@ -259,12 +257,12 @@ def test_marker(test_context):
     marker = xt.Marker(_context=test_context)
     marker.track(particles)
 
-    assert np.isclose(test_context.nparray_from_context_array(particles.zeta)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.zeta)[0],
                       dtk_particle.zeta,
                       rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.x)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.x)[0],
                       dtk_particle.x, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.y)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.y)[0],
                       dtk_particle.y, rtol=1e-14, atol=1e-14)
 
 
@@ -299,9 +297,9 @@ def test_elens(test_context):
 
     dtk_elens.track(dtk_particle)
 
-    assert np.isclose(test_context.nparray_from_context_array(particles.px)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.px)[0],
                       dtk_particle.px, rtol=1e-2, atol=1e-2)
-    assert np.isclose(test_context.nparray_from_context_array(particles.py)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.py)[0],
                       dtk_particle.py, rtol=1e-9, atol=1e-9)
 
 
@@ -357,9 +355,9 @@ def test_elens_measured_radial(test_context):
 
     particle_test.move(_context=xo.ContextCpu())
 
-    assert np.isclose(particle_test.px[0], particle_ref.px[0],
+    xo.assert_allclose(particle_test.px[0], particle_ref.px[0],
                       rtol=1e-2, atol=1e-2)
-    assert np.isclose(particle_test.py[0], particle_ref.py[0],
+    xo.assert_allclose(particle_test.py[0], particle_ref.py[0],
                       rtol=1e-2, atol=1e-2)
 
 
@@ -395,9 +393,9 @@ def test_wire(test_context):
 
     dtk_wire.track(dtk_particle)
 
-    assert np.isclose(test_context.nparray_from_context_array(particles.px)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.px)[0],
                       dtk_particle.px, rtol=1e-9, atol=1e-9)
-    assert np.isclose(test_context.nparray_from_context_array(particles.py)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.py)[0],
                       dtk_particle.py, rtol=1e-9, atol=1e-9)
 
 
@@ -427,17 +425,17 @@ def test_linear_transfer_first_order_taylor_map(test_context):
     dtk_arc = dtk.elements.FirstOrderTaylorMap(m0 = m0, m1 = m1)
     dtk_arc.track(dtk_particle)
 
-    assert np.isclose(test_context.nparray_from_context_array(particles.x)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.x)[0],
                       dtk_particle.x, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.px)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.px)[0],
                       dtk_particle.px, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.y)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.y)[0],
                       dtk_particle.y, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.py)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.py)[0],
                       dtk_particle.py, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.zeta)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.zeta)[0],
                       dtk_particle.zeta, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.delta)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.delta)[0],
                       dtk_particle.delta, rtol=1e-14, atol=1e-14)
 
 
@@ -451,7 +449,7 @@ def test_cavity(test_context):
 
     part = part.copy(_context=xo.ContextCpu())
 
-    assert np.allclose(part.energy,
+    xo.assert_allclose(part.energy,
                             part0.energy+cav.voltage, atol=5e-7, rtol=0)
 
     Pc = np.sqrt(part.energy**2 - part.mass0**2)
@@ -461,11 +459,11 @@ def test_cavity(test_context):
     tau0 = part0.zeta/(part0.beta0)
     tau = part.zeta/(part.beta0)
 
-    assert np.allclose(part.delta, delta, atol=1e-14, rtol=0)
-    assert np.allclose(part.rpp, 1/(1+delta), atol=1e-14, rtol=0)
-    assert np.allclose(part.rvv, beta/part.beta0, atol=1e-14, rtol=0)
-    assert np.allclose(tau, tau0, atol=1e-14, rtol=0)
-    assert np.allclose((part.ptau - part0.ptau) * part0.p0c, 30, atol=1e-9, rtol=0)
+    xo.assert_allclose(part.delta, delta, atol=1e-14, rtol=0)
+    xo.assert_allclose(part.rpp, 1/(1+delta), atol=1e-14, rtol=0)
+    xo.assert_allclose(part.rvv, beta/part.beta0, atol=1e-14, rtol=0)
+    xo.assert_allclose(tau, tau0, atol=1e-14, rtol=0)
+    xo.assert_allclose((part.ptau - part0.ptau) * part0.p0c, 30, atol=1e-9, rtol=0)
 
 @for_all_test_contexts
 def test_exciter(test_context):
@@ -487,19 +485,19 @@ def test_exciter(test_context):
     expected_px = np.array([0.1, 0.2, 0.3])
     particles.move(_context=xo.context_default)
 
-    assert np.allclose(particles.px, expected_px)
+    xo.assert_allclose(particles.px, expected_px)
 
     particles.move(_context=test_context)
     line.track(particles, num_turns=1)
     expected_px += np.array([0.2, 0.3, 0.1])
     particles.move(_context=xo.context_default)
-    assert np.allclose(particles.px, expected_px)
+    xo.assert_allclose(particles.px, expected_px)
 
     particles.move(_context=test_context)
     line.track(particles, num_turns=1)
     expected_px += np.array([0.3, 0.1, 0])
     particles.move(_context=xo.context_default)
-    assert np.allclose(particles.px, expected_px)
+    xo.assert_allclose(particles.px, expected_px)
 
 
 test_source = r"""
@@ -639,17 +637,17 @@ def test_simplified_accelerator_segment(test_context):
 
     dtk_arc.track(dtk_particle)
 
-    assert np.isclose(test_context.nparray_from_context_array(particles.x)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.x)[0],
                       dtk_particle.x, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.px)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.px)[0],
                       dtk_particle.px, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.y)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.y)[0],
                       dtk_particle.y, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.py)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.py)[0],
                       dtk_particle.py, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.zeta)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.zeta)[0],
                       dtk_particle.zeta, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.delta)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.delta)[0],
                       dtk_particle.delta, rtol=1e-14, atol=1e-14)
 
 
@@ -728,17 +726,17 @@ def test_simplified_accelerator_segment_chroma_detuning(test_context):
         y_ref_0 = y_ref_0, py_ref_0 = py_ref_0, y_ref_1 = y_ref_1, py_ref_1 = py_ref_1)
     dtk_arc.track(dtk_particle)
 
-    assert np.isclose(test_context.nparray_from_context_array(particles.x)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.x)[0],
                       dtk_particle.x, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.px)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.px)[0],
                       dtk_particle.px, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.y)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.y)[0],
                       dtk_particle.y, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.py)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.py)[0],
                       dtk_particle.py, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.zeta)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.zeta)[0],
                       dtk_particle.zeta, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.delta)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.delta)[0],
                       dtk_particle.delta, rtol=1e-14, atol=1e-14)
 
 
@@ -823,17 +821,17 @@ def test_simplified_accelerator_segment_uncorrelated_damping(test_context):
         damping_rate_zeta = damping_rate_zeta,damping_rate_pzeta = damping_rate_pzeta)
     dtk_arc.track(dtk_particle)
     
-    assert np.isclose(test_context.nparray_from_context_array(particles.x)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.x)[0],
                       dtk_particle.x, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.px)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.px)[0],
                       dtk_particle.px, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.y)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.y)[0],
                       dtk_particle.y, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.py)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.py)[0],
                       dtk_particle.py, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.zeta)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.zeta)[0],
                       dtk_particle.zeta, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.delta)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.delta)[0],
                       dtk_particle.delta, rtol=1e-14, atol=1e-14)
 
 @for_all_test_contexts
@@ -908,17 +906,17 @@ def test_simplified_accelerator_segment_correlated_damping(test_context):
         damping_matrix = damping_matrix)
     dtk_arc.track(dtk_particle)
     
-    assert np.isclose(test_context.nparray_from_context_array(particles.x)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.x)[0],
                       dtk_particle.x, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.px)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.px)[0],
                       dtk_particle.px, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.y)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.y)[0],
                       dtk_particle.y, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.py)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.py)[0],
                       dtk_particle.py, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.zeta)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.zeta)[0],
                       dtk_particle.zeta, rtol=1e-14, atol=1e-14)
-    assert np.isclose(test_context.nparray_from_context_array(particles.delta)[0],
+    xo.assert_allclose(test_context.nparray_from_context_array(particles.delta)[0],
                       dtk_particle.delta, rtol=1e-14, atol=1e-14)
 
 @for_all_test_contexts
@@ -1004,9 +1002,9 @@ def test_simplified_accelerator_segment_uncorrelated_damping_equilibrium(test_co
     equ_emit_y_0 = np.average(emit_y)
     equ_emit_s_0 = np.average(emit_s)
 
-    assert np.isclose(equ_emit_x,equ_emit_x_0, rtol=1e-1, atol=1e-10)
-    assert np.isclose(equ_emit_y,equ_emit_y_0, rtol=1e-1, atol=1e-10)
-    assert np.isclose(equ_emit_s,equ_emit_s_0, rtol=1e-1, atol=1e-10)
+    xo.assert_allclose(equ_emit_x,equ_emit_x_0, rtol=1e-1, atol=1e-10)
+    xo.assert_allclose(equ_emit_y,equ_emit_y_0, rtol=1e-1, atol=1e-10)
+    xo.assert_allclose(equ_emit_s,equ_emit_s_0, rtol=1e-1, atol=1e-10)
 
 
 @for_all_test_contexts
@@ -1097,13 +1095,13 @@ def test_nonlinearlens(test_context):
         px.append(mad_results.px)
         py.append(mad_results.py)
 
-        assert np.allclose(part.x[ii], mad_results.x, atol=1e-14, rtol=0), 'x'
-        assert np.allclose(part.px[ii], mad_results.px, atol=1e-14, rtol=0), 'px'
-        assert np.allclose(part.y[ii], mad_results.y, atol=1e-14, rtol=0), 'y'
-        assert np.allclose(part.py[ii], mad_results.py, atol=1e-14, rtol=0), 'py'
-        assert np.allclose(xt_tau[ii], mad_results.t, atol=1e-14, rtol=0), 't'
-        assert np.allclose(part.ptau[ii], mad_results.pt, atol=1e-14, rtol=0), 'pt'
-        assert np.allclose(part.s[ii], mad_results.s, atol=1e-14, rtol=0), 's'
+        xo.assert_allclose(part.x[ii], mad_results.x, atol=1e-14, rtol=0), 'x'
+        xo.assert_allclose(part.px[ii], mad_results.px, atol=1e-14, rtol=0), 'px'
+        xo.assert_allclose(part.y[ii], mad_results.y, atol=1e-14, rtol=0), 'y'
+        xo.assert_allclose(part.py[ii], mad_results.py, atol=1e-14, rtol=0), 'py'
+        xo.assert_allclose(xt_tau[ii], mad_results.t, atol=1e-14, rtol=0), 't'
+        xo.assert_allclose(part.ptau[ii], mad_results.pt, atol=1e-14, rtol=0), 'pt'
+        xo.assert_allclose(part.s[ii], mad_results.s, atol=1e-14, rtol=0), 's'
 
 @for_all_test_contexts
 def test_multipole_tilt_90_deg(test_context):
@@ -1125,12 +1123,12 @@ def test_multipole_tilt_90_deg(test_context):
     p.move(_context=xo.context_default)
     py.move(_context=xo.context_default)
 
-    assert np.allclose(p.x, py.x, rtol=0, atol=1e-14)
-    assert np.allclose(p.y, py.y, rtol=0, atol=1e-14)
-    assert np.allclose(p.px, py.px, rtol=0, atol=1e-14)
-    assert np.allclose(p.py, py.py, rtol=0, atol=1e-14)
-    assert np.allclose(p.zeta, py.zeta, rtol=0, atol=1e-14)
-    assert np.allclose(p.ptau, py.ptau, rtol=0, atol=1e-14)
+    xo.assert_allclose(p.x, py.x, rtol=0, atol=1e-14)
+    xo.assert_allclose(p.y, py.y, rtol=0, atol=1e-14)
+    xo.assert_allclose(p.px, py.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(p.py, py.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(p.zeta, py.zeta, rtol=0, atol=1e-14)
+    xo.assert_allclose(p.ptau, py.ptau, rtol=0, atol=1e-14)
 
     # Check weak focusing
     pf = xt.Particles(x=0, y=0.3, delta=0., p0c=1e12, _context=test_context)
@@ -1142,9 +1140,9 @@ def test_multipole_tilt_90_deg(test_context):
     pf.move(_context=xo.context_default)
     pfy.move(_context=xo.context_default)
 
-    assert np.allclose(pf.x, pfy.x, rtol=0, atol=1e-14)
-    assert np.allclose(pf.y, pfy.y, rtol=0, atol=1e-14)
-    assert np.allclose(pf.px, pfy.px, rtol=0, atol=1e-14)
-    assert np.allclose(pf.py, pfy.py, rtol=0, atol=1e-14)
-    assert np.allclose(pf.zeta, pfy.zeta, rtol=0, atol=1e-14)
-    assert np.allclose(pf.ptau, pfy.ptau, rtol=0, atol=1e-14)
+    xo.assert_allclose(pf.x, pfy.x, rtol=0, atol=1e-14)
+    xo.assert_allclose(pf.y, pfy.y, rtol=0, atol=1e-14)
+    xo.assert_allclose(pf.px, pfy.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(pf.py, pfy.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(pf.zeta, pfy.zeta, rtol=0, atol=1e-14)
+    xo.assert_allclose(pf.ptau, pfy.ptau, rtol=0, atol=1e-14)

--- a/tests/test_elements_thick.py
+++ b/tests/test_elements_thick.py
@@ -4,12 +4,12 @@
 # ######################################### #
 import numpy as np
 import pytest
+from cpymad.madx import Madx
+
 import xobjects as xo
 import xpart as xp
-from cpymad.madx import Madx
-from xobjects.test_helpers import for_all_test_contexts
-
 import xtrack as xt
+from xobjects.test_helpers import for_all_test_contexts
 from xtrack.mad_loader import MadLoader
 from xtrack.slicing import Strategy, Uniform
 
@@ -91,17 +91,17 @@ def test_combined_function_dipole_against_ptc(test_context, k0, k1, k2, length,
         part.move(_context=xo.context_default)
 
         xt_tau = part.zeta/part.beta0
-        assert np.allclose(part.x[ii], mad_results.x, rtol=0,
+        xo.assert_allclose(part.x[ii], mad_results.x, rtol=0,
                            atol=(1e-11 if k1 == 0 and k2 == 0 else 5e-9))
-        assert np.allclose(part.px[ii], mad_results.px, rtol=0,
+        xo.assert_allclose(part.px[ii], mad_results.px, rtol=0,
                            atol=(1e-11 if k1 == 0 and k2 == 0 else 5e-9))
-        assert np.allclose(part.y[ii], mad_results.y, rtol=0,
+        xo.assert_allclose(part.y[ii], mad_results.y, rtol=0,
                            atol=(1e-11 if k1 == 0 and k2 == 0 else 5e-9))
-        assert np.allclose(part.py[ii], mad_results.py, rtol=0,
+        xo.assert_allclose(part.py[ii], mad_results.py, rtol=0,
                            atol=(1e-11 if k1 == 0 and k2 == 0 else 5e-9))
-        assert np.allclose(xt_tau[ii], mad_results.t, rtol=0,
+        xo.assert_allclose(xt_tau[ii], mad_results.t, rtol=0,
                            atol=(1e-10 if k1 == 0 and k2 == 0 else 5e-9))
-        assert np.allclose(part.ptau[ii], mad_results.pt, atol=1e-11, rtol=0)
+        xo.assert_allclose(part.ptau[ii], mad_results.pt, atol=1e-11, rtol=0)
 
         part = p0.copy(_context=test_context)
         line_core_only.track(part)
@@ -109,12 +109,12 @@ def test_combined_function_dipole_against_ptc(test_context, k0, k1, k2, length,
         part.move(_context=xo.context_default)
         p0.move(_context=xo.context_default)
         assert np.all(part.state == 1)
-        assert np.allclose(part.x[ii], p0.x[ii], atol=1e-11, rtol=0)
-        assert np.allclose(part.px[ii], p0.px[ii], atol=1e-11, rtol=0)
-        assert np.allclose(part.y[ii], p0.y[ii], atol=1e-11, rtol=0)
-        assert np.allclose(part.py[ii], p0.py[ii], atol=1e-11, rtol=0)
-        assert np.allclose(part.zeta[ii], p0.zeta[ii], atol=1e-11, rtol=0)
-        assert np.allclose(part.ptau[ii], p0.ptau[ii], atol=1e-11, rtol=0)
+        xo.assert_allclose(part.x[ii], p0.x[ii], atol=1e-11, rtol=0)
+        xo.assert_allclose(part.px[ii], p0.px[ii], atol=1e-11, rtol=0)
+        xo.assert_allclose(part.y[ii], p0.y[ii], atol=1e-11, rtol=0)
+        xo.assert_allclose(part.py[ii], p0.py[ii], atol=1e-11, rtol=0)
+        xo.assert_allclose(part.zeta[ii], p0.zeta[ii], atol=1e-11, rtol=0)
+        xo.assert_allclose(part.ptau[ii], p0.ptau[ii], atol=1e-11, rtol=0)
 
 @for_all_test_contexts
 def test_combined_function_dipole_expanded(test_context):
@@ -147,12 +147,12 @@ def test_combined_function_dipole_expanded(test_context):
     line_thick.track(p_ref)
     p_ref.move(_context=xo.context_default)
 
-    assert np.allclose(p_test.x, p_ref.x, rtol=0, atol=5e-9)
-    assert np.allclose(p_test.px, p_ref.px, rtol=0, atol=2e-9)
-    assert np.allclose(p_test.y, p_ref.y, rtol=0, atol=5e-9)
-    assert np.allclose(p_test.py, p_ref.py, rtol=0, atol=2e-9)
-    assert np.allclose(p_test.zeta, p_ref.zeta, rtol=0, atol=1e-11)
-    assert np.allclose(p_test.ptau, p_ref.ptau, atol=1e-11, rtol=0)
+    xo.assert_allclose(p_test.x, p_ref.x, rtol=0, atol=5e-9)
+    xo.assert_allclose(p_test.px, p_ref.px, rtol=0, atol=2e-9)
+    xo.assert_allclose(p_test.y, p_ref.y, rtol=0, atol=5e-9)
+    xo.assert_allclose(p_test.py, p_ref.py, rtol=0, atol=2e-9)
+    xo.assert_allclose(p_test.zeta, p_ref.zeta, rtol=0, atol=1e-11)
+    xo.assert_allclose(p_test.ptau, p_ref.ptau, atol=1e-11, rtol=0)
 
     # Check backtrack
     line_thick.configure_bend_model(core='expanded')
@@ -161,12 +161,12 @@ def test_combined_function_dipole_expanded(test_context):
     p_test.move(_context=xo.context_default)
     p0.move(_context=xo.context_default)
 
-    assert np.allclose(p_test.x, p0.x, atol=1e-11, rtol=0)
-    assert np.allclose(p_test.px, p0.px, atol=1e-11, rtol=0)
-    assert np.allclose(p_test.y, p0.y, atol=1e-11, rtol=0)
-    assert np.allclose(p_test.py, p0.py, atol=1e-11, rtol=0)
-    assert np.allclose(p_test.zeta, p0.zeta, atol=1e-11, rtol=0)
-    assert np.allclose(p_test.ptau, p0.ptau, atol=1e-11, rtol=0)
+    xo.assert_allclose(p_test.x, p0.x, atol=1e-11, rtol=0)
+    xo.assert_allclose(p_test.px, p0.px, atol=1e-11, rtol=0)
+    xo.assert_allclose(p_test.y, p0.y, atol=1e-11, rtol=0)
+    xo.assert_allclose(p_test.py, p0.py, atol=1e-11, rtol=0)
+    xo.assert_allclose(p_test.zeta, p0.zeta, atol=1e-11, rtol=0)
+    xo.assert_allclose(p_test.ptau, p0.ptau, atol=1e-11, rtol=0)
 
 def test_thick_bend_survey():
     circumference = 10
@@ -279,7 +279,7 @@ def test_thick_multipolar_component(test_context, element_type, h):
 
     # Check that the results are the same
     for attr in ['x', 'px', 'y', 'py', 'zeta', 'delta']:
-        assert np.allclose(
+        xo.assert_allclose(
             getattr(p_no_slices, attr),
             getattr(p_with_slices, attr),
             atol=1e-14,
@@ -334,27 +334,27 @@ def test_import_thick_bend_from_madx(use_true_thick_bends, with_knobs, bend_type
     assert elem.model == {False: 'expanded', True: 'full'}[use_true_thick_bends]
 
     # Element:
-    assert np.isclose(elem.length, 2.0, atol=1e-16)
-    assert np.isclose(elem.k0, 0.2, atol=1e-16)
-    assert np.isclose(elem.h, 0.05, atol=1e-16)  # h = angle / L
-    assert np.allclose(elem.ksl, 0.0, atol=1e-16)
+    xo.assert_allclose(elem.length, 2.0, atol=1e-16)
+    xo.assert_allclose(elem.k0, 0.2, atol=1e-16)
+    xo.assert_allclose(elem.h, 0.05, atol=1e-16)  # h = angle / L
+    xo.assert_allclose(elem.ksl, 0.0, atol=1e-16)
 
-    assert np.allclose(
+    xo.assert_allclose(
         elem.knl,
         np.array([0, 0, 0.8, 0, 0, 0]),  # knl = [0, 0, k2 * L, 0, 0]
         atol=1e-16,
     )
 
     # Edges:
-    assert np.isclose(elem.edge_entry_fint, 0.5, atol=1e-16)
-    assert np.isclose(elem.edge_entry_hgap, 0.6, atol=1e-16)
-    assert np.isclose(elem.edge_entry_angle,
+    xo.assert_allclose(elem.edge_entry_fint, 0.5, atol=1e-16)
+    xo.assert_allclose(elem.edge_entry_hgap, 0.6, atol=1e-16)
+    xo.assert_allclose(elem.edge_entry_angle,
                       {'rbend': 0.7 + 0.1 / 2, 'sbend': 0.7}[bend_type],
                       atol=1e-16)
 
-    assert np.isclose(elem.edge_exit_fint, 0.5, atol=1e-16)
-    assert np.isclose(elem.edge_exit_hgap, 0.6, atol=1e-16)
-    assert np.isclose(elem.edge_exit_angle,
+    xo.assert_allclose(elem.edge_exit_fint, 0.5, atol=1e-16)
+    xo.assert_allclose(elem.edge_exit_hgap, 0.6, atol=1e-16)
+    xo.assert_allclose(elem.edge_exit_angle,
                      {'rbend': 0.8 + 0.1 / 2, 'sbend': 0.8}[bend_type],
                       atol=1e-16)
 
@@ -371,28 +371,28 @@ def test_import_thick_bend_from_madx(use_true_thick_bends, with_knobs, bend_type
 
     # Verify that the line has been adjusted correctly
     # Element:
-    assert np.isclose(elem.length, 3.0, atol=1e-16)
-    assert np.isclose(elem.k0, 0.4, atol=1e-16)
-    assert np.isclose(elem.h, 0.2 / 3.0, atol=1e-16)  # h = angle / length
-    assert np.allclose(elem.ksl, 0.0, atol=1e-16)
+    xo.assert_allclose(elem.length, 3.0, atol=1e-16)
+    xo.assert_allclose(elem.k0, 0.4, atol=1e-16)
+    xo.assert_allclose(elem.h, 0.2 / 3.0, atol=1e-16)  # h = angle / length
+    xo.assert_allclose(elem.ksl, 0.0, atol=1e-16)
 
-    assert np.allclose(
+    xo.assert_allclose(
         elem.knl,
         np.array([0, 0, 2.4, 0, 0, 0]),  # knl = [0, 0, k2 * L, 0, 0]
         atol=1e-16,
     )
 
     # Edges:
-    assert np.isclose(elem.edge_entry_fint, 1.0, atol=1e-16)
-    assert np.isclose(elem.edge_entry_hgap, 1.2, atol=1e-16)
-    assert np.isclose(elem.edge_entry_angle,
+    xo.assert_allclose(elem.edge_entry_fint, 1.0, atol=1e-16)
+    xo.assert_allclose(elem.edge_entry_hgap, 1.2, atol=1e-16)
+    xo.assert_allclose(elem.edge_entry_angle,
         {'rbend': 1.4 + 0.2 / 2, 'sbend': 1.4}[bend_type],
         atol=1e-16)
-    assert np.isclose(elem.k0, 0.4, atol=1e-16)
+    xo.assert_allclose(elem.k0, 0.4, atol=1e-16)
 
-    assert np.isclose(elem.edge_exit_fint, 1.0, atol=1e-16)
-    assert np.isclose(elem.edge_exit_hgap, 1.2, atol=1e-16)
-    assert np.isclose(elem.edge_exit_angle,
+    xo.assert_allclose(elem.edge_exit_fint, 1.0, atol=1e-16)
+    xo.assert_allclose(elem.edge_exit_hgap, 1.2, atol=1e-16)
+    xo.assert_allclose(elem.edge_exit_angle,
         {'rbend': 1.6 + 0.2 / 2, 'sbend': 1.6}[bend_type],
         atol=1e-16)
 
@@ -420,9 +420,9 @@ def test_import_thick_quad_from_madx(with_knobs):
     elem = line['elem']
 
     # Verify that the line has been imported correctly
-    assert np.isclose(elem.length, 2.0, atol=1e-16)
-    assert np.isclose(elem.k1, 0.1, atol=1e-16)
-    assert np.isclose(elem.k1s, 0.2, atol=1e-16)
+    xo.assert_allclose(elem.length, 2.0, atol=1e-16)
+    xo.assert_allclose(elem.k1, 0.1, atol=1e-16)
+    xo.assert_allclose(elem.k1s, 0.2, atol=1e-16)
 
     # Finish the test here if we are not using knobs
     if not with_knobs:
@@ -436,9 +436,9 @@ def test_import_thick_quad_from_madx(with_knobs):
     line.vars['knob_b'] = 3.0
 
     # Verify that the line has been adjusted correctly
-    assert np.isclose(elem.length, 3.0, atol=1e-16)
-    assert np.isclose(elem.k1, 1.1, atol=1e-16)
-    assert np.isclose(elem.k1s, 1.2, atol=1e-16)
+    xo.assert_allclose(elem.length, 3.0, atol=1e-16)
+    xo.assert_allclose(elem.k1, 1.1, atol=1e-16)
+    xo.assert_allclose(elem.k1s, 1.2, atol=1e-16)
 
 
 @pytest.mark.parametrize(
@@ -482,16 +482,16 @@ def test_import_thick_bend_from_madx_and_slice(
     # Verify that the slices are correct
     for elem in elems:
         assert isinstance(elem, xt.ThinSliceBend)
-        assert np.isclose(elem.weight, 0.5, atol=1e-16)
-        assert np.isclose(elem._parent.length, 2.0, atol=1e-16)
-        assert np.isclose(elem._parent.k0, 0.2, atol=1e-16)
-        assert np.allclose(elem._parent.knl, [0., 0, 0.8, 0, 0, 0], atol=1e-16)
-        assert np.allclose(elem._parent.ksl, 0, atol=1e-16)
-        assert np.isclose(elem._parent.h, 0.05, atol=1e-16)
+        xo.assert_allclose(elem.weight, 0.5, atol=1e-16)
+        xo.assert_allclose(elem._parent.length, 2.0, atol=1e-16)
+        xo.assert_allclose(elem._parent.k0, 0.2, atol=1e-16)
+        xo.assert_allclose(elem._parent.knl, [0., 0, 0.8, 0, 0, 0], atol=1e-16)
+        xo.assert_allclose(elem._parent.ksl, 0, atol=1e-16)
+        xo.assert_allclose(elem._parent.h, 0.05, atol=1e-16)
 
     for drift in drifts:
-        assert np.isclose(drift._parent.length, 2., atol=1e-16)
-        assert np.isclose(drift.weight, 1./3., atol=1e-16)
+        xo.assert_allclose(drift._parent.length, 2., atol=1e-16)
+        xo.assert_allclose(drift.weight, 1./3., atol=1e-16)
 
     # Finish the test here if we are not using knobs
     if not with_knobs:
@@ -506,26 +506,26 @@ def test_import_thick_bend_from_madx_and_slice(
 
     # Verify that the line has been adjusted correctly
     for elem in elems:
-        assert np.isclose(elem.weight, 0.5, atol=1e-16)
-        assert np.isclose(elem._parent.length, 3.0, atol=1e-16)
-        assert np.isclose(elem._parent.k0, 0.4, atol=1e-16)
-        assert np.allclose(elem._parent.knl, [0., 0, 2.4, 0, 0, 0], atol=1e-16)
-        assert np.allclose(elem._parent.ksl, 0, atol=1e-16)
-        assert np.isclose(elem._parent.h, 0.2/3, atol=1e-16)
+        xo.assert_allclose(elem.weight, 0.5, atol=1e-16)
+        xo.assert_allclose(elem._parent.length, 3.0, atol=1e-16)
+        xo.assert_allclose(elem._parent.k0, 0.4, atol=1e-16)
+        xo.assert_allclose(elem._parent.knl, [0., 0, 2.4, 0, 0, 0], atol=1e-16)
+        xo.assert_allclose(elem._parent.ksl, 0, atol=1e-16)
+        xo.assert_allclose(elem._parent.h, 0.2/3, atol=1e-16)
 
-        assert np.isclose(elem._xobject.weight, 0.5, atol=1e-16)
-        assert np.isclose(elem._xobject._parent.length, 3.0, atol=1e-16)
-        assert np.isclose(elem._xobject._parent.k0, 0.4, atol=1e-16)
-        assert np.allclose(elem._xobject._parent.knl, [0., 0, 2.4, 0, 0, 0], atol=1e-16)
-        assert np.allclose(elem._xobject._parent.ksl, 0, atol=1e-16)
-        assert np.isclose(elem._xobject._parent.h, 0.2/3, atol=1e-16)
+        xo.assert_allclose(elem._xobject.weight, 0.5, atol=1e-16)
+        xo.assert_allclose(elem._xobject._parent.length, 3.0, atol=1e-16)
+        xo.assert_allclose(elem._xobject._parent.k0, 0.4, atol=1e-16)
+        xo.assert_allclose(elem._xobject._parent.knl, [0., 0, 2.4, 0, 0, 0], atol=1e-16)
+        xo.assert_allclose(elem._xobject._parent.ksl, 0, atol=1e-16)
+        xo.assert_allclose(elem._xobject._parent.h, 0.2/3, atol=1e-16)
 
         assert elem._parent._buffer is line._buffer
         assert elem._xobject._parent._buffer is line._buffer
 
     for drift in drifts:
-        assert np.isclose(drift._parent.length, 3, atol=1e-16)
-        assert np.isclose(drift.weight, 1./3., atol=1e-16)
+        xo.assert_allclose(drift._parent.length, 3, atol=1e-16)
+        xo.assert_allclose(drift.weight, 1./3., atol=1e-16)
 
         assert drift._parent._buffer is line._buffer
         assert drift._xobject._parent._buffer is line._buffer
@@ -562,14 +562,14 @@ def test_import_thick_quad_from_madx_and_slice(with_knobs):
 
     # Verify that the slices are correct
     for elem in elems:
-        assert np.isclose(elem.weight, 0.5, atol=1e-16)
-        assert np.isclose(elem._parent.length, 2.0, atol=1e-16)
-        assert np.isclose(elem._parent.k1, 0.1, atol=1e-16)
-        assert np.isclose(elem._parent.k1s, 0.2, atol=1e-16)
+        xo.assert_allclose(elem.weight, 0.5, atol=1e-16)
+        xo.assert_allclose(elem._parent.length, 2.0, atol=1e-16)
+        xo.assert_allclose(elem._parent.k1, 0.1, atol=1e-16)
+        xo.assert_allclose(elem._parent.k1s, 0.2, atol=1e-16)
 
     for drift in drifts:
-        assert np.isclose(drift._parent.length, 2., atol=1e-16)
-        assert np.isclose(drift.weight, 1./3., atol=1e-16)
+        xo.assert_allclose(drift._parent.length, 2., atol=1e-16)
+        xo.assert_allclose(drift.weight, 1./3., atol=1e-16)
 
     # Finish the test here if we are not using knobs
     if not with_knobs:
@@ -584,25 +584,25 @@ def test_import_thick_quad_from_madx_and_slice(with_knobs):
 
     # Verify that the line has been adjusted correctly
     for elem in elems:
-        assert np.isclose(elem.weight, 0.5, atol=1e-16)
-        assert np.isclose(elem._parent.length, 3.0, atol=1e-16)
-        assert np.isclose(elem._parent.k1, 2.1, atol=1e-16)
-        assert np.isclose(elem._parent.k1s, 2.2, atol=1e-16)
+        xo.assert_allclose(elem.weight, 0.5, atol=1e-16)
+        xo.assert_allclose(elem._parent.length, 3.0, atol=1e-16)
+        xo.assert_allclose(elem._parent.k1, 2.1, atol=1e-16)
+        xo.assert_allclose(elem._parent.k1s, 2.2, atol=1e-16)
 
-        assert np.isclose(elem._xobject.weight, 0.5, atol=1e-16)
-        assert np.isclose(elem._xobject._parent.length, 3.0, atol=1e-16)
-        assert np.isclose(elem._xobject._parent.k1, 2.1, atol=1e-16)
-        assert np.isclose(elem._xobject._parent.k1s, 2.2, atol=1e-16)
+        xo.assert_allclose(elem._xobject.weight, 0.5, atol=1e-16)
+        xo.assert_allclose(elem._xobject._parent.length, 3.0, atol=1e-16)
+        xo.assert_allclose(elem._xobject._parent.k1, 2.1, atol=1e-16)
+        xo.assert_allclose(elem._xobject._parent.k1s, 2.2, atol=1e-16)
 
         assert elem._parent._buffer is line._buffer
         assert elem._xobject._parent._buffer is line._buffer
 
     for drift in drifts:
-        assert np.isclose(drift._parent.length, 3., atol=1e-16)
-        assert np.isclose(drift.weight, 1./3., atol=1e-16)
+        xo.assert_allclose(drift._parent.length, 3., atol=1e-16)
+        xo.assert_allclose(drift.weight, 1./3., atol=1e-16)
 
-        assert np.isclose(drift._xobject._parent.length, 3., atol=1e-16)
-        assert np.isclose(drift._xobject.weight, 1./3., atol=1e-16)
+        xo.assert_allclose(drift._xobject._parent.length, 3., atol=1e-16)
+        xo.assert_allclose(drift._xobject.weight, 1./3., atol=1e-16)
 
         assert drift._parent._buffer is line._buffer
         assert drift._xobject._parent._buffer is line._buffer
@@ -631,16 +631,16 @@ def test_fringe_implementations(test_context):
     p_ng.move(_context=xo.context_default)
     p_ptc.move(_context=xo.context_default)
 
-    assert np.isclose(p_ng.x, p_ptc.x, rtol=0, atol=1e-10)
-    assert np.isclose(p_ng.px, p_ptc.px, rtol=0, atol=1e-12)
-    assert np.isclose(p_ng.y, p_ptc.y, rtol=0, atol=1e-12)
-    assert np.isclose(p_ng.py, p_ptc.py, rtol=0, atol=1e-12)
-    assert np.isclose(p_ng.delta, p_ptc.delta, rtol=0, atol=1e-12)
-    assert np.isclose(p_ng.s, p_ptc.s, rtol=0, atol=1e-12)
-    assert np.isclose(p_ng.zeta, p_ptc.zeta, rtol=0, atol=1e-10)
+    xo.assert_allclose(p_ng.x, p_ptc.x, rtol=0, atol=1e-10)
+    xo.assert_allclose(p_ng.px, p_ptc.px, rtol=0, atol=1e-12)
+    xo.assert_allclose(p_ng.y, p_ptc.y, rtol=0, atol=1e-12)
+    xo.assert_allclose(p_ng.py, p_ptc.py, rtol=0, atol=1e-12)
+    xo.assert_allclose(p_ng.delta, p_ptc.delta, rtol=0, atol=1e-12)
+    xo.assert_allclose(p_ng.s, p_ptc.s, rtol=0, atol=1e-12)
+    xo.assert_allclose(p_ng.zeta, p_ptc.zeta, rtol=0, atol=1e-10)
 
-    assert np.isclose(np.linalg.det(R_ng), 1, rtol=0, atol=1e-8) # Symplecticity check
-    assert np.isclose(np.linalg.det(R_ptc), 1, rtol=0, atol=1e-8) # Symplecticity check
+    xo.assert_allclose(np.linalg.det(R_ng), 1, rtol=0, atol=1e-8) # Symplecticity check
+    xo.assert_allclose(np.linalg.det(R_ptc), 1, rtol=0, atol=1e-8) # Symplecticity check
 
 
 @for_all_test_contexts
@@ -662,13 +662,13 @@ def test_backtrack_with_bend_quadrupole_and_cfm(test_context):
 
     p0.move(_context=xo.context_default)
     p2.move(_context=xo.context_default)
-    assert np.allclose(p2.s, p0.s, atol=1e-15, rtol=0)
-    assert np.allclose(p2.x, p0.x, atol=1e-15, rtol=0)
-    assert np.allclose(p2.px, p0.px, atol=1e-15, rtol=0)
-    assert np.allclose(p2.y, p0.y, atol=1e-15, rtol=0)
-    assert np.allclose(p2.py, p0.py, atol=1e-15, rtol=0)
-    assert np.allclose(p2.zeta, p0.zeta, atol=1e-15, rtol=0)
-    assert np.allclose(p2.delta, p0.delta, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.s, p0.s, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.x, p0.x, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.px, p0.px, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.y, p0.y, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.py, p0.py, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.zeta, p0.zeta, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.delta, p0.delta, atol=1e-15, rtol=0)
 
     # Same for quadrupole
     q = xt.Quadrupole(k1=0.2, length=1.0)
@@ -685,13 +685,13 @@ def test_backtrack_with_bend_quadrupole_and_cfm(test_context):
 
     p0.move(_context=xo.context_default)
     p2.move(_context=xo.context_default)
-    assert np.allclose(p2.s, p0.s, atol=1e-15, rtol=0)
-    assert np.allclose(p2.x, p0.x, atol=1e-15, rtol=0)
-    assert np.allclose(p2.px, p0.px, atol=1e-15, rtol=0)
-    assert np.allclose(p2.y, p0.y, atol=1e-15, rtol=0)
-    assert np.allclose(p2.py, p0.py, atol=1e-15, rtol=0)
-    assert np.allclose(p2.zeta, p0.zeta, atol=1e-15, rtol=0)
-    assert np.allclose(p2.delta, p0.delta, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.s, p0.s, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.x, p0.x, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.px, p0.px, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.y, p0.y, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.py, p0.py, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.zeta, p0.zeta, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.delta, p0.delta, atol=1e-15, rtol=0)
 
     # Same for dipole edge
     de = xt.DipoleEdge(e1=0.1, k=3, fint=0.3)
@@ -727,13 +727,13 @@ def test_backtrack_with_bend_quadrupole_and_cfm(test_context):
 
     p0.move(_context=xo.context_default)
     p2.move(_context=xo.context_default)
-    assert np.allclose(p2.s, p0.s, atol=1e-15, rtol=0)
-    assert np.allclose(p2.x, p0.x, atol=1e-15, rtol=0)
-    assert np.allclose(p2.px, p0.px, atol=1e-15, rtol=0)
-    assert np.allclose(p2.y, p0.y, atol=1e-15, rtol=0)
-    assert np.allclose(p2.py, p0.py, atol=1e-15, rtol=0)
-    assert np.allclose(p2.zeta, p0.zeta, atol=1e-15, rtol=0)
-    assert np.allclose(p2.delta, p0.delta, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.s, p0.s, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.x, p0.x, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.px, p0.px, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.y, p0.y, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.py, p0.py, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.zeta, p0.zeta, atol=1e-15, rtol=0)
+    xo.assert_allclose(p2.delta, p0.delta, atol=1e-15, rtol=0)
 
 def test_import_thick_with_apertures_and_slice():
     mad = Madx(stdout=False)
@@ -770,7 +770,7 @@ def test_import_thick_with_apertures_and_slice():
 
 
     def _assert_eq(a, b):
-        assert np.isclose(a, b, atol=1e-16)
+        xo.assert_allclose(a, b, atol=1e-16)
 
     _assert_eq(line[f'elm_aper'].rot_s_rad, 0.1)
     _assert_eq(line[f'elm_aper'].shift_x, 0.2)
@@ -852,12 +852,12 @@ def test_sextupole(test_context):
 
     p_thin.move(_context=xo.context_default)
     p_thick.move(_context=xo.context_default)
-    assert np.allclose(p_thin.x, p_thick.x, rtol=0, atol=1e-14)
-    assert np.allclose(p_thin.px, p_thick.px, rtol=0, atol=1e-14)
-    assert np.allclose(p_thin.y, p_thick.y, rtol=0, atol=1e-14)
-    assert np.allclose(p_thin.py, p_thick.py, rtol=0, atol=1e-14)
-    assert np.allclose(p_thin.delta, p_thick.delta, rtol=0, atol=1e-14)
-    assert np.allclose(p_thin.zeta, p_thick.zeta, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thin.x, p_thick.x, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thin.px, p_thick.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thin.y, p_thick.y, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thin.py, p_thick.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thin.delta, p_thick.delta, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thin.zeta, p_thick.zeta, rtol=0, atol=1e-14)
 
     # slicing
     Teapot = xt.slicing.Teapot
@@ -872,12 +872,12 @@ def test_sextupole(test_context):
     line_sliced.track(p_sliced)
 
     p_sliced.move(_context=xo.context_default)
-    assert np.allclose(p_sliced.x, p_thick.x, rtol=0, atol=5e-6)
-    assert np.allclose(p_sliced.px, p_thick.px, rtol=0.01, atol=1e-10)
-    assert np.allclose(p_sliced.y, p_thick.y, rtol=0, atol=5e-6)
-    assert np.allclose(p_sliced.py, p_thick.py, rtol=0.01, atol=1e-10)
-    assert np.allclose(p_sliced.delta, p_thick.delta, rtol=0, atol=1e-14)
-    assert np.allclose(p_sliced.zeta, p_thick.zeta, rtol=0, atol=2e-7)
+    xo.assert_allclose(p_sliced.x, p_thick.x, rtol=0, atol=5e-6)
+    xo.assert_allclose(p_sliced.px, p_thick.px, rtol=0.01, atol=1e-10)
+    xo.assert_allclose(p_sliced.y, p_thick.y, rtol=0, atol=5e-6)
+    xo.assert_allclose(p_sliced.py, p_thick.py, rtol=0.01, atol=1e-10)
+    xo.assert_allclose(p_sliced.delta, p_thick.delta, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_sliced.zeta, p_thick.zeta, rtol=0, atol=2e-7)
 
     p_thick.move(_context=test_context)
     p_thin.move(_context=test_context)
@@ -891,24 +891,24 @@ def test_sextupole(test_context):
     p_thin.move(_context=xo.context_default)
     p_sliced.move(_context=xo.context_default)
 
-    assert np.allclose(p_thin.x, p.x, rtol=0, atol=1e-14)
-    assert np.allclose(p_thin.px, p.px, rtol=0, atol=1e-14)
-    assert np.allclose(p_thin.y, p.y, rtol=0, atol=1e-14)
-    assert np.allclose(p_thin.py, p.py, rtol=0, atol=1e-14)
-    assert np.allclose(p_thin.delta, p.delta, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thin.x, p.x, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thin.px, p.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thin.y, p.y, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thin.py, p.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thin.delta, p.delta, rtol=0, atol=1e-14)
 
-    assert np.allclose(p_thick.x, p.x, rtol=0, atol=1e-14)
-    assert np.allclose(p_thick.px, p.px, rtol=0, atol=1e-14)
-    assert np.allclose(p_thick.y, p.y, rtol=0, atol=1e-14)
-    assert np.allclose(p_thick.py, p.py, rtol=0, atol=1e-14)
-    assert np.allclose(p_thick.delta, p.delta, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thick.x, p.x, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thick.px, p.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thick.y, p.y, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thick.py, p.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_thick.delta, p.delta, rtol=0, atol=1e-14)
 
-    assert np.allclose(p_sliced.x, p.x, rtol=0, atol=1e-14)
-    assert np.allclose(p_sliced.px, p.px, rtol=0, atol=1e-14)
-    assert np.allclose(p_sliced.y, p.y, rtol=0, atol=1e-14)
-    assert np.allclose(p_sliced.py, p.py, rtol=0, atol=1e-14)
-    assert np.allclose(p_sliced.delta, p.delta, rtol=0, atol=1e-14)
-    assert np.allclose(p_sliced.zeta, p.zeta, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_sliced.x, p.x, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_sliced.px, p.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_sliced.y, p.y, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_sliced.py, p.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_sliced.delta, p.delta, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_sliced.zeta, p.zeta, rtol=0, atol=1e-14)
 
     from cpymad.madx import Madx
     mad = Madx(stdout=False)
@@ -929,17 +929,17 @@ def test_sextupole(test_context):
 
     elem = line_mad['elem']
     assert isinstance(elem, xt.Sextupole)
-    assert np.isclose(elem.length, 0.4, rtol=0, atol=1e-14)
-    assert np.isclose(elem.k2, 3, rtol=0, atol=1e-14)
-    assert np.isclose(elem.k2s, 10, rtol=0, atol=1e-14)
+    xo.assert_allclose(elem.length, 0.4, rtol=0, atol=1e-14)
+    xo.assert_allclose(elem.k2, 3, rtol=0, atol=1e-14)
+    xo.assert_allclose(elem.k2s, 10, rtol=0, atol=1e-14)
 
     line_mad.vv['knob_a'] = 0.5
     line_mad.vv['knob_b'] = 0.6
     line_mad.vv['knob_l'] = 0.7
 
-    assert np.isclose(elem.length, 0.7, rtol=0, atol=1e-14)
-    assert np.isclose(elem.k2, 1.5, rtol=0, atol=1e-14)
-    assert np.isclose(elem.k2s, 3.0, rtol=0, atol=1e-14)
+    xo.assert_allclose(elem.length, 0.7, rtol=0, atol=1e-14)
+    xo.assert_allclose(elem.k2, 1.5, rtol=0, atol=1e-14)
+    xo.assert_allclose(elem.k2s, 3.0, rtol=0, atol=1e-14)
 
 @pytest.mark.parametrize(
     'ks, ksi, length',
@@ -1013,13 +1013,13 @@ def test_solenoid_against_madx(test_context, ks, ksi, length):
         part.move(_context=xo.context_default)
 
         xt_tau = part.zeta/part.beta0
-        assert np.allclose(part.x[ii], mad_results.x, atol=1e-10, rtol=0), 'x'
-        assert np.allclose(part.px[ii], mad_results.px, atol=1e-11, rtol=0), 'px'
-        assert np.allclose(part.y[ii], mad_results.y, atol=1e-10, rtol=0), 'y'
-        assert np.allclose(part.py[ii], mad_results.py, atol=1e-11, rtol=0), 'py'
-        assert np.allclose(xt_tau[ii], mad_results.t, atol=1e-9, rtol=0), 't'
-        assert np.allclose(part.ptau[ii], mad_results.pt, atol=1e-11, rtol=0), 'pt'
-        assert np.allclose(part.s[ii], mad_results.s, atol=1e-11, rtol=0), 's'
+        xo.assert_allclose(part.x[ii], mad_results.x, atol=1e-10, rtol=0), 'x'
+        xo.assert_allclose(part.px[ii], mad_results.px, atol=1e-11, rtol=0), 'px'
+        xo.assert_allclose(part.y[ii], mad_results.y, atol=1e-10, rtol=0), 'y'
+        xo.assert_allclose(part.py[ii], mad_results.py, atol=1e-11, rtol=0), 'py'
+        xo.assert_allclose(xt_tau[ii], mad_results.t, atol=1e-9, rtol=0), 't'
+        xo.assert_allclose(part.ptau[ii], mad_results.pt, atol=1e-11, rtol=0), 'pt'
+        xo.assert_allclose(part.s[ii], mad_results.s, atol=1e-11, rtol=0), 's'
 
 
 @for_all_test_contexts
@@ -1043,12 +1043,12 @@ def test_solenoid_thick_drift_like(test_context):
     p_sol.move(_context=xo.context_default)
     p_drift.move(_context=xo.context_default)
 
-    assert np.allclose(p_sol.x, p_drift.x, atol=1e-9)
-    assert np.allclose(p_sol.px, p_drift.px, atol=1e-9)
-    assert np.allclose(p_sol.y, p_drift.y, atol=1e-9)
-    assert np.allclose(p_sol.py, p_drift.py, atol=1e-9)
-    assert np.allclose(p_sol.zeta, p_drift.zeta, atol=1e-9)
-    assert np.allclose(p_sol.delta, p_drift.delta, atol=1e-9)
+    xo.assert_allclose(p_sol.x, p_drift.x, atol=1e-9)
+    xo.assert_allclose(p_sol.px, p_drift.px, atol=1e-9)
+    xo.assert_allclose(p_sol.y, p_drift.y, atol=1e-9)
+    xo.assert_allclose(p_sol.py, p_drift.py, atol=1e-9)
+    xo.assert_allclose(p_sol.zeta, p_drift.zeta, atol=1e-9)
+    xo.assert_allclose(p_sol.delta, p_drift.delta, atol=1e-9)
 
 
 @for_all_test_contexts
@@ -1078,14 +1078,14 @@ def test_solenoid_thick_analytic(test_context, length, expected):
 
     p_sol.move(_context=xo.context_default)
 
-    assert np.allclose(p_sol.x, expected[0], atol=1e-9)
-    assert np.allclose(p_sol.px, expected[1], atol=1e-9)
-    assert np.allclose(p_sol.y, expected[2], atol=1e-9)
-    assert np.allclose(p_sol.py, expected[3], atol=1e-9)
+    xo.assert_allclose(p_sol.x, expected[0], atol=1e-9)
+    xo.assert_allclose(p_sol.px, expected[1], atol=1e-9)
+    xo.assert_allclose(p_sol.y, expected[2], atol=1e-9)
+    xo.assert_allclose(p_sol.py, expected[3], atol=1e-9)
     delta_ell = (p_sol.s - p_sol.zeta) * p_sol.rvv
-    assert np.allclose(delta_ell, expected[4], atol=1e-9)
-    assert np.allclose(p_sol.delta, expected[5], atol=1e-9)
-    assert np.allclose(p_sol.s, length, atol=1e-9)
+    xo.assert_allclose(delta_ell, expected[4], atol=1e-9)
+    xo.assert_allclose(p_sol.delta, expected[5], atol=1e-9)
+    xo.assert_allclose(p_sol.s, length, atol=1e-9)
 
 @for_all_test_contexts
 def test_skew_quadrupole(test_context):
@@ -1116,12 +1116,12 @@ def test_skew_quadrupole(test_context):
     p_test.move(_context=xo.context_default)
     p_ref.move(_context=xo.context_default)
 
-    assert np.isclose(p_test.x, p_ref.x, atol=1e-8, rtol=0)
-    assert np.isclose(p_test.px, p_ref.px, atol=5e-8, rtol=0)
-    assert np.isclose(p_test.y, p_ref.y, atol=1e-8, rtol=0)
-    assert np.isclose(p_test.py, p_ref.py, atol=5e-8, rtol=0)
-    assert np.isclose(p_test.zeta, p_ref.zeta, atol=1e-8, rtol=0)
-    assert np.isclose(p_test.delta, p_ref.delta, atol=5e-8, rtol=0)
+    xo.assert_allclose(p_test.x, p_ref.x, atol=1e-8, rtol=0)
+    xo.assert_allclose(p_test.px, p_ref.px, atol=5e-8, rtol=0)
+    xo.assert_allclose(p_test.y, p_ref.y, atol=1e-8, rtol=0)
+    xo.assert_allclose(p_test.py, p_ref.py, atol=5e-8, rtol=0)
+    xo.assert_allclose(p_test.zeta, p_ref.zeta, atol=1e-8, rtol=0)
+    xo.assert_allclose(p_test.delta, p_ref.delta, atol=5e-8, rtol=0)
 
 @for_all_test_contexts
 def test_octupole(test_context):
@@ -1150,9 +1150,9 @@ def test_octupole(test_context):
     p_test.move(_context=xo.context_default)
     p_ref.move(_context=xo.context_default)
 
-    assert np.isclose(p_test.x, p_ref.x, atol=1e-12, rtol=0)
-    assert np.isclose(p_test.px, p_ref.px, atol=1e-12, rtol=0)
-    assert np.isclose(p_test.y, p_ref.y, atol=1e-12, rtol=0)
-    assert np.isclose(p_test.py, p_ref.py, atol=1e-12, rtol=0)
-    assert np.isclose(p_test.zeta, p_ref.zeta, atol=1e-12, rtol=0)
-    assert np.isclose(p_test.delta, p_ref.delta, atol=1e-12, rtol=0)
+    xo.assert_allclose(p_test.x, p_ref.x, atol=1e-12, rtol=0)
+    xo.assert_allclose(p_test.px, p_ref.px, atol=1e-12, rtol=0)
+    xo.assert_allclose(p_test.y, p_ref.y, atol=1e-12, rtol=0)
+    xo.assert_allclose(p_test.py, p_ref.py, atol=1e-12, rtol=0)
+    xo.assert_allclose(p_test.zeta, p_ref.zeta, atol=1e-12, rtol=0)
+    xo.assert_allclose(p_test.delta, p_ref.delta, atol=1e-12, rtol=0)

--- a/tests/test_footprint.py
+++ b/tests/test_footprint.py
@@ -3,10 +3,9 @@ import pathlib
 import numpy as np
 import pytest
 
-import xtrack as xt
-import xpart as xp
 import xobjects as xo
-
+import xpart as xp
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(__file__).parent.joinpath('../test_data').absolute()
@@ -54,38 +53,38 @@ def test_footprint(test_context, freeze_longitudinal):
     assert len(fp1.r_grid) == 11
     assert len(fp1.theta_grid) == 7
 
-    assert np.isclose(fp1.r_grid[0], 0.05, rtol=0, atol=1e-10)
-    assert np.isclose(fp1.r_grid[-1], 7, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp1.r_grid[0], 0.05, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp1.r_grid[-1], 7, rtol=0, atol=1e-10)
 
-    assert np.isclose(fp1.theta_grid[0], 0.01, rtol=0, atol=1e-10)
-    assert np.isclose(fp1.theta_grid[-1], np.pi/2 - 0.01, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp1.theta_grid[0], 0.01, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp1.theta_grid[-1], np.pi/2 - 0.01, rtol=0, atol=1e-10)
 
     #i_theta = 0, i_r = 0
-    assert np.isclose(fp1.x_norm_2d[0, 0], 0.05, rtol=0, atol=1e-3)
-    assert np.isclose(fp1.y_norm_2d[0, 0], 0, rtol=0, atol=1e-3)
-    assert np.isclose(fp1.qx[0, 0], 0.31, rtol=0, atol=5e-5)
-    assert np.isclose(fp1.qy[0, 0], 0.32, rtol=0, atol=5e-5)
+    xo.assert_allclose(fp1.x_norm_2d[0, 0], 0.05, rtol=0, atol=1e-3)
+    xo.assert_allclose(fp1.y_norm_2d[0, 0], 0, rtol=0, atol=1e-3)
+    xo.assert_allclose(fp1.qx[0, 0], 0.31, rtol=0, atol=5e-5)
+    xo.assert_allclose(fp1.qy[0, 0], 0.32, rtol=0, atol=5e-5)
 
     #i_theta = 0, i_r = 10
-    assert np.isclose(fp1.x_norm_2d[0, -1], 7, rtol=0, atol=1e-3)
-    assert np.isclose(fp1.y_norm_2d[0, -1], 0.07, rtol=0, atol=1e-3)
-    assert np.isclose(fp1.qx[0, -1], 0.3129, rtol=0, atol=2e-4)
-    assert np.isclose(fp1.qy[0, -1], 0.3185, rtol=0, atol=2e-4)
+    xo.assert_allclose(fp1.x_norm_2d[0, -1], 7, rtol=0, atol=1e-3)
+    xo.assert_allclose(fp1.y_norm_2d[0, -1], 0.07, rtol=0, atol=1e-3)
+    xo.assert_allclose(fp1.qx[0, -1], 0.3129, rtol=0, atol=2e-4)
+    xo.assert_allclose(fp1.qy[0, -1], 0.3185, rtol=0, atol=2e-4)
 
     #i_theta = 6, i_r = 0
-    assert np.isclose(fp1.x_norm_2d[-1, 0], 0, rtol=0, atol=1e-3)
-    assert np.isclose(fp1.y_norm_2d[-1, 0], 0.05, rtol=0, atol=1e-3)
-    assert np.isclose(fp1.qx[0, 0], 0.31, rtol=0, atol=5e-5)
-    assert np.isclose(fp1.qy[0, 0], 0.32, rtol=0, atol=5e-5)
+    xo.assert_allclose(fp1.x_norm_2d[-1, 0], 0, rtol=0, atol=1e-3)
+    xo.assert_allclose(fp1.y_norm_2d[-1, 0], 0.05, rtol=0, atol=1e-3)
+    xo.assert_allclose(fp1.qx[0, 0], 0.31, rtol=0, atol=5e-5)
+    xo.assert_allclose(fp1.qy[0, 0], 0.32, rtol=0, atol=5e-5)
 
     #i_theta = 6, i_r = 10
-    assert np.isclose(fp1.x_norm_2d[-1, -1], 0.07, rtol=0, atol=1e-3)
-    assert np.isclose(fp1.y_norm_2d[-1, -1], 7, rtol=0, atol=1e-3)
-    assert np.isclose(fp1.qx[-1, -1], 0.3085, rtol=0, atol=2e-4)
-    assert np.isclose(fp1.qy[-1, -1], 0.3229, rtol=0, atol=2e-4)
+    xo.assert_allclose(fp1.x_norm_2d[-1, -1], 0.07, rtol=0, atol=1e-3)
+    xo.assert_allclose(fp1.y_norm_2d[-1, -1], 7, rtol=0, atol=1e-3)
+    xo.assert_allclose(fp1.qx[-1, -1], 0.3085, rtol=0, atol=2e-4)
+    xo.assert_allclose(fp1.qy[-1, -1], 0.3229, rtol=0, atol=2e-4)
 
-    assert np.isclose(np.max(fp1.qx[:]) - np.min(fp1.qx[:]), 4.4e-3, rtol=0, atol=1e-4)
-    assert np.isclose(np.max(fp1.qy[:]) - np.min(fp1.qy[:]), 4.4e-3, rtol=0, atol=1e-4)
+    xo.assert_allclose(np.max(fp1.qx[:]) - np.min(fp1.qx[:]), 4.4e-3, rtol=0, atol=1e-4)
+    xo.assert_allclose(np.max(fp1.qy[:]) - np.min(fp1.qy[:]), 4.4e-3, rtol=0, atol=1e-4)
 
     line.vars['i_oct_b1'] = 0
     fp0 = line.get_footprint(nemitt_x=nemitt_x, nemitt_y=nemitt_y,
@@ -94,23 +93,23 @@ def test_footprint(test_context, freeze_longitudinal):
     assert hasattr(fp0, 'theta_grid')
     assert hasattr(fp0, 'r_grid')
 
-    assert np.isclose(fp0.r_grid[0], 0.1, rtol=0, atol=1e-10)
-    assert np.isclose(fp0.r_grid[-1], 6, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp0.r_grid[0], 0.1, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp0.r_grid[-1], 6, rtol=0, atol=1e-10)
 
-    assert np.isclose(fp0.theta_grid[0], 0.05, rtol=0, atol=1e-10)
-    assert np.isclose(fp0.theta_grid[-1], np.pi/2-0.05, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp0.theta_grid[0], 0.05, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp0.theta_grid[-1], np.pi/2-0.05, rtol=0, atol=1e-10)
 
     assert len(fp0.r_grid) == 10
     assert len(fp0.theta_grid) == 10
 
     #i_theta = 0, i_r = 0
-    assert np.isclose(fp0.x_norm_2d[0, 0], 0.1, rtol=0, atol=1e-3)
-    assert np.isclose(fp0.y_norm_2d[0, 0], 0.005, rtol=0, atol=1e-3)
-    assert np.isclose(fp0.qx[0, 0], 0.31, rtol=0, atol=5e-5)
-    assert np.isclose(fp0.qy[0, 0], 0.32, rtol=0, atol=5e-5)
+    xo.assert_allclose(fp0.x_norm_2d[0, 0], 0.1, rtol=0, atol=1e-3)
+    xo.assert_allclose(fp0.y_norm_2d[0, 0], 0.005, rtol=0, atol=1e-3)
+    xo.assert_allclose(fp0.qx[0, 0], 0.31, rtol=0, atol=5e-5)
+    xo.assert_allclose(fp0.qy[0, 0], 0.32, rtol=0, atol=5e-5)
 
-    assert np.isclose(np.max(fp0.qx[:]) - np.min(fp0.qx[:]), 0.0003, rtol=0, atol=2e-5)
-    assert np.isclose(np.max(fp0.qy[:]) - np.min(fp0.qy[:]), 0.0003, rtol=0, atol=2e-5)
+    xo.assert_allclose(np.max(fp0.qx[:]) - np.min(fp0.qx[:]), 0.0003, rtol=0, atol=2e-5)
+    xo.assert_allclose(np.max(fp0.qy[:]) - np.min(fp0.qy[:]), 0.0003, rtol=0, atol=2e-5)
 
     line.vars['i_oct_b1'] = 500
     fp1_jgrid = line.get_footprint(nemitt_x=nemitt_x, nemitt_y=nemitt_y,
@@ -125,34 +124,34 @@ def test_footprint(test_context, freeze_longitudinal):
     assert len(fp1_jgrid.Jx_grid) == 9
     assert len(fp1_jgrid.Jy_grid) == 8
 
-    assert np.allclose(np.diff(fp1_jgrid.Jx_grid), np.diff(fp1_jgrid.Jx_grid)[0],
+    xo.assert_allclose(np.diff(fp1_jgrid.Jx_grid), np.diff(fp1_jgrid.Jx_grid)[0],
                     rtol=0, atol=1e-10)
-    assert np.allclose(np.diff(fp1_jgrid.Jy_grid), np.diff(fp1_jgrid.Jy_grid)[0],
+    xo.assert_allclose(np.diff(fp1_jgrid.Jy_grid), np.diff(fp1_jgrid.Jy_grid)[0],
                         rtol=0, atol=1e-10)
 
-    assert np.isclose(fp1_jgrid.x_norm_2d[0, 0], 0.01, rtol=0, atol=1e-10)
-    assert np.isclose(fp1_jgrid.y_norm_2d[0, 0], 0.01, rtol=0, atol=1e-10)
-    assert np.isclose(fp1_jgrid.qx[0, 0], 0.31, rtol=0, atol=5e-5)
-    assert np.isclose(fp1_jgrid.qy[0, 0], 0.32, rtol=0, atol=5e-5)
+    xo.assert_allclose(fp1_jgrid.x_norm_2d[0, 0], 0.01, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp1_jgrid.y_norm_2d[0, 0], 0.01, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp1_jgrid.qx[0, 0], 0.31, rtol=0, atol=5e-5)
+    xo.assert_allclose(fp1_jgrid.qy[0, 0], 0.32, rtol=0, atol=5e-5)
 
-    assert np.isclose(fp1_jgrid.x_norm_2d[0, -1], 6, rtol=0, atol=1e-10)
-    assert np.isclose(fp1_jgrid.y_norm_2d[0, -1], 0.01, rtol=0, atol=1e-10)
-    assert np.isclose(fp1_jgrid.qx[0, -1], 0.3121, rtol=0, atol=1e-4)
-    assert np.isclose(fp1_jgrid.qy[0, -1], 0.3189, rtol=0, atol=1e-4)
+    xo.assert_allclose(fp1_jgrid.x_norm_2d[0, -1], 6, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp1_jgrid.y_norm_2d[0, -1], 0.01, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp1_jgrid.qx[0, -1], 0.3121, rtol=0, atol=1e-4)
+    xo.assert_allclose(fp1_jgrid.qy[0, -1], 0.3189, rtol=0, atol=1e-4)
 
-    assert np.isclose(fp1_jgrid.x_norm_2d[-1, 0], 0.01, rtol=0, atol=1e-10)
-    assert np.isclose(fp1_jgrid.y_norm_2d[-1, 0], 6, rtol=0, atol=1e-10)
-    assert np.isclose(fp1_jgrid.qx[-1, 0], 0.3089, rtol=0, atol=1e-4)
-    assert np.isclose(fp1_jgrid.qy[-1, 0], 0.3221, rtol=0, atol=1e-4)
+    xo.assert_allclose(fp1_jgrid.x_norm_2d[-1, 0], 0.01, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp1_jgrid.y_norm_2d[-1, 0], 6, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp1_jgrid.qx[-1, 0], 0.3089, rtol=0, atol=1e-4)
+    xo.assert_allclose(fp1_jgrid.qy[-1, 0], 0.3221, rtol=0, atol=1e-4)
 
-    assert np.isclose(fp1_jgrid.x_norm_2d[-1, -1], 6, rtol=0, atol=1e-10)
-    assert np.isclose(fp1_jgrid.y_norm_2d[-1, -1], 6, rtol=0, atol=1e-10)
-    assert np.isclose(fp1_jgrid.qx[-1, -1], 0.3111, rtol=0, atol=1e-4)
-    assert np.isclose(fp1_jgrid.qy[-1, -1], 0.3210, rtol=0, atol=1e-4)
+    xo.assert_allclose(fp1_jgrid.x_norm_2d[-1, -1], 6, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp1_jgrid.y_norm_2d[-1, -1], 6, rtol=0, atol=1e-10)
+    xo.assert_allclose(fp1_jgrid.qx[-1, -1], 0.3111, rtol=0, atol=1e-4)
+    xo.assert_allclose(fp1_jgrid.qy[-1, -1], 0.3210, rtol=0, atol=1e-4)
 
-    assert np.isclose(np.max(fp1_jgrid.qx[:]) - np.min(fp1_jgrid.qx[:]), 0.0032,
+    xo.assert_allclose(np.max(fp1_jgrid.qx[:]) - np.min(fp1_jgrid.qx[:]), 0.0032,
                         rtol=0, atol=1e-4)
-    assert np.isclose(np.max(fp1_jgrid.qy[:]) - np.min(fp1_jgrid.qy[:]), 0.0032,
+    xo.assert_allclose(np.max(fp1_jgrid.qy[:]) - np.min(fp1_jgrid.qy[:]), 0.0032,
                         rtol=0, atol=1e-4)
 
     x_norm_range = [1, 6]
@@ -190,8 +189,8 @@ def test_footprint(test_context, freeze_longitudinal):
                                 mode='uniform_action_grid',
                                 **kwargs)
 
-    assert np.allclose((fp60k.qx - fp50k.qx)/(fp600.qx-fp500.qx), 100, rtol=0, atol=1e-2)
-    assert np.allclose((fp60k.qy - fp50k.qy)/(fp600.qy-fp500.qy), 100, rtol=0, atol=1e-2)
+    xo.assert_allclose((fp60k.qx - fp50k.qx)/(fp600.qx-fp500.qx), 100, rtol=0, atol=1e-2)
+    xo.assert_allclose((fp60k.qy - fp50k.qy)/(fp600.qy-fp500.qy), 100, rtol=0, atol=1e-2)
 
 @for_all_test_contexts
 def test_footprint_delta0(test_context):
@@ -222,9 +221,9 @@ def test_footprint_delta0(test_context):
     fp2 = line.get_footprint(nemitt_x=nemitt_x, nemitt_y=nemitt_y,
                             freeze_longitudinal=True, delta0=1e-4)
 
-    assert np.allclose(line.record_last_track.delta[:], 1e-4, atol=1e-12, rtol=0)
+    xo.assert_allclose(line.record_last_track.delta[:], 1e-4, atol=1e-12, rtol=0)
 
     # It is 12, 9 instead of 10, 10 because of non-linear chromaticity
-    assert np.isclose((np.max(fp2.qx) - np.max(fp1.qx))/1e-4, 12, atol=0.5, rtol=0)
-    assert np.isclose((np.max(fp2.qy) - np.max(fp1.qy))/1e-4, 9, atol=0.5, rtol=0)
+    xo.assert_allclose((np.max(fp2.qx) - np.max(fp1.qx))/1e-4, 12, atol=0.5, rtol=0)
+    xo.assert_allclose((np.max(fp2.qy) - np.max(fp1.qy))/1e-4, 9, atol=0.5, rtol=0)
 

--- a/tests/test_freeze_longitudinal.py
+++ b/tests/test_freeze_longitudinal.py
@@ -1,10 +1,9 @@
 import json
 import pathlib
-import numpy as np
 
-import xtrack as xt
-import xpart as xp
 import xobjects as xo
+import xpart as xp
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
@@ -34,8 +33,8 @@ def test_freeze_longitudinal_explicit(test_context):
     particles = line.build_particles(delta=1e-3, x=[-1e-3, 0, 1e-3])
     line.track(particles, num_turns=10)
     particles.move(_context=xo.context_default)
-    assert np.allclose(particles.delta, 1e-3, rtol=0, atol=1e-12)
-    assert np.allclose(particles.zeta, 0, rtol=9, atol=1e-12)
+    xo.assert_allclose(particles.delta, 1e-3, rtol=0, atol=1e-12)
+    xo.assert_allclose(particles.zeta, 0, rtol=9, atol=1e-12)
 
     # Twiss with frozen longitudinal coordinates (needs to be 4d)
     twiss = line.twiss(method='4d')
@@ -48,11 +47,11 @@ def test_freeze_longitudinal_explicit(test_context):
     particles = line.build_particles(delta=1e-3, x=[-1e-3, 0, 1e-3])
     line.track(particles, num_turns=10)
     particles.move(_context=xo.context_default)
-    assert np.allclose(particles.delta, 0.00099218, rtol=0, atol=1e-6)
+    xo.assert_allclose(particles.delta, 0.00099218, rtol=0, atol=1e-6)
 
     # Twiss with unfrozen longitudinal coordinates (can be 6d)
     twiss = line.twiss(method='6d')
-    assert np.isclose(twiss.slip_factor, 0.00032151, rtol=0, atol=1e-6)
+    xo.assert_allclose(twiss.slip_factor, 0.00032151, rtol=0, atol=1e-6)
 
 
 @for_all_test_contexts
@@ -77,8 +76,8 @@ def test_freeze_longitudinal_context_manager(test_context):
         particles = line.build_particles(delta=1e-3, x=[-1e-3, 0, 1e-3])
         line.track(particles, num_turns=10)
         particles.move(_context=xo.context_default)
-        assert np.allclose(particles.delta, 1e-3, rtol=0, atol=1e-12)
-        assert np.allclose(particles.zeta, 0, rtol=9, atol=1e-12)
+        xo.assert_allclose(particles.delta, 1e-3, rtol=0, atol=1e-12)
+        xo.assert_allclose(particles.zeta, 0, rtol=9, atol=1e-12)
 
         # Twiss with frozen longitudinal coordinates (needs to be 4d)
         twiss = line.twiss(method='4d')
@@ -88,11 +87,11 @@ def test_freeze_longitudinal_context_manager(test_context):
     particles = line.build_particles(delta=1e-3, x=[-1e-3, 0, 1e-3])
     line.track(particles, num_turns=10)
     particles.move(_context=xo.context_default)
-    assert np.allclose(particles.delta, 0.00099218, rtol=0, atol=1e-6)
+    xo.assert_allclose(particles.delta, 0.00099218, rtol=0, atol=1e-6)
 
     # Twiss with unfrozen longitudinal coordinates (can be 6d)
     twiss = line.twiss(method='6d')
-    assert np.isclose(twiss.slip_factor, 0.00032151, rtol=0, atol=1e-6)
+    xo.assert_allclose(twiss.slip_factor, 0.00032151, rtol=0, atol=1e-6)
 
 
 @for_all_test_contexts
@@ -116,8 +115,8 @@ def test_freeze_longitudinal_individual_methods(test_context):
     particles = line.build_particles(delta=1e-3, x=[-1e-3, 0, 1e-3])
     line.track(particles, num_turns=10, freeze_longitudinal=True)
     particles.move(_context=xo.context_default)
-    assert np.allclose(particles.delta, 1e-3, rtol=0, atol=1e-12)
-    assert np.allclose(particles.zeta, 0, rtol=9, atol=1e-12)
+    xo.assert_allclose(particles.delta, 1e-3, rtol=0, atol=1e-12)
+    xo.assert_allclose(particles.zeta, 0, rtol=9, atol=1e-12)
 
     # Twiss with frozen longitudinal coordinates (needs to be 4d)
     twiss = line.twiss(method='4d', freeze_longitudinal=True)
@@ -127,8 +126,8 @@ def test_freeze_longitudinal_individual_methods(test_context):
     particles = line.build_particles(delta=1e-3, x=[-1e-3, 0, 1e-3])
     line.track(particles, num_turns=10)
     particles.move(_context=xo.context_default)
-    assert np.allclose(particles.delta, 0.00099218, rtol=0, atol=1e-6)
+    xo.assert_allclose(particles.delta, 0.00099218, rtol=0, atol=1e-6)
 
     # Twiss with unfrozen longitudinal coordinates (can be 6d)
     twiss = line.twiss(method='6d')
-    assert np.isclose(twiss.slip_factor, 0.00032151, rtol=0, atol=1e-6)
+    xo.assert_allclose(twiss.slip_factor, 0.00032151, rtol=0, atol=1e-6)

--- a/tests/test_full_rings.py
+++ b/tests/test_full_rings.py
@@ -3,17 +3,18 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
-import pickle
 import json
 import pathlib
-import pytest
-import numpy as np
+import pickle
 
-import xtrack as xt
-import xpart as xp
-from xobjects.test_helpers import for_all_test_contexts
+import numpy as np
+import pytest
 
 import ducktrack as dtk
+import xobjects as xo
+import xpart as xp
+import xtrack as xt
+from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
     __file__).parent.joinpath('../test_data').absolute()
@@ -142,11 +143,11 @@ def test_full_rings(
     parttest = part_co.copy()
     for _ in range(10):
         line.track(parttest)
-        assert np.isclose(parttest._xobject.x[0], part_co._xobject.x[0],
+        xo.assert_allclose(parttest._xobject.x[0], part_co._xobject.x[0],
                           rtol=0, atol=1e-11)
-        assert np.isclose(parttest._xobject.y[0], part_co._xobject.y[0],
+        xo.assert_allclose(parttest._xobject.y[0], part_co._xobject.y[0],
                           rtol=0, atol=1e-11)
-        assert np.isclose(parttest._xobject.zeta[0], part_co._xobject.zeta[0],
+        xo.assert_allclose(parttest._xobject.zeta[0], part_co._xobject.zeta[0],
                           rtol=0, atol=5e-11)
 
 @for_all_test_contexts

--- a/tests/test_ions.py
+++ b/tests/test_ions.py
@@ -1,11 +1,11 @@
 import pathlib
 
-import numpy as np
-import xpart as xp
 from cpymad.madx import Madx
-from xobjects.test_helpers import for_all_test_contexts
 
+import xobjects as xo
+import xpart as xp
 import xtrack as xt
+from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
         __file__).parent.joinpath('../test_data').absolute()
@@ -44,14 +44,14 @@ def test_ions(test_context):
                                     q0=mad.sequence.sps.beam.charge,
                                     gamma0=mad.sequence.sps.beam.gamma)
 
-    assert np.isclose(line['actcse.31632'].voltage, V_RF, atol=1e-10)
+    xo.assert_allclose(line['actcse.31632'].voltage, V_RF, atol=1e-10)
 
     line.build_tracker()
 
     tw = line.twiss()
 
-    assert np.isclose(tw.qs, qs_mad, atol=1e-6)
-    assert np.isclose(tw.qx, summad_4d.q1, atol=1e-5)
-    assert np.isclose(tw.qy, summad_4d.q2, atol=1e-5)
-    assert np.isclose(tw.dqx, summad_6d.dq1, atol=0.5)
-    assert np.isclose(tw.dqy, summad_6d.dq2, atol=0.5)
+    xo.assert_allclose(tw.qs, qs_mad, rtol=0, atol=1e-6)
+    xo.assert_allclose(tw.qx, summad_4d.q1, rtol=0, atol=1e-5)
+    xo.assert_allclose(tw.qy, summad_4d.q2, rtol=0, atol=1e-5)
+    xo.assert_allclose(tw.dqx - summad_6d.dq1, 0, rtol=0, atol=0.5)
+    xo.assert_allclose(tw.dqy - summad_6d.dq2, 0, rtol=0, atol=0.5)

--- a/tests/test_lhc_match_phase_15.py
+++ b/tests/test_lhc_match_phase_15.py
@@ -1,15 +1,14 @@
 import pathlib
-import pytest
 
 import numpy as np
+import pytest
+from cpymad.madx import Madx
 
 import xdeps as xd
+import xobjects as xo
 import xtrack as xt
 import xtrack._temp.lhc_match as lm
-
 from xobjects.test_helpers import for_all_test_contexts
-
-from cpymad.madx import Madx
 
 test_data_folder = pathlib.Path(
     __file__).parent.joinpath('../test_data').absolute()
@@ -283,8 +282,8 @@ def test_lhc_match_phase_15(test_context, config):
 
     for ll in ['lhcb1', 'lhcb2']:
 
-        assert np.isclose(tw[ll].qx, tw_ref[ll].qx, atol=1e-7, rtol=0)
-        assert np.isclose(tw[ll].qy, tw_ref[ll].qy, atol=1e-7, rtol=0)
+        xo.assert_allclose(tw[ll].qx, tw_ref[ll].qx, atol=1e-7, rtol=0)
+        xo.assert_allclose(tw[ll].qy, tw_ref[ll].qy, atol=1e-7, rtol=0)
 
         mux_15 = tw[ll]['mux', 'ip5'] - tw[ll]['mux', 'ip1']
         mux_ref_15 = tw_ref[ll]['mux', 'ip5'] - tw_ref[ll]['mux', 'ip1']
@@ -292,20 +291,20 @@ def test_lhc_match_phase_15(test_context, config):
         muy_15 = tw[ll]['muy', 'ip5'] - tw[ll]['muy', 'ip1']
         muy_ref_15 = tw_ref[ll]['muy', 'ip5'] - tw_ref[ll]['muy', 'ip1']
 
-        assert np.isclose(mux_15, mux_ref_15 + d_mux[ll], atol=1e-7, rtol=0)
-        assert np.isclose(muy_15, muy_ref_15 + d_muy[ll], atol=1e-7, rtol=0)
+        xo.assert_allclose(mux_15, mux_ref_15 + d_mux[ll], atol=1e-7, rtol=0)
+        xo.assert_allclose(muy_15, muy_ref_15 + d_muy[ll], atol=1e-7, rtol=0)
 
         twip = tw[ll].rows['ip.*']
         twip_ref = tw_ref[ll].rows['ip.*']
 
-        assert np.allclose(twip['betx'], twip_ref['betx'], rtol=1e-6, atol=0)
-        assert np.allclose(twip['bety'], twip_ref['bety'], rtol=1e-6, atol=0)
-        assert np.allclose(twip['alfx'], twip_ref['alfx'], rtol=0, atol=1e-5)
-        assert np.allclose(twip['alfy'], twip_ref['alfy'], rtol=0, atol=1e-5)
-        assert np.allclose(twip['dx'], twip_ref['dx'], rtol=0, atol=1e-6)
-        assert np.allclose(twip['dy'], twip_ref['dy'], rtol=0, atol=1e-6)
-        assert np.allclose(twip['dpx'], twip_ref['dpx'], rtol=0, atol=1e-7)
-        assert np.allclose(twip['dpy'], twip_ref['dpy'], rtol=0, atol=1e-7)
+        xo.assert_allclose(twip['betx'], twip_ref['betx'], rtol=1e-6, atol=0)
+        xo.assert_allclose(twip['bety'], twip_ref['bety'], rtol=1e-6, atol=0)
+        xo.assert_allclose(twip['alfx'], twip_ref['alfx'], rtol=0, atol=1e-5)
+        xo.assert_allclose(twip['alfy'], twip_ref['alfy'], rtol=0, atol=1e-5)
+        xo.assert_allclose(twip['dx'], twip_ref['dx'], rtol=0, atol=1e-6)
+        xo.assert_allclose(twip['dy'], twip_ref['dy'], rtol=0, atol=1e-6)
+        xo.assert_allclose(twip['dpx'], twip_ref['dpx'], rtol=0, atol=1e-7)
+        xo.assert_allclose(twip['dpy'], twip_ref['dpy'], rtol=0, atol=1e-7)
 
 
     # -----------------------------------------------------------------------------
@@ -316,45 +315,45 @@ def test_lhc_match_phase_15(test_context, config):
     tw = collider.twiss()
     collider.vars['on_x2'] = 0
 
-    assert np.isclose(tw.lhcb1['py', 'ip2'], 34e-6, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['py', 'ip2'], -34e-6, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['y', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['y', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['py', 'ip2'], 34e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['py', 'ip2'], -34e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['y', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['y', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip2'], 0, atol=1e-8, rtol=0)
 
     collider.vars['on_x8'] = 35
     tw = collider.twiss()
     collider.vars['on_x8'] = 0
 
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 35e-6, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], -35e-6, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['py', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['py', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 35e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], -35e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['py', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['py', 'ip8'], 0, atol=1e-8, rtol=0)
 
     collider.vars['on_sep2'] = 0.5
     tw = collider.twiss()
     collider.vars['on_sep2'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip2'], -0.5e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip2'], 0.5e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['y', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['y', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip2'], -0.5e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip2'], 0.5e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['y', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['y', 'ip2'], 0, atol=1e-8, rtol=0)
 
     collider.vars['on_sep8'] = 0.6
     tw = collider.twiss()
     collider.vars['on_sep8'] = 0
 
-    assert np.isclose(tw.lhcb1['y', 'ip8'], 0.6e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['y', 'ip8'], -0.6e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['py', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['py', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['y', 'ip8'], 0.6e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['y', 'ip8'], -0.6e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['py', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['py', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-8, rtol=0)
 
     # Check lower level knobs (disconnects higher level knobs)
 
@@ -362,146 +361,146 @@ def test_lhc_match_phase_15(test_context, config):
     tw = collider.twiss()
     collider.vars['on_o2v'] = 0
 
-    assert np.isclose(tw.lhcb1['y', 'ip2'], 0.3e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['y', 'ip2'], 0.3e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['py', 'ip2'], 0., atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['py', 'ip2'], 0., atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['y', 'ip2'], 0.3e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['y', 'ip2'], 0.3e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['py', 'ip2'], 0., atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['py', 'ip2'], 0., atol=1e-8, rtol=0)
 
     collider.vars['on_o2h'] = 0.4
     tw = collider.twiss()
     collider.vars['on_o2h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip2'], 0.4e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip2'], 0.4e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip2'], 0., atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip2'], 0., atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip2'], 0.4e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip2'], 0.4e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip2'], 0., atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip2'], 0., atol=1e-8, rtol=0)
 
     collider.vars['on_o8v'] = 0.5
     tw = collider.twiss()
     collider.vars['on_o8v'] = 0
 
-    assert np.isclose(tw.lhcb1['y', 'ip8'], 0.5e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['y', 'ip8'], 0.5e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['py', 'ip8'], 0., atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['py', 'ip8'], 0., atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['y', 'ip8'], 0.5e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['y', 'ip8'], 0.5e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['py', 'ip8'], 0., atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['py', 'ip8'], 0., atol=1e-8, rtol=0)
 
     collider.vars['on_o8h'] = 0.6
     tw = collider.twiss()
     collider.vars['on_o8h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 0.6e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], 0.6e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 0., atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], 0., atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 0.6e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], 0.6e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 0., atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], 0., atol=1e-8, rtol=0)
 
     collider.vars['on_a2h'] = 20
     tw = collider.twiss()
     collider.vars['on_a2h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip2'], 20e-6, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip2'], 20e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip2'], 20e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip2'], 20e-6, atol=1e-8, rtol=0)
 
     collider.vars['on_a2v'] = 15
     tw = collider.twiss()
     collider.vars['on_a2v'] = 0
 
-    assert np.isclose(tw.lhcb1['y', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['y', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['py', 'ip2'], 15e-6, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['py', 'ip2'], 15e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['y', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['y', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['py', 'ip2'], 15e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['py', 'ip2'], 15e-6, atol=1e-8, rtol=0)
 
     collider.vars['on_a8h'] = 20
     tw = collider.twiss()
     collider.vars['on_a8h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 20e-6, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], 20e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 20e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], 20e-6, atol=1e-8, rtol=0)
 
     collider.vars['on_a8v'] = 50
     tw = collider.twiss()
     collider.vars['on_a8v'] = 0
 
-    assert np.isclose(tw.lhcb1['y', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['y', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['py', 'ip8'], 50e-6, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['py', 'ip8'], 50e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['y', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['y', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['py', 'ip8'], 50e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['py', 'ip8'], 50e-6, atol=1e-8, rtol=0)
 
     collider.vars['on_x2v'] = 100
     tw = collider.twiss()
     collider.vars['on_x2v'] = 0
 
-    assert np.isclose(tw.lhcb1['y', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['y', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['py', 'ip2'], 100e-6, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['py', 'ip2'], -100e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['y', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['y', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['py', 'ip2'], 100e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['py', 'ip2'], -100e-6, atol=1e-8, rtol=0)
 
     collider.vars['on_x2h'] = 120
     tw = collider.twiss()
     collider.vars['on_x2h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip2'], 120e-6, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip2'], -120e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip2'], 120e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip2'], -120e-6, atol=1e-8, rtol=0)
 
 
     collider.vars['on_x8h'] = 100
     tw = collider.twiss()
     collider.vars['on_x8h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 100e-6, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], -100e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 100e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], -100e-6, atol=1e-8, rtol=0)
 
     collider.vars['on_x8v'] = 120
     tw = collider.twiss()
     collider.vars['on_x8v'] = 0
 
-    assert np.isclose(tw.lhcb1['y', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['y', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['py', 'ip8'], 120e-6, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['py', 'ip8'], -120e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['y', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['y', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['py', 'ip8'], 120e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['py', 'ip8'], -120e-6, atol=1e-8, rtol=0)
 
     collider.vars['on_sep2h'] = 1.6
     tw = collider.twiss()
     collider.vars['on_sep2h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip2'], 1.6e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip2'], -1.6e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip2'], 1.6e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip2'], -1.6e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip2'], 0, atol=1e-8, rtol=0)
 
     collider.vars['on_sep2v'] = 1.7
     tw = collider.twiss()
     collider.vars['on_sep2v'] = 0
 
-    assert np.isclose(tw.lhcb1['y', 'ip2'], 1.7e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['y', 'ip2'], -1.7e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['py', 'ip2'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['py', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['y', 'ip2'], 1.7e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['y', 'ip2'], -1.7e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['py', 'ip2'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['py', 'ip2'], 0, atol=1e-8, rtol=0)
 
     collider.vars['on_sep8h'] = 1.5
     tw = collider.twiss()
     collider.vars['on_sep8h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 1.5e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], -1.5e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 1.5e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], -1.5e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], 0, atol=1e-8, rtol=0)
 
     collider.vars['on_sep8v'] = 1.7
     tw = collider.twiss()
     collider.vars['on_sep8v'] = 0
 
-    assert np.isclose(tw.lhcb1['y', 'ip8'], 1.7e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['y', 'ip8'], -1.7e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['py', 'ip8'], 0, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['py', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['y', 'ip8'], 1.7e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['y', 'ip8'], -1.7e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['py', 'ip8'], 0, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['py', 'ip8'], 0, atol=1e-8, rtol=0)
 
     # Both knobs together
     collider.vars['on_x8h'] = 120
@@ -510,10 +509,10 @@ def test_lhc_match_phase_15(test_context, config):
     collider.vars['on_x8h'] = 0
     collider.vars['on_sep8h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 1.7e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], -1.7e-3, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 120e-6, atol=1e-8, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], -120e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 1.7e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], -1.7e-3, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 120e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], -120e-6, atol=1e-8, rtol=0)
 
     # Check generated optics in madx
 
@@ -531,10 +530,10 @@ def test_lhc_match_phase_15(test_context, config):
     twmad_b1 = xd.Table(mad.table.twb1)
     twmad_b2 = xd.Table(mad.table.twb2)
 
-    assert np.isclose(twmad_b1['betx', 'ip1:1'], 0.15, rtol=1e-7, atol=0)
-    assert np.isclose(twmad_b1['bety', 'ip1:1'], 0.15, rtol=1e-7, atol=0)
-    assert np.isclose(twmad_b2['betx', 'ip1:1'], 0.15, rtol=1e-7, atol=0)
-    assert np.isclose(twmad_b2['bety', 'ip1:1'], 0.15, rtol=1e-7, atol=0)
+    xo.assert_allclose(twmad_b1['betx', 'ip1:1'], 0.15, rtol=1e-7, atol=0)
+    xo.assert_allclose(twmad_b1['bety', 'ip1:1'], 0.15, rtol=1e-7, atol=0)
+    xo.assert_allclose(twmad_b2['betx', 'ip1:1'], 0.15, rtol=1e-7, atol=0)
+    xo.assert_allclose(twmad_b2['bety', 'ip1:1'], 0.15, rtol=1e-7, atol=0)
 
     twmad_b1.rows['ip.*'].cols['betx bety x y px py'].show()
     twmad_b2.rows['ip.*'].cols['betx bety x y px py'].show()
@@ -548,10 +547,10 @@ def test_lhc_match_phase_15(test_context, config):
     twmad_b1 = xd.Table(mad.table.twb1)
     twmad_b2 = xd.Table(mad.table.twb2)
 
-    assert np.isclose(twmad_b1['px', 'ip8:1'], 100e-6, rtol=0, atol=1e-9)
-    assert np.isclose(twmad_b2['px', 'ip8:1'], -100e-6, rtol=0, atol=1e-9)
-    assert np.isclose(twmad_b1['py', 'ip2:1'], 110e-6, rtol=0, atol=5e-10)
-    assert np.isclose(twmad_b2['py', 'ip2:1'], -110e-6, rtol=0, atol=5e-10)
+    xo.assert_allclose(twmad_b1['px', 'ip8:1'], 100e-6, rtol=0, atol=1e-9)
+    xo.assert_allclose(twmad_b2['px', 'ip8:1'], -100e-6, rtol=0, atol=1e-9)
+    xo.assert_allclose(twmad_b1['py', 'ip2:1'], 110e-6, rtol=0, atol=5e-10)
+    xo.assert_allclose(twmad_b2['py', 'ip2:1'], -110e-6, rtol=0, atol=5e-10)
 
     # Match tunes and chromaticity in the Xsuite model
     opt = collider.match(
@@ -574,11 +573,11 @@ def test_lhc_match_phase_15(test_context, config):
     mad.input('twiss, sequence=lhcb1, table=twb1')
     mad.input('twiss, sequence=lhcb2, table=twb2')
 
-    assert np.isclose(mad.table.twb1.summary.q1, 62.315, rtol=0, atol=1e-6)
-    assert np.isclose(mad.table.twb1.summary.q2, 60.325, rtol=0, atol=1e-6)
-    assert np.isclose(mad.table.twb2.summary.q1, 62.316, rtol=0, atol=1e-6)
-    assert np.isclose(mad.table.twb2.summary.q2, 60.324, rtol=0, atol=1e-6)
-    assert np.isclose(mad.table.twb1.summary.dq1, 10.0, rtol=0, atol=0.5)
-    assert np.isclose(mad.table.twb1.summary.dq2, 12.0, rtol=0, atol=0.5)
-    assert np.isclose(mad.table.twb2.summary.dq1, 9.0, rtol=0, atol=0.5)
-    assert np.isclose(mad.table.twb2.summary.dq2, 11.0, rtol=0, atol=0.5)
+    xo.assert_allclose(mad.table.twb1.summary.q1, 62.315, rtol=0, atol=1e-6)
+    xo.assert_allclose(mad.table.twb1.summary.q2, 60.325, rtol=0, atol=1e-6)
+    xo.assert_allclose(mad.table.twb2.summary.q1, 62.316, rtol=0, atol=1e-6)
+    xo.assert_allclose(mad.table.twb2.summary.q2, 60.324, rtol=0, atol=1e-6)
+    xo.assert_allclose(mad.table.twb1.summary.dq1, 10.0, rtol=0, atol=0.5)
+    xo.assert_allclose(mad.table.twb1.summary.dq2, 12.0, rtol=0, atol=0.5)
+    xo.assert_allclose(mad.table.twb2.summary.dq1, 9.0, rtol=0, atol=0.5)
+    xo.assert_allclose(mad.table.twb2.summary.dq2, 11.0, rtol=0, atol=0.5)

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -3,18 +3,17 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
-import pickle
 import pathlib
+import pickle
 
 import numpy as np
 import pytest
 
-import xtrack as xt
-import xpart as xp
 import xobjects as xo
-
-from xtrack import Line, Node, Multipole
+import xpart as xp
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
+from xtrack import Line, Node, Multipole
 
 test_data_folder = pathlib.Path(
             __file__).parent.joinpath('../test_data').absolute()
@@ -37,9 +36,9 @@ def test_simplification_methods():
     line.merge_consecutive_drifts(inplace=True)
     assert len(line.element_names) == 3
     assert line.get_length() == line.get_s_elements(mode='downstream')[-1] == 5
-    assert np.isclose(line[0].length, 3.3, rtol=0, atol=1e-12)
+    xo.assert_allclose(line[0].length, 3.3, rtol=0, atol=1e-12)
     assert isinstance(line[1], xt.Cavity)
-    assert np.isclose(line[2].length, 1.7, rtol=0, atol=1e-12)
+    xo.assert_allclose(line[2].length, 1.7, rtol=0, atol=1e-12)
 
     # Test merging of drifts, while keeping one
     line.insert_element(element=xt.Drift(length=1), name='drift1', at_s=1.2)
@@ -80,14 +79,14 @@ def test_simplification_methods():
     assert len(joined_mult) == 1
     joined_mult = joined_mult[0]
     assert 'm2' in joined_mult
-    assert np.allclose(line[joined_mult].knl, [5,2,3], rtol=0, atol=1e-15)
-    assert np.allclose(line[joined_mult].ksl, [10,60,0], rtol=0, atol=1e-15)
+    xo.assert_allclose(line[joined_mult].knl, [5,2,3], rtol=0, atol=1e-15)
+    xo.assert_allclose(line[joined_mult].ksl, [10,60,0], rtol=0, atol=1e-15)
     # Merging all
     line._replace_with_equivalent_elements()
     line.merge_consecutive_multipoles(inplace=True)
     assert len(line.element_names) == 4
-    assert np.allclose(line[1].knl, [7,5,11], rtol=0, atol=1e-15)
-    assert np.allclose(line[1].ksl, [52,60,17], rtol=0, atol=1e-15)
+    xo.assert_allclose(line[1].knl, [7,5,11], rtol=0, atol=1e-15)
+    xo.assert_allclose(line[1].ksl, [52,60,17], rtol=0, atol=1e-15)
 
     # Test removing inactive multipoles
     line.insert_element(element=xt.Multipole(knl=[0, 8, 1], ksl=[0, 20, 30]), name='m5', at_s=3.3)
@@ -497,7 +496,7 @@ def test_from_sequence():
     for i, l in enumerate([3, 0, 4, 0, 1, 0, 2]):
         cls = xt.Multipole if i%2 else xt.Drift
         assert isinstance(line.elements[i], cls)
-        assert np.isclose(line.elements[i].length, l)
+        xo.assert_allclose(line.elements[i].length, l)
 
     # using pre-defined elements by name
     # ----------------------------------
@@ -515,7 +514,7 @@ def test_from_sequence():
     for i, l in enumerate([1, 0.3, 3, 0.3, 2, 0.5, 4]):
         cls = xt.Multipole if i%2 else xt.Drift
         assert isinstance(line.elements[i], cls)
-        assert np.isclose(line.elements[i].length, l)
+        xo.assert_allclose(line.elements[i].length, l)
     assert line.elements[1] == line.elements[3]
     assert line.element_names[1] == 'quad'
     assert line.element_names[3] == 'quad3'
@@ -591,7 +590,7 @@ def test_from_sequence_with_thick(refer):
     elif refer == 'exit':
         offset = -1
 
-    assert np.allclose(
+    xo.assert_allclose(
         line.get_s_position(line.element_names),
         [
             0,             # drift
@@ -743,16 +742,16 @@ def test_pickle():
     # Check that expressions work on old and new line
     line.vars['on_x1'] = 234
     ln.vars['on_x1'] = 123
-    assert np.isclose(line.twiss(method='4d')['px', 'ip1'], 234e-6, atol=1e-9, rtol=0)
-    assert np.isclose(ln.twiss(method='4d')['px', 'ip1'], 123e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(line.twiss(method='4d')['px', 'ip1'], 234e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(ln.twiss(method='4d')['px', 'ip1'], 123e-6, atol=1e-9, rtol=0)
 
     ln.vars['on_x1'] = 321
-    assert np.isclose(line.twiss(method='4d')['px', 'ip1'], 234e-6, atol=1e-9, rtol=0)
-    assert np.isclose(ln.twiss(method='4d')['px', 'ip1'], 321e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(line.twiss(method='4d')['px', 'ip1'], 234e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(ln.twiss(method='4d')['px', 'ip1'], 321e-6, atol=1e-9, rtol=0)
 
     line.vars['on_x1'] = 213
-    assert np.isclose(line.twiss(method='4d')['px', 'ip1'], 213e-6, atol=1e-9, rtol=0)
-    assert np.isclose(ln.twiss(method='4d')['px', 'ip1'], 321e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(line.twiss(method='4d')['px', 'ip1'], 213e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(ln.twiss(method='4d')['px', 'ip1'], 321e-6, atol=1e-9, rtol=0)
 
     line.discard_tracker()
 
@@ -764,16 +763,16 @@ def test_pickle():
 
     collider.vars['on_x1'] = 234
     coll.vars['on_x1'] = 123
-    assert np.isclose(collider['lhcb1'].twiss(method='4d')['px', 'ip1'], 234e-6, atol=1e-9, rtol=0)
-    assert np.isclose(coll['lhcb1'].twiss(method='4d')['px', 'ip1'], 123e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(collider['lhcb1'].twiss(method='4d')['px', 'ip1'], 234e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(coll['lhcb1'].twiss(method='4d')['px', 'ip1'], 123e-6, atol=1e-9, rtol=0)
 
     coll.vars['on_x1'] = 321
-    assert np.isclose(collider['lhcb1'].twiss(method='4d')['px', 'ip1'], 234e-6, atol=1e-9, rtol=0)
-    assert np.isclose(coll['lhcb1'].twiss(method='4d')['px', 'ip1'], 321e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(collider['lhcb1'].twiss(method='4d')['px', 'ip1'], 234e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(coll['lhcb1'].twiss(method='4d')['px', 'ip1'], 321e-6, atol=1e-9, rtol=0)
 
     collider.vars['on_x1'] = 213
-    assert np.isclose(collider['lhcb1'].twiss(method='4d')['px', 'ip1'], 213e-6, atol=1e-9, rtol=0)
-    assert np.isclose(coll['lhcb1'].twiss(method='4d')['px', 'ip1'], 321e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(collider['lhcb1'].twiss(method='4d')['px', 'ip1'], 213e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(coll['lhcb1'].twiss(method='4d')['px', 'ip1'], 321e-6, atol=1e-9, rtol=0)
 
 
 def test_line_attr():
@@ -870,21 +869,21 @@ def test_insert_thin_elements_at_s_lhc(test_context):
     # Check that there are no duplicated elements
     assert len(tt.name) == len(set(tt.name))
 
-    assert np.isclose(tt['s', 'm0_at_a'], s0, rtol=0, atol=1e-6)
-    assert np.isclose(tt['s', 'm1_at_a'], s0, rtol=0, atol=1e-6)
-    assert np.isclose(tt['s', 'm2_at_a'], s0, rtol=0, atol=1e-6)
+    xo.assert_allclose(tt['s', 'm0_at_a'], s0, rtol=0, atol=1e-6)
+    xo.assert_allclose(tt['s', 'm1_at_a'], s0, rtol=0, atol=1e-6)
+    xo.assert_allclose(tt['s', 'm2_at_a'], s0, rtol=0, atol=1e-6)
 
-    assert np.isclose(tt['s', 'm0_at_b'], s0 + 10., rtol=0, atol=1e-6)
-    assert np.isclose(tt['s', 'm1_at_b'], s0 + 10., rtol=0, atol=1e-6)
-    assert np.isclose(tt['s', 'm2_at_b'], s0 + 10., rtol=0, atol=1e-6)
+    xo.assert_allclose(tt['s', 'm0_at_b'], s0 + 10., rtol=0, atol=1e-6)
+    xo.assert_allclose(tt['s', 'm1_at_b'], s0 + 10., rtol=0, atol=1e-6)
+    xo.assert_allclose(tt['s', 'm2_at_b'], s0 + 10., rtol=0, atol=1e-6)
 
-    assert np.isclose(tt['s', 'm0_at_c'], s1, rtol=0, atol=1e-6)
-    assert np.isclose(tt['s', 'm1_at_c'], s1, rtol=0, atol=1e-6)
-    assert np.isclose(tt['s', 'm2_at_c'], s1, rtol=0, atol=1e-6)
+    xo.assert_allclose(tt['s', 'm0_at_c'], s1, rtol=0, atol=1e-6)
+    xo.assert_allclose(tt['s', 'm1_at_c'], s1, rtol=0, atol=1e-6)
+    xo.assert_allclose(tt['s', 'm2_at_c'], s1, rtol=0, atol=1e-6)
 
-    assert np.isclose(tt['s', 'm0_at_d'], s2, rtol=0, atol=1e-6)
-    assert np.isclose(tt['s', 'm1_at_d'], s2, rtol=0, atol=1e-6)
-    assert np.isclose(tt['s', 'm2_at_d'], s2, rtol=0, atol=1e-6)
+    xo.assert_allclose(tt['s', 'm0_at_d'], s2, rtol=0, atol=1e-6)
+    xo.assert_allclose(tt['s', 'm1_at_d'], s2, rtol=0, atol=1e-6)
+    xo.assert_allclose(tt['s', 'm2_at_d'], s2, rtol=0, atol=1e-6)
 
     assert np.all(tt.rows['mq.28r3.b1_entry%%-3':'mq.28r3.b1_entry'].name
             == np.array(['m0_at_a', 'm1_at_a', 'm2_at_a', 'mq.28r3.b1_entry']))
@@ -901,10 +900,10 @@ def test_insert_thin_elements_at_s_lhc(test_context):
                 == np.array(['m0_at_d', 'm1_at_d', 'm2_at_d',
                             'lhcb1ip7_p_', '_end_point']))
 
-    assert np.isclose(line.get_length(), tw0.s[-1], atol=1e-6)
+    xo.assert_allclose(line.get_length(), tw0.s[-1], atol=1e-6)
 
     tw1 = line.twiss()
-    assert np.isclose(tw1.qx, tw0.qx, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw1.qx, tw0.qx, atol=1e-9, rtol=0)
 
 
 def test_elements_intersecting_s():
@@ -944,7 +943,7 @@ def test_elements_intersecting_s():
     }
     result = line._elements_intersecting_s(cuts)
     for kk in expected.keys() | result.keys():
-        assert np.allclose(expected[kk], result[kk], atol=1e-16)
+        xo.assert_allclose(expected[kk], result[kk], atol=1e-16)
 
 
 def test_slicing_at_custom_s():
@@ -979,12 +978,12 @@ def test_slicing_at_custom_s():
     line.cut_at_s(cuts)
 
     tab = line.get_table()
-    assert np.allclose(tab.rows[r'e1\.\.\d*'].s, [0, 0.5], atol=1e-16)
-    assert np.allclose(tab.rows[r'e2\.\.\d*'].s, [1, 1.1, 1.7], atol=1e-16)
-    assert np.allclose(tab.rows[r'e3\.\.\d*'].s, [3], atol=1e-16)
-    assert np.allclose(tab.rows[r'e4\.\.\d*'].s, [4, 4.5], atol=1e-16)
-    assert np.allclose(tab.rows[r'e5\.\.\d*'].s, [5], atol=1e-16)
-    assert np.allclose(tab.rows[r'e6\.\.\d*'].s, [7, 7.8, 7.9], atol=1e-16)
+    xo.assert_allclose(tab.rows[r'e1\.\.\d*'].s, [0, 0.5], atol=1e-16)
+    xo.assert_allclose(tab.rows[r'e2\.\.\d*'].s, [1, 1.1, 1.7], atol=1e-16)
+    xo.assert_allclose(tab.rows[r'e3'].s, [3], atol=1e-16)
+    xo.assert_allclose(tab.rows[r'e4\.\.\d*'].s, [4, 4.5], atol=1e-16)
+    xo.assert_allclose(tab.rows[r'e5'].s, [5], atol=1e-16)
+    xo.assert_allclose(tab.rows[r'e6\.\.\d*'].s, [7, 7.8, 7.9], atol=1e-16)
 
 def test_insert_thick_element_reuse_marker_name():
 

--- a/tests/test_lumi.py
+++ b/tests/test_lumi.py
@@ -1,7 +1,9 @@
 import numpy as np
 
-import xtrack as xt
+import xobjects as xo
 import xpart as xp
+import xtrack as xt
+
 
 def test_lumi_calculation():
 
@@ -103,7 +105,7 @@ def test_lumi_calculation():
         twiss_b2=twiss_b2,
         crab=False)
 
-    assert np.isclose(ll_ip1, 1.0e+34, rtol=1e-2, atol=0)
+    xo.assert_allclose(ll_ip1, 1.0e+34, rtol=1e-2, atol=0)
 
     ll_ip5 = xt.lumi.luminosity_from_twiss(
         n_colliding_bunches=n_colliding_bunches,
@@ -116,4 +118,4 @@ def test_lumi_calculation():
         twiss_b2=twiss_b2,
         crab=False)
 
-    assert np.isclose(ll_ip5, 1.0e+34, rtol=1e-2, atol=0)
+    xo.assert_allclose(ll_ip5, 1.0e+34, rtol=1e-2, atol=0)

--- a/tests/test_mad_writer.py
+++ b/tests/test_mad_writer.py
@@ -1,8 +1,10 @@
 import pathlib
-import pytest
 
 import numpy as np
+import pytest
 from cpymad.madx import Madx
+
+import xobjects as xo
 import xtrack as xt
 
 test_data_folder = pathlib.Path(
@@ -52,18 +54,18 @@ def test_mad_writer(case):
 
     assert np.all(tw2.rows['ip.*'].name == tw.rows['ip.*'].name)
 
-    assert np.allclose(tw2.rows['ip.*'].s, tw.rows['ip.*'].s, rtol=0, atol=2e-9)
-    assert np.allclose(tw2.rows['ip.*'].x, tw.rows['ip.*'].x, rtol=0, atol=1e-9)
-    assert np.allclose(tw2.rows['ip.*'].y, tw.rows['ip.*'].y, rtol=0, atol=1e-9)
-    assert np.allclose(tw2.rows['ip.*'].px, tw.rows['ip.*'].px, rtol=0, atol=1e-9)
-    assert np.allclose(tw2.rows['ip.*'].py, tw.rows['ip.*'].py, rtol=0, atol=1e-9)
-    assert np.allclose(tw2.rows['ip.*'].mux, tw.rows['ip.*'].mux, rtol=0, atol=1e-8)
-    assert np.allclose(tw2.rows['ip.*'].muy, tw.rows['ip.*'].muy, rtol=0, atol=1e-8)
-    assert np.allclose(tw2.rows['ip.*'].betx, tw.rows['ip.*'].betx, rtol=1e-7, atol=0)
-    assert np.allclose(tw2.rows['ip.*'].bety, tw.rows['ip.*'].bety, rtol=1e-7, atol=0)
-    assert np.allclose(tw2.rows['ip.*'].ax_chrom, tw.rows['ip.*'].ax_chrom, rtol=1e-5, atol=0)
-    assert np.allclose(tw2.rows['ip.*'].dx_zeta, tw.rows['ip.*'].dx_zeta, rtol=2e-4, atol=1e-6)
-    assert np.allclose(tw2.rows['ip.*'].dy_zeta, tw.rows['ip.*'].dy_zeta, rtol=2e-4, atol=1e-6)
+    xo.assert_allclose(tw2.rows['ip.*'].s, tw.rows['ip.*'].s, rtol=0, atol=2e-9)
+    xo.assert_allclose(tw2.rows['ip.*'].x, tw.rows['ip.*'].x, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw2.rows['ip.*'].y, tw.rows['ip.*'].y, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw2.rows['ip.*'].px, tw.rows['ip.*'].px, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw2.rows['ip.*'].py, tw.rows['ip.*'].py, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw2.rows['ip.*'].mux, tw.rows['ip.*'].mux, rtol=0, atol=1e-8)
+    xo.assert_allclose(tw2.rows['ip.*'].muy, tw.rows['ip.*'].muy, rtol=0, atol=1e-8)
+    xo.assert_allclose(tw2.rows['ip.*'].betx, tw.rows['ip.*'].betx, rtol=1e-7, atol=0)
+    xo.assert_allclose(tw2.rows['ip.*'].bety, tw.rows['ip.*'].bety, rtol=1e-7, atol=0)
+    xo.assert_allclose(tw2.rows['ip.*'].ax_chrom, tw.rows['ip.*'].ax_chrom, rtol=1e-5, atol=0)
+    xo.assert_allclose(tw2.rows['ip.*'].dx_zeta, tw.rows['ip.*'].dx_zeta, rtol=2e-4, atol=1e-6)
+    xo.assert_allclose(tw2.rows['ip.*'].dy_zeta, tw.rows['ip.*'].dy_zeta, rtol=2e-4, atol=1e-6)
 
-    assert np.isclose(tw2.qs, tw.qs, rtol=1e-4, atol=0)
-    assert np.isclose(tw2.ddqx, tw.ddqx, rtol=1e-3, atol=0)
+    xo.assert_allclose(tw2.qs, tw.qs, rtol=1e-4, atol=0)
+    xo.assert_allclose(tw2.ddqx, tw.ddqx, rtol=1e-3, atol=0)

--- a/tests/test_madloader.py
+++ b/tests/test_madloader.py
@@ -2,46 +2,47 @@ import itertools
 import pathlib
 
 import numpy as np
-
-import xtrack.mad_loader
-from xtrack import MadLoader
-import xtrack as xt
+from cpymad.madx import Madx
 from scipy.constants import c as clight
 
+import xobjects as xo
 import xpart as xp
-
-from cpymad.madx import Madx
+import xtrack as xt
+import xtrack.mad_loader
+from xtrack import MadLoader
 
 test_data_folder = pathlib.Path(
-            __file__).parent.joinpath('../test_data').absolute()
+    __file__).parent.joinpath('../test_data').absolute()
+
 
 def test_non_zero_index():
-    lst=[1,2,3,0,0,0]
-    assert xtrack.mad_loader.non_zero_len([1,2,3,0,0,0])==3
+    lst = [1, 2, 3, 0, 0, 0]
+    assert xtrack.mad_loader.non_zero_len(lst) == 3
+
 
 def test_add_lists():
-    a=[1,2,3,1,1,1]
-    b=[1,1,1,4,5,6]
-    c=xtrack.mad_loader.add_lists(a,b,8)
-    assert c==[2, 3, 4, 5, 6, 7, 0, 0]
+    a = [1, 2, 3, 1, 1, 1]
+    b = [1, 1, 1, 4, 5, 6]
+    c = xtrack.mad_loader.add_lists(a, b, 8)
+    assert c == [2, 3, 4, 5, 6, 7, 0, 0]
+
 
 def test_add_lists():
-    a=[1,2,3,1,1,1]
-    b=[1,1,1,4,5,6,7,8]
-    c=xtrack.mad_loader.add_lists(a,b,8)
-    assert c==[2, 3, 4, 5, 6, 7, 7, 8]
+    a = [1, 2, 3, 1, 1, 1]
+    b = [1, 1, 1, 4, 5, 6, 7, 8]
+    c = xtrack.mad_loader.add_lists(a, b, 8)
+    assert c == [2, 3, 4, 5, 6, 7, 7, 8]
 
-    a=[1,2,3,1,1,1]
-    b=[1,1,1,4,5,6,7,8]
-    c=xtrack.mad_loader.add_lists(a,b,10)
-    assert c==[2, 3, 4, 5, 6, 7, 7, 8,0,0]
+    a = [1, 2, 3, 1, 1, 1]
+    b = [1, 1, 1, 4, 5, 6, 7, 8]
+    c = xtrack.mad_loader.add_lists(a, b, 10)
+    assert c == [2, 3, 4, 5, 6, 7, 7, 8, 0, 0]
 
 
 def test_tilt_shift_and_errors():
-
     mad = Madx(stdout=False)
 
-    src="""
+    src = """
     k1=0.2;
     tilt=0.1;
 
@@ -102,19 +103,18 @@ def test_tilt_shift_and_errors():
     from xtrack import MadLoader
 
     def gen_options(opt1):
-        for v in itertools.product(*([[True, False]]*len(opt1))):
-            yield dict(zip(opt1,v))
+        for v in itertools.product(*([[True, False]] * len(opt1))):
+            yield dict(zip(opt1, v))
 
-    opt1=["enable_expressions",
+    opt1 = ["enable_expressions",
         "enable_errors",
         "enable_apertures"]
 
-    opt2=["skip_markers","merge_drifts","merge_multipoles"]
-
+    opt2 = ["skip_markers", "merge_drifts", "merge_multipoles"]
 
     for opt in gen_options(opt1):
-        ml=MadLoader(mad.sequence.seq,**opt)
-        line=ml.make_line()
+        ml = MadLoader(mad.sequence.seq, **opt)
+        line = ml.make_line()
 
         if opt['enable_apertures'] and opt['enable_errors']:
             assert np.all(np.array(line.element_names) == (
@@ -128,7 +128,7 @@ def test_tilt_shift_and_errors():
                 'elm3',
                 'drift_2', 'seq$end'))
 
-        elif opt['enable_apertures'] and not(opt['enable_errors']):
+        elif opt['enable_apertures'] and not (opt['enable_errors']):
             assert np.all(np.array(line.element_names) == (
                 'seq$start',
                 'elm1_aper',
@@ -140,15 +140,15 @@ def test_tilt_shift_and_errors():
                 'elm2',
                 'elm3_aper',
                 'elm3', 'drift_2', 'seq$end'
-                ))
-        elif not(opt['enable_apertures']) and opt['enable_errors']:
+            ))
+        elif not (opt['enable_apertures']) and opt['enable_errors']:
             assert np.all(np.array(line.element_names) == (
                 'seq$start', 'elm1',
                 'drift_0', 'mk', 'mk2',
                 'drift_1', 'elm2',
                 'elm3',
                 'drift_2', 'seq$end'))
-        elif not(opt['enable_apertures']) and not(opt['enable_errors']):
+        elif not (opt['enable_apertures']) and not (opt['enable_errors']):
             assert np.all(np.array(line.element_names) == (
                 'seq$start', 'elm1',
                 'drift_0', 'mk', 'mk2', 'drift_1', 'elm2',
@@ -165,53 +165,53 @@ def test_tilt_shift_and_errors():
 
         on_err = int(opt['enable_errors'])
         if opt['enable_apertures']:
+            xo.assert_allclose(line['elm2_aper'].rot_s_rad,
+                               mad_elm2.aper_tilt,
+                               rtol=0, atol=1e-13)
 
-            assert np.isclose(line['elm2_aper'].rot_s_rad,
-                                mad_elm2.aper_tilt,
-                                rtol=0, atol=1e-13)
-
-            assert np.isclose(line['elm2_aper'].shift_x,
-                        on_err * mad_elm2.align_errors.arex + mad_elm2.aper_offset[0],
-                        rtol=0, atol=1e-13)
-            assert np.isclose(line['elm2_aper'].shift_y,
-                        on_err * mad_elm2.align_errors.arey + mad_elm2.aper_offset[1],
-                        rtol=0, atol=1e-13)
+            xo.assert_allclose(line['elm2_aper'].shift_x,
+                               on_err * mad_elm2.align_errors.arex + mad_elm2.aper_offset[0],
+                               rtol=0, atol=1e-13)
+            xo.assert_allclose(line['elm2_aper'].shift_y,
+                               on_err * mad_elm2.align_errors.arey + mad_elm2.aper_offset[1],
+                               rtol=0, atol=1e-13)
 
             assert isinstance(line['elm2_aper'], xt.LimitRectEllipse)
             assert line['elm2_aper'].max_x == .1
             assert line['elm2_aper'].max_y == .2
-            assert line['elm2_aper'].a_squ == .11**2
-            assert line['elm2_aper'].b_squ == .22**2
+            assert line['elm2_aper'].a_squ == .11 ** 2
+            assert line['elm2_aper'].b_squ == .22 ** 2
 
-        assert np.isclose(line['elm2'].rot_s_rad,
-                    (mad_elm2.tilt + on_err * mad_elm2.align_errors.dpsi),
-                    rtol=0, atol=1e-13)
+        xo.assert_allclose(line['elm2'].rot_s_rad,
+                           (mad_elm2.tilt + on_err * mad_elm2.align_errors.dpsi),
+                           rtol=0, atol=1e-13)
 
         if opt['enable_errors']:
-            assert np.isclose(line['elm2'].shift_x,
-                                on_err * mad_elm2.align_errors.dx, rtol=0, atol=1e-13)
-            assert np.isclose(line['elm2'].shift_y,
-                                on_err * mad_elm2.align_errors.dy, rtol=0, atol=1e-13)
+            xo.assert_allclose(line['elm2'].shift_x,
+                               on_err * mad_elm2.align_errors.dx, rtol=0, atol=1e-13)
+            xo.assert_allclose(line['elm2'].shift_y,
+                               on_err * mad_elm2.align_errors.dy, rtol=0, atol=1e-13)
 
-        for ii in range(line['elm2'].order+1):
+        for ii in range(line['elm2'].order + 1):
             ref = 0
-            if len(mad_elm2.knl)>ii:
+            if len(mad_elm2.knl) > ii:
                 ref += mad_elm2.knl[ii]
-            if opt['enable_errors'] and len(mad_elm2.field_errors.dkn)>ii:
+            if opt['enable_errors'] and len(mad_elm2.field_errors.dkn) > ii:
                 ref += mad_elm2.field_errors.dkn[ii]
-            assert np.isclose(line['elm2'].knl[ii], ref, rtol=0, atol=1e-13)
+            xo.assert_allclose(line['elm2'].knl[ii], ref, rtol=0, atol=1e-13)
 
-        for ii in range(line['elm2'].order+1):
+        for ii in range(line['elm2'].order + 1):
             ref = 0
-            if len(mad_elm2.ksl)>ii:
+            if len(mad_elm2.ksl) > ii:
                 ref += mad_elm2.ksl[ii]
-            if opt['enable_errors'] and len(mad_elm2.field_errors.dks)>ii:
+            if opt['enable_errors'] and len(mad_elm2.field_errors.dks) > ii:
                 ref += mad_elm2.field_errors.dks[ii]
-            assert np.isclose(line['elm2'].ksl[ii], ref, rtol=0, atol=1e-13)
+            xo.assert_allclose(line['elm2'].ksl[ii], ref, rtol=0, atol=1e-13)
 
     for opt in gen_options(opt2):
-        ml=MadLoader(mad.sequence.seq,**opt)
-        line=list(ml.iter_elements())
+        ml = MadLoader(mad.sequence.seq, **opt)
+        line = list(ml.iter_elements())
+
 
 def test_matrix():
     mad = Madx(stdout=False)
@@ -227,10 +227,11 @@ def test_matrix():
     beam; use, sequence=ss;
     """)
 
-    line=MadLoader(mad.sequence.ss).make_line()
-    line=MadLoader(mad.sequence.ss,enable_expressions=True).make_line()
-    line.vars['a11']=2.0
-    assert line[1].m1[0,0]==line.vars['a11']._value
+    line = MadLoader(mad.sequence.ss).make_line()
+    line = MadLoader(mad.sequence.ss, enable_expressions=True).make_line()
+    line.vars['a11'] = 2.0
+    assert line[1].m1[0, 0] == line.vars['a11']._value
+
 
 def test_srotation():
     mad = Madx(stdout=False)
@@ -244,11 +245,12 @@ def test_srotation():
     beam; use, sequence=ss;
     """)
 
-    line=MadLoader(mad.sequence.ss).make_line()
-    line=MadLoader(mad.sequence.ss,enable_expressions=True).make_line()
-    assert isinstance(line[1],xt.SRotation)
+    line = MadLoader(mad.sequence.ss).make_line()
+    line = MadLoader(mad.sequence.ss, enable_expressions=True).make_line()
+    assert isinstance(line[1], xt.SRotation)
     line.vars['angle'] = 2.0
-    assert line[1].angle == line.vars['angle']._value*180/np.pi
+    assert line[1].angle == line.vars['angle']._value * 180 / np.pi
+
 
 def test_xrotation():
     mad = Madx(stdout=False)
@@ -262,11 +264,12 @@ def test_xrotation():
     beam; use, sequence=ss;
     """)
 
-    line=MadLoader(mad.sequence.ss).make_line()
-    line=MadLoader(mad.sequence.ss,enable_expressions=True).make_line()
-    assert isinstance(line[1],xt.XRotation)
+    line = MadLoader(mad.sequence.ss).make_line()
+    line = MadLoader(mad.sequence.ss, enable_expressions=True).make_line()
+    assert isinstance(line[1], xt.XRotation)
     line.vars['angle'] = 2.0
-    assert line[1].angle == line.vars['angle']._value*180/np.pi
+    assert line[1].angle == line.vars['angle']._value * 180 / np.pi
+
 
 def test_yrotation():
     mad = Madx(stdout=False)
@@ -280,14 +283,14 @@ def test_yrotation():
     beam; use, sequence=ss;
     """)
 
-    line=MadLoader(mad.sequence.ss).make_line()
-    line=MadLoader(mad.sequence.ss,enable_expressions=True).make_line()
-    assert isinstance(line[1],xt.YRotation)
+    line = MadLoader(mad.sequence.ss).make_line()
+    line = MadLoader(mad.sequence.ss, enable_expressions=True).make_line()
+    assert isinstance(line[1], xt.YRotation)
     line.vars['angle'] = 2.0
-    assert line[1].angle == line.vars['angle']._value*180/np.pi
+    assert line[1].angle == line.vars['angle']._value * 180 / np.pi
+
 
 def test_mad_elements_import():
-
     mad = Madx(stdout=False)
 
     # Element definitions
@@ -315,30 +318,30 @@ def test_mad_elements_import():
     oct0: marker, apertype=octagon, aperture:={a * 3, a * 6, a * pi/6, a * pi/3};
     """)
 
-    matrix_m0 = np.random.randn(6)*1E-6
-    matrix_m1 = np.reshape(np.random.randn(36),(6,6))
+    matrix_m0 = np.random.randn(6) * 1E-6
+    matrix_m1 = np.reshape(np.random.randn(36), (6, 6))
     mad.input(f"mat:matrix,l:=0.003*a,"
               f"kick1:={matrix_m0[0]}*a,kick2:={matrix_m0[1]}*a,"
               f"kick3:={matrix_m0[2]}*a,kick4:={matrix_m0[3]}*a,"
               f"kick5:={matrix_m0[4]}*a,kick6:={matrix_m0[5]}*a,"
-              f"rm11:={matrix_m1[0,0]}*a,rm12:={matrix_m1[0,1]}*a,"
-              f"rm13:={matrix_m1[0,2]}*a,rm14:={matrix_m1[0,3]}*a,"
-              f"rm15:={matrix_m1[0,4]}*a,rm16:={matrix_m1[0,5]}*a,"
-              f"rm21:={matrix_m1[1,0]}*a,rm22:={matrix_m1[1,1]}*a,"
-              f"rm23:={matrix_m1[1,2]}*a,rm24:={matrix_m1[1,3]}*a,"
-              f"rm25:={matrix_m1[1,4]}*a,rm26:={matrix_m1[1,5]}*a,"
-              f"rm31:={matrix_m1[2,0]}*a,rm32:={matrix_m1[2,1]}*a,"
-              f"rm33:={matrix_m1[2,2]}*a,rm34:={matrix_m1[2,3]}*a,"
-              f"rm35:={matrix_m1[2,4]}*a,rm36:={matrix_m1[2,5]}*a,"
-              f"rm41:={matrix_m1[3,0]}*a,rm42:={matrix_m1[3,1]}*a,"
-              f"rm43:={matrix_m1[3,2]}*a,rm44:={matrix_m1[3,3]}*a,"
-              f"rm45:={matrix_m1[3,4]}*a,rm46:={matrix_m1[3,5]}*a,"
-              f"rm51:={matrix_m1[4,0]}*a,rm52:={matrix_m1[4,1]}*a,"
-              f"rm53:={matrix_m1[4,2]}*a,rm54:={matrix_m1[4,3]}*a,"
-              f"rm55:={matrix_m1[4,4]}*a,rm56:={matrix_m1[4,5]}*a,"
-              f"rm61:={matrix_m1[5,0]}*a,rm62:={matrix_m1[5,1]}*a,"
-              f"rm63:={matrix_m1[5,2]}*a,rm64:={matrix_m1[5,3]}*a,"
-              f"rm65:={matrix_m1[5,4]}*a,rm66={matrix_m1[5,5]}*a;")
+              f"rm11:={matrix_m1[0, 0]}*a,rm12:={matrix_m1[0, 1]}*a,"
+              f"rm13:={matrix_m1[0, 2]}*a,rm14:={matrix_m1[0, 3]}*a,"
+              f"rm15:={matrix_m1[0, 4]}*a,rm16:={matrix_m1[0, 5]}*a,"
+              f"rm21:={matrix_m1[1, 0]}*a,rm22:={matrix_m1[1, 1]}*a,"
+              f"rm23:={matrix_m1[1, 2]}*a,rm24:={matrix_m1[1, 3]}*a,"
+              f"rm25:={matrix_m1[1, 4]}*a,rm26:={matrix_m1[1, 5]}*a,"
+              f"rm31:={matrix_m1[2, 0]}*a,rm32:={matrix_m1[2, 1]}*a,"
+              f"rm33:={matrix_m1[2, 2]}*a,rm34:={matrix_m1[2, 3]}*a,"
+              f"rm35:={matrix_m1[2, 4]}*a,rm36:={matrix_m1[2, 5]}*a,"
+              f"rm41:={matrix_m1[3, 0]}*a,rm42:={matrix_m1[3, 1]}*a,"
+              f"rm43:={matrix_m1[3, 2]}*a,rm44:={matrix_m1[3, 3]}*a,"
+              f"rm45:={matrix_m1[3, 4]}*a,rm46:={matrix_m1[3, 5]}*a,"
+              f"rm51:={matrix_m1[4, 0]}*a,rm52:={matrix_m1[4, 1]}*a,"
+              f"rm53:={matrix_m1[4, 2]}*a,rm54:={matrix_m1[4, 3]}*a,"
+              f"rm55:={matrix_m1[4, 4]}*a,rm56:={matrix_m1[4, 5]}*a,"
+              f"rm61:={matrix_m1[5, 0]}*a,rm62:={matrix_m1[5, 1]}*a,"
+              f"rm63:={matrix_m1[5, 2]}*a,rm64:={matrix_m1[5, 3]}*a,"
+              f"rm65:={matrix_m1[5, 4]}*a,rm66={matrix_m1[5, 5]}*a;")
 
     # Sequence
     mad.input("""
@@ -362,13 +365,12 @@ def test_mad_elements_import():
     oct: oct0, at=3;
     endsequence;
     """
-    )
+              )
 
     # Beam
     mad.input("""
     beam, particle=proton, gamma=1.05, sequence=testseq;
     """)
-
 
     mad.use('testseq')
 
@@ -380,30 +382,28 @@ def test_mad_elements_import():
                                           install_apertures=True)
         line.particle_ref = xp.Particles(mass0=xp.PROTON_MASS_EV, gamma0=1.05)
 
-        line = xt.Line.from_dict(line.to_dict()) # This calls the to_dict method fot all
-                                                # elements
-
+        line = xt.Line.from_dict(line.to_dict())  # This calls the to_dict method fot all
+        # elements
 
         assert len(line.element_names) == len(line.element_dict.keys())
         assert line.get_length() == 10
 
         assert isinstance(line['m0'], xt.Multipole)
         assert line.get_s_position('m0') == 0.1
-        assert np.all(line['m0'].knl == np.array([1,2,3]))
-        assert np.all(line['m0'].ksl == np.array([0,5,6]))
+        assert np.all(line['m0'].knl == np.array([1, 2, 3]))
+        assert np.all(line['m0'].ksl == np.array([0, 5, 6]))
         assert line['m0'].hxl == 1
         assert line['m0'].length == 1.1
-        assert len(line['m1'].knl)==3
-        assert len(line['m1'].ksl)==3
-        assert len(line['m2'].knl)==3
-        assert len(line['m2'].ksl)==3
+        assert len(line['m1'].knl) == 3
+        assert len(line['m1'].ksl) == 3
+        assert len(line['m2'].knl) == 3
+        assert len(line['m2'].ksl) == 3
         if test_expressions:
-          assert len(line['m3'].knl)==4
-          assert len(line['m3'].ksl)==4
+            assert len(line['m3'].knl) == 4
+            assert len(line['m3'].ksl) == 4
         else:
-          assert len(line['m3'].knl)==3
-          assert len(line['m3'].ksl)==3
-
+            assert len(line['m3'].knl) == 3
+            assert len(line['m3'].ksl) == 3
 
         assert isinstance(line['k0'], xt.Multipole)
         assert line.get_s_position('k0') == 0.3
@@ -441,8 +441,8 @@ def test_mad_elements_import():
 
         assert isinstance(line['c1'], xt.Cavity)
         assert line.get_s_position('c1') == 0.2
-        assert np.isclose(line['c1'].frequency, clight*line.particle_ref.beta0/10.*8,
-                        rtol=0, atol=1e-7)
+        xo.assert_allclose(line['c1'].frequency, clight * line.particle_ref.beta0 / 10. * 8,
+                           rtol=0, atol=1e-7)
         assert line['c1'].lag == 180
         assert line['c1'].voltage == 6e6
 
@@ -455,10 +455,10 @@ def test_mad_elements_import():
 
         assert isinstance(line['r0'], xt.RFMultipole)
         assert line.get_s_position('r0') == 0.4
-        assert np.all(line['r0'].knl == np.array([2,3]))
-        assert np.all(line['r0'].ksl == np.array([0,5]))
-        assert np.all(line['r0'].pn == np.array([0.3*360,0.4*360]))
-        assert np.all(line['r0'].ps == np.array([0.5*360,0.6*360]))
+        assert np.all(line['r0'].knl == np.array([2, 3]))
+        assert np.all(line['r0'].ksl == np.array([0, 5]))
+        assert np.all(line['r0'].pn == np.array([0.3 * 360, 0.4 * 360]))
+        assert np.all(line['r0'].ps == np.array([0.5 * 360, 0.6 * 360]))
         assert line['r0'].voltage == 2e6
         assert line['r0'].order == 1
         assert line['r0'].frequency == 100e6
@@ -468,8 +468,8 @@ def test_mad_elements_import():
         assert line.get_s_position('cb0') == 0.41
         assert len(line['cb0'].knl) == 1
         assert len(line['cb0'].ksl) == 1
-        assert np.isclose(line['cb0'].knl[0], 2*1e6/line.particle_ref.p0c[0],
-                        rtol=0, atol=1e-12)
+        xo.assert_allclose(line['cb0'].knl[0], 2 * 1e6 / line.particle_ref.p0c[0],
+                           rtol=0, atol=1e-12)
         assert np.all(line['cb0'].ksl == 0)
         assert np.all(line['cb0'].pn == np.array([270]))
         assert np.all(line['cb0'].ps == 0.)
@@ -482,8 +482,8 @@ def test_mad_elements_import():
         assert line.get_s_position('cb1') == 0.42
         assert len(line['cb1'].knl) == 1
         assert len(line['cb1'].ksl) == 1
-        assert np.isclose(line['cb1'].ksl[0], -2*1e6/line.particle_ref.p0c[0],
-                        rtol=0, atol=1e-12)
+        xo.assert_allclose(line['cb1'].ksl[0], -2 * 1e6 / line.particle_ref.p0c[0],
+                           rtol=0, atol=1e-12)
         assert np.all(line['cb1'].knl == 0)
         assert np.all(line['cb1'].ps == np.array([270]))
         assert np.all(line['cb1'].pn == 0.)
@@ -492,7 +492,6 @@ def test_mad_elements_import():
         assert line['cb1'].frequency == 100e6
         assert line['cb1'].lag == 0
 
-
         assert isinstance(line['w'], xt.Wire)
         assert line.get_s_position('w') == 1
         assert line['w'].L_phy == 1
@@ -500,38 +499,38 @@ def test_mad_elements_import():
         assert line['w'].xma == 1e-3
         assert line['w'].yma == 2e-3
 
-        assert isinstance(line['mat0'],xt.FirstOrderTaylorMap)
+        assert isinstance(line['mat0'], xt.FirstOrderTaylorMap)
         assert line.get_s_position('mat0') == 2
-        assert np.allclose(line['mat0'].m0,matrix_m0,rtol=0.0,atol=1E-12)
-        assert np.allclose(line['mat0'].m1,matrix_m1,rtol=0.0,atol=1E-12)
+        xo.assert_allclose(line['mat0'].m0, matrix_m0, rtol=0.0, atol=1E-12)
+        xo.assert_allclose(line['mat0'].m1, matrix_m1, rtol=0.0, atol=1E-12)
 
         assert isinstance(line['oct_aper'], xt.LimitPolygon)
         assert line.get_s_position('oct_aper') == 3
         x_1, x_2, y_1, y_2 = 3, 2 * np.sqrt(3), np.sqrt(3), 6
-        expected_x_vertices = [x_1, x_2,  -x_2, -x_1, -x_1, -x_2, x_2, x_1]
+        expected_x_vertices = [x_1, x_2, -x_2, -x_1, -x_1, -x_2, x_2, x_1]
         expected_y_vertices = [y_1, y_2, y_2, y_1, -y_1, -y_2, -y_2, -y_1]
-        assert np.allclose(line['oct_aper'].x_vertices, expected_x_vertices)
-        assert np.allclose(line['oct_aper'].y_vertices, expected_y_vertices)
+        xo.assert_allclose(line['oct_aper'].x_vertices, expected_x_vertices)
+        xo.assert_allclose(line['oct_aper'].y_vertices, expected_y_vertices)
 
 
 def test_selective_expr_import_and_replace_in_expr():
-
     # Load line with knobs on correctors only
     from cpymad.madx import Madx
     mad = Madx(stdout=False)
-    mad.call(str( test_data_folder /
-                'hllhc14_no_errors_with_coupling_knobs/lhcb1_seq.madx'))
+    mad.call(str(test_data_folder /
+                 'hllhc14_no_errors_with_coupling_knobs/lhcb1_seq.madx'))
     mad.use(sequence='lhcb1')
     line = xt.Line.from_madx_sequence(mad.sequence.lhcb1,
-        deferred_expressions=True,
-        replace_in_expr={'bv_aux': 'bv_aux_lhcb1'},
-        expressions_for_element_types=('kicker', 'hkicker', 'vkicker'))
+                                      deferred_expressions=True,
+                                      replace_in_expr={'bv_aux': 'bv_aux_lhcb1'},
+                                      expressions_for_element_types=('kicker', 'hkicker', 'vkicker'))
 
     assert len(line.vars['bv_aux_lhcb1']._find_dependant_targets()) > 1
     assert 'bv_aux' not in line.vars
 
-    assert line.element_refs['mqxfa.b3r5..1'].knl[1]._expr is None # multipole
-    assert line.element_refs['mcbxfbv.b2r1'].ksl[0]._expr is not None # kicker
+    assert line.element_refs['mqxfa.b3r5..1'].knl[1]._expr is None  # multipole
+    assert line.element_refs['mcbxfbv.b2r1'].ksl[0]._expr is not None  # kicker
+
 
 def test_load_madx_optics_file():
     collider = xt.Multiline.from_json(
@@ -567,9 +566,9 @@ def test_load_madx_optics_file():
     assert collider.lhcb1.varval['on_x1'] == 70
     assert collider.lhcb2.varval['on_x1'] == 70
 
-    collider.vars['on_disp'] = 0 # more precise angle
-    assert np.isclose(collider.twiss().lhcb1['px', 'ip1'], 70e-6, atol=1e-8, rtol=0)
-    assert np.isclose(collider.twiss().lhcb2['px', 'ip1'], -70e-6, atol=1e-8, rtol=0)
+    collider.vars['on_disp'] = 0  # more precise angle
+    xo.assert_allclose(collider.twiss().lhcb1['px', 'ip1'], 70e-6, atol=1e-8, rtol=0)
+    xo.assert_allclose(collider.twiss().lhcb2['px', 'ip1'], -70e-6, atol=1e-8, rtol=0)
 
     collider.vars.load_madx_optics_file(
         test_data_folder / 'hllhc15_thick/opt_round_300_1500.madx')
@@ -577,67 +576,67 @@ def test_load_madx_optics_file():
     collider._xdeps_manager.verify()
 
     tw = collider.twiss()
-    assert np.isclose(tw.lhcb1.qx, 62.31000000, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1.qy, 60.32000000, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2.qx, 62.31000000, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2.qy, 60.32000000, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['betx', 'ip1'], 0.30, atol=0, rtol=1e-4)
-    assert np.isclose(tw.lhcb1['bety', 'ip1'], 0.30, atol=0, rtol=1e-4)
-    assert np.isclose(tw.lhcb2['betx', 'ip1'], 0.30, atol=0, rtol=1e-4)
-    assert np.isclose(tw.lhcb2['bety', 'ip1'], 0.30, atol=0, rtol=1e-4)
+    xo.assert_allclose(tw.lhcb1.qx, 62.31000000, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1.qy, 60.32000000, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2.qx, 62.31000000, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2.qy, 60.32000000, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip1'], 0.30, atol=0, rtol=1e-4)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip1'], 0.30, atol=0, rtol=1e-4)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip1'], 0.30, atol=0, rtol=1e-4)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip1'], 0.30, atol=0, rtol=1e-4)
 
     # Check a knob
     collider.vars['on_x1'] = 30
     collider.vars['on_disp'] = 0
     tw = collider.twiss()
-    assert np.isclose(tw.lhcb1['px', 'ip1'], 30e-6, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip1'], -30e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip1'], 30e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip1'], -30e-6, atol=1e-9, rtol=0)
 
     collider.vars.load_madx_optics_file(
         test_data_folder / 'hllhc15_thick/opt_round_150_1500.madx')
 
     tw = collider.twiss()
-    assert np.isclose(tw.lhcb1.qx, 62.31000000, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1.qy, 60.32000000, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2.qx, 62.31000000, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2.qy, 60.32000000, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=0, rtol=1e-6)
-    assert np.isclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=0, rtol=1e-6)
-    assert np.isclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=0, rtol=1e-6)
-    assert np.isclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=0, rtol=1e-6)
+    xo.assert_allclose(tw.lhcb1.qx, 62.31000000, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1.qy, 60.32000000, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2.qx, 62.31000000, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2.qy, 60.32000000, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=0, rtol=1e-6)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=0, rtol=1e-6)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=0, rtol=1e-6)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=0, rtol=1e-6)
 
     # Check a knob
     collider.vars['on_x1'] = 10
     collider.vars['on_disp'] = 0
     tw = collider.twiss()
-    assert np.isclose(tw.lhcb1['px', 'ip1'], 10e-6, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip1'], -10e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip1'], 10e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip1'], -10e-6, atol=1e-9, rtol=0)
 
     # Try unregister/register
 
     collider.vars['ox_x1h'] = 20
     tw = collider.twiss()
-    assert np.isclose(tw.lhcb1['px', 'ip1'], 10e-6, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip1'], -10e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip1'], 10e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip1'], -10e-6, atol=1e-9, rtol=0)
 
     collider.vars['on_x8h'] = collider.vars['on_x2']
     collider.vars['on_x2'] = 25
     tw = collider.twiss()
 
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 25e-6, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], -25e-6, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb1['py', 'ip8'], 0, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['py', 'ip8'], 0, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb1['py', 'ip2'], 25e-6, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['py', 'ip2'], -25e-6, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip2'], 0, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip2'], 0, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 25e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], -25e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['py', 'ip8'], 0, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['py', 'ip8'], 0, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['py', 'ip2'], 25e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['py', 'ip2'], -25e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip2'], 0, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip2'], 0, atol=1e-9, rtol=0)
+
 
 def test_load_b2_with_bv_minus_one():
-
     test_data_folder_str = str(test_data_folder)
 
-    mad1=Madx(stdout=False)
+    mad1 = Madx(stdout=False)
     mad1.call(test_data_folder_str + '/hllhc15_thick/lhc.seq')
     mad1.call(test_data_folder_str + '/hllhc15_thick/hllhc_sequence.madx')
     mad1.input('beam, sequence=lhcb1, particle=proton, energy=7000;')
@@ -647,7 +646,7 @@ def test_load_b2_with_bv_minus_one():
     mad1.call(test_data_folder_str + '/hllhc15_thick/opt_round_150_1500.madx')
     mad1.twiss()
 
-    mad4=Madx(stdout=False)
+    mad4 = Madx(stdout=False)
     mad4.input('mylhcbeam=4')
     mad4.call(test_data_folder_str + '/hllhc15_thick/lhcb4.seq')
     mad4.call(test_data_folder_str + '/hllhc15_thick/hllhc_sequence.madx')
@@ -657,41 +656,41 @@ def test_load_b2_with_bv_minus_one():
     mad4.twiss()
 
     for mad in [mad1, mad4]:
-        mad.globals['vrf400'] = 16 # Check voltage expressions
-        mad.globals['lagrf400.b2'] = 0.02 # Check lag expressions
-        mad.globals['on_x1'] = 100 # Check kicker expressions
-        mad.globals['on_sep2'] = 2 # Check kicker expressions
-        mad.globals['on_x5'] = 123 # Check kicker expressions
-        mad.globals['kqtf.b2'] = 1e-5 # Check quad expressions
+        mad.globals['vrf400'] = 16  # Check voltage expressions
+        mad.globals['lagrf400.b2'] = 0.02  # Check lag expressions
+        mad.globals['on_x1'] = 100  # Check kicker expressions
+        mad.globals['on_sep2'] = 2  # Check kicker expressions
+        mad.globals['on_x5'] = 123  # Check kicker expressions
+        mad.globals['kqtf.b2'] = 1e-5  # Check quad expressions
         mad.globals['ksf.b2'] = 1e-3  # Check sext expressions
-        mad.globals['kqs.l3b2'] = 1e-4 # Check skew expressions
-        mad.globals['kss.a45b2'] = 1e-4 # Check skew sext expressions
-        mad.globals['kof.a34b2'] = 3 # Check oct expressions
-        mad.globals['on_crab1'] = -190 # Check cavity expressions
-        mad.globals['on_crab5'] = -130 # Check cavity expressions
-        mad.globals['on_sol_atlas'] = 1 # Check solenoid expressions
-        mad.globals['kcdx3.r1'] = 1e-4 # Check thin decapole expressions
-        mad.globals['kcdsx3.r1'] = 1e-4 # Check thin skew decapole expressions
-        mad.globals['kctx3.l1'] = 1e-5 # Check thin dodecapole expressions
-        mad.globals['kctsx3.r1'] = 1e-5 # Check thin skew dodecapole expressions
+        mad.globals['kqs.l3b2'] = 1e-4  # Check skew expressions
+        mad.globals['kss.a45b2'] = 1e-4  # Check skew sext expressions
+        mad.globals['kof.a34b2'] = 3  # Check oct expressions
+        mad.globals['on_crab1'] = -190  # Check cavity expressions
+        mad.globals['on_crab5'] = -130  # Check cavity expressions
+        mad.globals['on_sol_atlas'] = 1  # Check solenoid expressions
+        mad.globals['kcdx3.r1'] = 1e-4  # Check thin decapole expressions
+        mad.globals['kcdsx3.r1'] = 1e-4  # Check thin skew decapole expressions
+        mad.globals['kctx3.l1'] = 1e-5  # Check thin dodecapole expressions
+        mad.globals['kctsx3.r1'] = 1e-5  # Check thin skew dodecapole expressions
 
-    line2=xt.Line.from_madx_sequence(mad1.sequence.lhcb2,
-                                    allow_thick=True,
-                                    deferred_expressions=True,
-                                    replace_in_expr={'bv_aux':'bvaux_b2'})
+    line2 = xt.Line.from_madx_sequence(mad1.sequence.lhcb2,
+                                       allow_thick=True,
+                                       deferred_expressions=True,
+                                       replace_in_expr={'bv_aux': 'bvaux_b2'})
     line2.particle_ref = xp.Particles(mass0=xp.PROTON_MASS_EV, p0c=7000e9)
 
-    line4=xt.Line.from_madx_sequence(mad4.sequence.lhcb2,
-                                    allow_thick=True,
-                                    deferred_expressions=True,
-                                    replace_in_expr={'bv_aux':'bvaux_b2'})
+    line4 = xt.Line.from_madx_sequence(mad4.sequence.lhcb2,
+                                       allow_thick=True,
+                                       deferred_expressions=True,
+                                       replace_in_expr={'bv_aux': 'bvaux_b2'})
     line4.particle_ref = xp.Particles(mass0=xp.PROTON_MASS_EV, p0c=7000e9)
 
     # Bend done
 
     # Quadrupole
-    assert np.isclose(line2['mq.27l2.b2'].k1, line4['mq.27l2.b2'].k1, rtol=0, atol=1e-12)
-    assert np.isclose(line2['mqs.27l3.b2'].k1s, line4['mqs.27l3.b2'].k1s, rtol=0, atol=1e-12)
+    xo.assert_allclose(line2['mq.27l2.b2'].k1, line4['mq.27l2.b2'].k1, rtol=0, atol=1e-12)
+    xo.assert_allclose(line2['mqs.27l3.b2'].k1s, line4['mqs.27l3.b2'].k1s, rtol=0, atol=1e-12)
 
     tt2 = line2.get_table()
     tt4 = line4.get_table()
@@ -710,11 +709,11 @@ def test_load_b2_with_bv_minus_one():
 
     assert set(l2names) == set(l4names)
 
-    assert np.allclose(
+    xo.assert_allclose(
         tt2nodr.rows[l2names].s, tt4nodr.rows[l2names].s, rtol=0, atol=1e-8)
 
     for nn in l2names:
-        print(nn+'              ', end='\r', flush=True)
+        print(nn + '              ', end='\r', flush=True)
         if nn == '_end_point':
             continue
         e2 = line2[nn]
@@ -725,4 +724,4 @@ def test_load_b2_with_bv_minus_one():
             if kk in ('__class__', 'model', 'side'):
                 assert d2[kk] == d4[kk]
                 continue
-            assert np.allclose(d2[kk], d4[kk], rtol=1e-10, atol=1e-16)
+            xo.assert_allclose(d2[kk], d4[kk], rtol=1e-10, atol=1e-16)

--- a/tests/test_match_and_track_from_element.py
+++ b/tests/test_match_and_track_from_element.py
@@ -3,13 +3,14 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
-import pathlib
 import json
+import pathlib
+
 import numpy as np
 
+import xobjects as xo
 import xpart as xp
 import xtrack as xt
-import xobjects as xo
 from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
@@ -42,7 +43,7 @@ def test_match_and_track_from_element(test_context):
     tw = line.twiss(at_elements=[at_element])
 
     particles.move(_context=xo.context_default) # To easily do the checks with numpy
-    assert np.isclose(
+    xo.assert_allclose(
         np.sqrt(tw['betx'][0]*2.5e-6/particles.beta0[0]/particles.gamma0[0]),
         np.max(np.abs(particles.x - np.mean(particles.x))), rtol=1e-3, atol=0)
     particles.move(_context=test_context)
@@ -58,7 +59,7 @@ def test_match_and_track_from_element(test_context):
     # Check that distribution is matched at the end of the turn
     tw0 = line.twiss(at_elements=[0])
     particles.move(_context=xo.context_default)
-    assert np.isclose(
+    xo.assert_allclose(
         np.sqrt(tw0['betx'][0]*2.5e-6/particles.beta0[0]/particles.gamma0[0]),
         np.max(np.abs(particles.x - np.mean(particles.x))), rtol=2e-3, atol=0)
 
@@ -72,7 +73,7 @@ def test_match_and_track_from_element(test_context):
     tw = line.twiss(at_elements=[at_element])
 
     particles.move(_context=xo.context_default)
-    assert np.isclose(
+    xo.assert_allclose(
         np.sqrt(tw['betx'][0]*2.5e-6/particles.beta0[0]/particles.gamma0[0]),
         np.max(np.abs(particles.x - np.mean(particles.x))), rtol=1e-3, atol=0)
     particles.move(_context=test_context)
@@ -81,11 +82,11 @@ def test_match_and_track_from_element(test_context):
 
     tw0 = line.twiss(at_elements=[0])
     particles.move(_context=xo.context_default)
-    assert np.isclose(
+    xo.assert_allclose(
         np.sqrt(tw0['betx'][0]*2.5e-6/particles.beta0[0]/particles.gamma0[0]),
         np.max(np.abs(particles.x - np.mean(particles.x))), rtol=2e-3, atol=0)
     assert np.all(particles.at_turn==3)
-    assert np.allclose(particles.s, 3*line.get_length(), rtol=0, atol=1e-7)
+    xo.assert_allclose(particles.s, 3*line.get_length(), rtol=0, atol=1e-7)
 
     # Check collective case
     line_w_collective = xt.Line.from_dict(input_data['line'])
@@ -108,7 +109,7 @@ def test_match_and_track_from_element(test_context):
     tw = line_w_collective.twiss(at_elements=[at_element])
 
     particles.move(_context=xo.context_default)
-    assert np.isclose(
+    xo.assert_allclose(
         np.sqrt(tw['betx'][0]*2.5e-6/particles.beta0[0]/particles.gamma0[0]),
         np.max(np.abs(particles.x - np.mean(particles.x))), rtol=1e-3, atol=0)
     particles.move(_context=test_context)
@@ -117,11 +118,11 @@ def test_match_and_track_from_element(test_context):
 
     tw0 = line_w_collective.twiss(at_elements=[0])
     particles.move(_context=xo.context_default)
-    assert np.isclose(
+    xo.assert_allclose(
         np.sqrt(tw0['betx'][0]*2.5e-6/particles.beta0[0]/particles.gamma0[0]),
         np.max(np.abs(particles.x - np.mean(particles.x))), rtol=3e-3, atol=0)
     assert np.all(particles.at_turn==3)
-    assert np.allclose(particles.s, 3*line_w_collective.get_length(), rtol=0, atol=1e-7)
+    xo.assert_allclose(particles.s, 3*line_w_collective.get_length(), rtol=0, atol=1e-7)
 
     # Check match_at_s
     at_element = 'ip6'
@@ -135,10 +136,10 @@ def test_match_and_track_from_element(test_context):
     tw = line_w_collective.twiss(at_elements=[at_element])
 
     particles.move(_context=xo.context_default)
-    assert np.isclose(
+    xo.assert_allclose(
         np.sqrt(tw['betx'][0]*2.5e-6/particles.beta0[0]/particles.gamma0[0]),
         np.max(np.abs(particles.x - np.mean(particles.x))), rtol=1e-3, atol=0)
-    assert np.allclose(particles.s, tw['s'][0], atol=1e-8, rtol=0)
+    xo.assert_allclose(particles.s, tw['s'][0], atol=1e-8, rtol=0)
 
     phasex_first_part = np.angle(particles.x[0] / np.sqrt(tw['betx'][0]) -
                 1j*(particles.x[0]  * tw['alfx'][0] / np.sqrt(tw['betx'][0]) +
@@ -148,7 +149,7 @@ def test_match_and_track_from_element(test_context):
         at_s=line_w_collective.get_s_position('ip6') + 100)['mux'][0]
     mu_at_element = line_w_collective.twiss(at_elements=[at_element])['mux'][0]
 
-    assert np.isclose(phasex_first_part, (mu_at_element - mu_at_s)*2*np.pi,
+    xo.assert_allclose(phasex_first_part, (mu_at_element - mu_at_s)*2*np.pi,
                     atol=0, rtol=0.02)
     particles.move(_context=test_context)
 
@@ -156,8 +157,8 @@ def test_match_and_track_from_element(test_context):
 
     tw0 = line_w_collective.twiss(at_elements=[0])
     particles.move(_context=xo.context_default)
-    assert np.isclose(
+    xo.assert_allclose(
         np.sqrt(tw0['betx'][0]*2.5e-6/particles.beta0[0]/particles.gamma0[0]),
         np.max(np.abs(particles.x - np.mean(particles.x))), rtol=2e-3, atol=0)
     assert np.all(particles.at_turn==3)
-    assert np.allclose(particles.s, 3*line_w_collective.get_length(), rtol=0, atol=1e-7)
+    xo.assert_allclose(particles.s, 3*line_w_collective.get_length(), rtol=0, atol=1e-7)

--- a/tests/test_match_coupling_knob.py
+++ b/tests/test_match_coupling_knob.py
@@ -1,7 +1,9 @@
-import numpy as np
-import xtrack as xt
 import pathlib
 
+import numpy as np
+
+import xobjects as xo
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
@@ -79,7 +81,7 @@ def test_match_coupling_knob(test_context):
     # Check orthogonality
     line.vars['c_minus_re.b1'] = 1e-3
     line.vars['c_minus_im.b1'] = 1e-3
-    assert np.isclose(line.twiss().c_minus/np.sqrt(2), 1e-3, rtol=0, atol=1.5e-5)
+    xo.assert_allclose(line.twiss().c_minus/np.sqrt(2), 1e-3, rtol=0, atol=1.5e-5)
 
     # Compare against "legacy" knobs
     line_legacy = xt.Line.from_json(test_data_folder /
@@ -101,8 +103,8 @@ def test_match_coupling_knob(test_context):
     tt_im_leg = line_legacy.get_table(attr=True)
 
     # Withing 12% of the maximum value
-    assert np.allclose(tt_re.k1sl, tt_re_leg.k1sl, rtol=0,
+    xo.assert_allclose(tt_re.k1sl, tt_re_leg.k1sl, rtol=0,
                     atol=0.12 * np.max(tt_re_leg.k1sl))
-    assert np.allclose(tt_im.k1sl, tt_im_leg.k1sl, rtol=0,
+    xo.assert_allclose(tt_im.k1sl, tt_im_leg.k1sl, rtol=0,
                     atol=0.12 * np.max(tt_im_leg.k1sl))
 

--- a/tests/test_match_nested.py
+++ b/tests/test_match_nested.py
@@ -2,9 +2,9 @@ import pathlib
 
 import numpy as np
 
-import xtrack
 import xdeps as xd
-
+import xobjects as xo
+import xtrack
 from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
@@ -116,15 +116,15 @@ def test_match_nested(test_context):
     twb1 = collider.lhcb1.twiss()
     mux_arc_target_b1 = twb1['mux', 's.ds.l7.b1'] - twb1['mux', 'e.ds.r6.b1']
     muy_arc_target_b1 = twb1['muy', 's.ds.l7.b1'] - twb1['muy', 'e.ds.r6.b1']
-    assert np.isclose(resb1['mux_arc_from_cell'] , mux_arc_target_b1, rtol=1e-6)
-    assert np.isclose(resb1['muy_arc_from_cell'] , muy_arc_target_b1, rtol=1e-6)
+    xo.assert_allclose(resb1['mux_arc_from_cell'] , mux_arc_target_b1, rtol=1e-6)
+    xo.assert_allclose(resb1['muy_arc_from_cell'] , muy_arc_target_b1, rtol=1e-6)
 
     # Check for b2
     twb2 = collider.lhcb2.twiss()
     mux_arc_target_b2 = twb2['mux', 's.ds.l7.b2'] - twb2['mux', 'e.ds.r6.b2']
     muy_arc_target_b2 = twb2['muy', 's.ds.l7.b2'] - twb2['muy', 'e.ds.r6.b2']
-    assert np.isclose(resb2['mux_arc_from_cell'] , mux_arc_target_b2, rtol=1e-6)
-    assert np.isclose(resb2['muy_arc_from_cell'] , muy_arc_target_b2, rtol=1e-6)
+    xo.assert_allclose(resb2['mux_arc_from_cell'] , mux_arc_target_b2, rtol=1e-6)
+    xo.assert_allclose(resb2['muy_arc_from_cell'] , muy_arc_target_b2, rtol=1e-6)
 
     starting_values = {
         'kqtf.a67b1': collider.vars['kqtf.a67b1']._value,
@@ -174,13 +174,13 @@ def test_match_nested(test_context):
     twb1_after = collider.lhcb1.twiss(start='e.ds.r6.b1',
                                     end='s.ds.l7.b1',
                                     init=tw_init_arcb1)
-    assert np.isclose(twb1_after['mux', 's.ds.l7.b1'] - twb1_after['mux', 'e.ds.r6.b1'],
+    xo.assert_allclose(twb1_after['mux', 's.ds.l7.b1'] - twb1_after['mux', 'e.ds.r6.b1'],
                         mux_arc_target_b1, rtol=0, atol=1e-8)
-    assert np.isclose(twb1_after['muy', 's.ds.l7.b1'] - twb1_after['muy', 'e.ds.r6.b1'],
+    xo.assert_allclose(twb1_after['muy', 's.ds.l7.b1'] - twb1_after['muy', 'e.ds.r6.b1'],
                         muy_arc_target_b1, rtol=0, atol=1e-8)
-    assert np.isclose(twb1_after['betx', 's.cell.67.b1'], twb1_after['betx', 'e.cell.67.b1'],
+    xo.assert_allclose(twb1_after['betx', 's.cell.67.b1'], twb1_after['betx', 'e.cell.67.b1'],
                         rtol=0, atol=1e-7)
-    assert np.isclose(twb1_after['bety', 's.cell.67.b1'], twb1_after['bety', 'e.cell.67.b1'],
+    xo.assert_allclose(twb1_after['bety', 's.cell.67.b1'], twb1_after['bety', 'e.cell.67.b1'],
                         rtol=0, atol=1e-7)
 
     resb2_after = action_arc_phase_s67_b2.run()
@@ -188,11 +188,11 @@ def test_match_nested(test_context):
     twb2_after = collider.lhcb2.twiss(start='e.ds.r6.b2',
                                     end='s.ds.l7.b2',
                                     init=tw_init_arcb2)
-    assert np.isclose(twb2_after['mux', 's.ds.l7.b2'] - twb2_after['mux', 'e.ds.r6.b2'],
+    xo.assert_allclose(twb2_after['mux', 's.ds.l7.b2'] - twb2_after['mux', 'e.ds.r6.b2'],
                         mux_arc_target_b2, rtol=0, atol=1e-8)
-    assert np.isclose(twb2_after['muy', 's.ds.l7.b2'] - twb2_after['muy', 'e.ds.r6.b2'],
+    xo.assert_allclose(twb2_after['muy', 's.ds.l7.b2'] - twb2_after['muy', 'e.ds.r6.b2'],
                         muy_arc_target_b2, rtol=0, atol=1e-8)
-    assert np.isclose(twb2_after['betx', 's.cell.67.b2'], twb2_after['betx', 'e.cell.67.b2'],
+    xo.assert_allclose(twb2_after['betx', 's.cell.67.b2'], twb2_after['betx', 'e.cell.67.b2'],
                         rtol=0, atol=1e-8)
-    assert np.isclose(twb2_after['bety', 's.cell.67.b2'], twb2_after['bety', 'e.cell.67.b2'],
+    xo.assert_allclose(twb2_after['bety', 's.cell.67.b2'], twb2_after['bety', 'e.cell.67.b2'],
                         rtol=0, atol=1e-8)

--- a/tests/test_match_optics_and_ip_knob.py
+++ b/tests/test_match_optics_and_ip_knob.py
@@ -1,6 +1,8 @@
 import pathlib
 
 import numpy as np
+
+import xobjects as xo
 import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
@@ -47,23 +49,23 @@ def test_ip_knob_matching(test_context):
 
     # Check a few steps and limits
 
-    assert np.isclose(collider.vars.vary_default['acbxh1.l8']['step'], 1.0e-15, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbxh1.l8']['limits'][0], -limitmcbx, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbxh1.l8']['limits'][1], limitmcbx, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbyhs5.r8b2']['step'], 1.0e-15, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][0], -limitmcbc, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][1], limitmcbc, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbxh1.l8']['step'], 1.0e-15, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbxh1.l8']['limits'][0], -limitmcbx, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbxh1.l8']['limits'][1], limitmcbx, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbyhs5.r8b2']['step'], 1.0e-15, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][0], -limitmcbc, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][1], limitmcbc, atol=1e-17, rtol=0)
 
     # Check that they are preserved by to_dict/from_dict
     collider = xt.Multiline.from_dict(collider.to_dict())
     collider.build_trackers()
 
-    assert np.isclose(collider.vars.vary_default['acbxh1.l8']['step'], 1.0e-15, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbxh1.l8']['limits'][0], -limitmcbx, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbxh1.l8']['limits'][1], limitmcbx, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbyhs5.r8b2']['step'], 1.0e-15, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][0], -limitmcbc, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][1], limitmcbc, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbxh1.l8']['step'], 1.0e-15, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbxh1.l8']['limits'][0], -limitmcbx, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbxh1.l8']['limits'][1], limitmcbx, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbyhs5.r8b2']['step'], 1.0e-15, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][0], -limitmcbc, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][1], limitmcbc, atol=1e-17, rtol=0)
 
     # kill all existing knobs orbit knobs in ip2 and ip8
     all_knobs_ip2ip8 = [
@@ -118,7 +120,7 @@ def test_ip_knob_matching(test_context):
     ll = opt.log()
     assert len(ll) == 1
     assert ll.iteration[0] == 0
-    assert np.isclose(ll['penalty', 0], 0.0424264, atol=1e-6, rtol=0)
+    xo.assert_allclose(ll['penalty', 0], 0.0424264, atol=1e-6, rtol=0)
     assert ll['tol_met', 0] == 'yyyyynyn'
     assert ll['target_active', 0] == 'yyyyyyyy'
     assert ll['vary_active', 0] == 'yyyyyyyyyyyyyy'
@@ -136,17 +138,17 @@ def test_ip_knob_matching(test_context):
     assert np.all(np.array(vtags) == np.array(
         ['', '', '', '', '', '', '', '', 'mcbx', 'mcbx', 'mcbx', 'mcbx', 'mcbx', 'mcbx']))
 
-    assert np.isclose(opt.vary[0].step, 2e-15, atol=1e-17, rtol=0)
-    assert np.isclose(opt.vary[0].limits[0], -9e-5, atol=1e-10, rtol=0)
-    assert np.isclose(opt.vary[0].limits[1], 9e-5, atol=1e-10, rtol=0)
-    assert np.isclose(opt.vary[2].step, 1e-15, atol=1e-17, rtol=0)
-    assert np.isclose(opt.vary[2].limits[0], -limitmcby, atol=1e-10, rtol=0)
-    assert np.isclose(opt.vary[2].limits[1], limitmcby, atol=1e-10, rtol=0)
+    xo.assert_allclose(opt.vary[0].step, 2e-15, atol=1e-17, rtol=0)
+    xo.assert_allclose(opt.vary[0].limits[0], -9e-5, atol=1e-10, rtol=0)
+    xo.assert_allclose(opt.vary[0].limits[1], 9e-5, atol=1e-10, rtol=0)
+    xo.assert_allclose(opt.vary[2].step, 1e-15, atol=1e-17, rtol=0)
+    xo.assert_allclose(opt.vary[2].limits[0], -limitmcby, atol=1e-10, rtol=0)
+    xo.assert_allclose(opt.vary[2].limits[1], limitmcby, atol=1e-10, rtol=0)
 
-    assert np.isclose(opt.targets[4].tol, 1.1e-10, atol=1e-14, rtol=0)
-    assert np.isclose(opt.targets[5].tol, 0.8e-10, atol=1e-14, rtol=0)
-    assert np.isclose(opt.targets[6].tol, 1.1e-10, atol=1e-14, rtol=0)
-    assert np.isclose(opt.targets[7].tol, 0.9e-10, atol=1e-14, rtol=0)
+    xo.assert_allclose(opt.targets[4].tol, 1.1e-10, atol=1e-14, rtol=0)
+    xo.assert_allclose(opt.targets[5].tol, 0.8e-10, atol=1e-14, rtol=0)
+    xo.assert_allclose(opt.targets[6].tol, 1.1e-10, atol=1e-14, rtol=0)
+    xo.assert_allclose(opt.targets[7].tol, 0.9e-10, atol=1e-14, rtol=0)
 
     # Set mcmbx by hand (as in mad-x script)
     testkqx8=abs(collider.varval['kqx.l8'])*7000./0.3
@@ -194,12 +196,12 @@ def test_ip_knob_matching(test_context):
     assert ll['tol_met', 10] != 'yyyyyyyy'
 
     # Check that mcbxs did not move
-    assert np.allclose(ll['vary_8', 1:], init_mcbx_plus, atol=1e-12, rtol=0)
-    assert np.allclose(ll['vary_9', 1:], init_mcbx_plus, atol=1e-12, rtol=0)
-    assert np.allclose(ll['vary_10', 1:], init_mcbx_plus, atol=1e-12, rtol=0)
-    assert np.allclose(ll['vary_11', 1:], -init_mcbx_plus, atol=1e-12, rtol=0)
-    assert np.allclose(ll['vary_12', 1:], -init_mcbx_plus, atol=1e-12, rtol=0)
-    assert np.allclose(ll['vary_13', 1:], -init_mcbx_plus, atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_8', 1:], init_mcbx_plus, atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_9', 1:], init_mcbx_plus, atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_10', 1:], init_mcbx_plus, atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_11', 1:], -init_mcbx_plus, atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_12', 1:], -init_mcbx_plus, atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_13', 1:], -init_mcbx_plus, atol=1e-12, rtol=0)
 
 
     # Link all mcbx stengths to the first one
@@ -223,11 +225,11 @@ def test_ip_knob_matching(test_context):
     assert np.all(ll['tol_met', -1] == 'yyyyyyyy')
 
     # Check imposed relationship among varys
-    assert np.isclose(ll['vary_8', 11], ll['vary_9', 11], atol=1e-12, rtol=0)
-    assert np.isclose(ll['vary_8', 11], ll['vary_10', 11], atol=1e-12, rtol=0)
-    assert np.isclose(ll['vary_8', 11], -ll['vary_11', 11], atol=1e-12, rtol=0)
-    assert np.isclose(ll['vary_8', 11], -ll['vary_12', 11], atol=1e-12, rtol=0)
-    assert np.isclose(ll['vary_8', 11], -ll['vary_13', 11], atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_8', 11], ll['vary_9', 11], atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_8', 11], ll['vary_10', 11], atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_8', 11], -ll['vary_11', 11], atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_8', 11], -ll['vary_12', 11], atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_8', 11], -ll['vary_13', 11], atol=1e-12, rtol=0)
 
     opt.generate_knob()
 
@@ -235,10 +237,10 @@ def test_ip_knob_matching(test_context):
     tw = collider.twiss()
     collider.vars['on_x8h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-10, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-10, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 100e-6, atol=1e-10, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], -100e-6, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 100e-6, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], -100e-6, atol=1e-10, rtol=0)
 
     # Match horizontal separation in ip8
     sep_match = 2e-3
@@ -297,20 +299,20 @@ def test_ip_knob_matching(test_context):
     tw = collider.twiss()
     collider.vars['on_sep8h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 1.5e-3, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], -1.5e-3, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 0, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], 0, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 1.5e-3, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], -1.5e-3, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 0, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], 0, atol=1e-9, rtol=0)
 
     # Check that on_x8h still works
     collider.vars['on_x8h'] = 100
     tw = collider.twiss()
     collider.vars['on_x8h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 100e-6, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], -100e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 100e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], -100e-6, atol=1e-9, rtol=0)
 
     # Both knobs together
     collider.vars['on_x8h'] = 120
@@ -319,10 +321,10 @@ def test_ip_knob_matching(test_context):
     collider.vars['on_x8h'] = 0
     collider.vars['on_sep8h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 1.7e-3, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], -1.7e-3, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 120e-6, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], -120e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 1.7e-3, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], -1.7e-3, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 120e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], -120e-6, atol=1e-9, rtol=0)
 
 @for_all_test_contexts
 def test_match_ir8_optics(test_context):
@@ -332,25 +334,25 @@ def test_match_ir8_optics(test_context):
     collider.build_trackers(test_context)
 
     tw = collider.twiss()
-    assert np.isclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip2'], 10., atol=1e-5, rtol=0)
 
 
     nrj = 7000.
@@ -535,25 +537,25 @@ def test_match_ir8_optics(test_context):
     assert opt.log()['tol_met', -1] == 'yyyyyyyyyyyyyy'
 
 
-    assert np.isclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip2'], 10., atol=1e-5, rtol=0)
 
     # Beam 2
 
@@ -702,23 +704,23 @@ def test_match_ir8_optics(test_context):
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyyyyyyyyyyyy'
     assert opt.log()['tol_met', -1] == 'yyyyyyyyyyyyyy'
 
-    assert np.isclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip2'], 10., atol=1e-5, rtol=0)
 

--- a/tests/test_match_optics_and_ip_knob_new_optimize_api.py
+++ b/tests/test_match_optics_and_ip_knob_new_optimize_api.py
@@ -1,6 +1,8 @@
 import pathlib
 
 import numpy as np
+
+import xobjects as xo
 import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
@@ -47,23 +49,23 @@ def test_ip_knob_matching_new_optimize_api(test_context):
 
     # Check a few steps and limits
 
-    assert np.isclose(collider.vars.vary_default['acbxh1.l8']['step'], 1.0e-15, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbxh1.l8']['limits'][0], -limitmcbx, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbxh1.l8']['limits'][1], limitmcbx, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbyhs5.r8b2']['step'], 1.0e-15, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][0], -limitmcbc, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][1], limitmcbc, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbxh1.l8']['step'], 1.0e-15, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbxh1.l8']['limits'][0], -limitmcbx, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbxh1.l8']['limits'][1], limitmcbx, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbyhs5.r8b2']['step'], 1.0e-15, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][0], -limitmcbc, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][1], limitmcbc, atol=1e-17, rtol=0)
 
     # Check that they are preserved by to_dict/from_dict
     collider = xt.Multiline.from_dict(collider.to_dict())
     collider.build_trackers()
 
-    assert np.isclose(collider.vars.vary_default['acbxh1.l8']['step'], 1.0e-15, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbxh1.l8']['limits'][0], -limitmcbx, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbxh1.l8']['limits'][1], limitmcbx, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbyhs5.r8b2']['step'], 1.0e-15, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][0], -limitmcbc, atol=1e-17, rtol=0)
-    assert np.isclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][1], limitmcbc, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbxh1.l8']['step'], 1.0e-15, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbxh1.l8']['limits'][0], -limitmcbx, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbxh1.l8']['limits'][1], limitmcbx, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbyhs5.r8b2']['step'], 1.0e-15, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][0], -limitmcbc, atol=1e-17, rtol=0)
+    xo.assert_allclose(collider.vars.vary_default['acbyhs5.r8b2']['limits'][1], limitmcbc, atol=1e-17, rtol=0)
 
     # kill all existing knobs orbit knobs in ip2 and ip8
     all_knobs_ip2ip8 = [
@@ -118,7 +120,7 @@ def test_ip_knob_matching_new_optimize_api(test_context):
     ll = opt.log()
     assert len(ll) == 1
     assert ll.iteration[0] == 0
-    assert np.isclose(ll['penalty', 0], 0.0424264, atol=1e-6, rtol=0)
+    xo.assert_allclose(ll['penalty', 0], 0.0424264, atol=1e-6, rtol=0)
     assert ll['tol_met', 0] == 'yyyyynyn'
     assert ll['target_active', 0] == 'yyyyyyyy'
     assert ll['vary_active', 0] == 'yyyyyyyyyyyyyy'
@@ -136,17 +138,17 @@ def test_ip_knob_matching_new_optimize_api(test_context):
     assert np.all(np.array(vtags) == np.array(
         ['', '', '', '', '', '', '', '', 'mcbx', 'mcbx', 'mcbx', 'mcbx', 'mcbx', 'mcbx']))
 
-    assert np.isclose(opt.vary[0].step, 2e-15, atol=1e-17, rtol=0)
-    assert np.isclose(opt.vary[0].limits[0], -9e-5, atol=1e-10, rtol=0)
-    assert np.isclose(opt.vary[0].limits[1], 9e-5, atol=1e-10, rtol=0)
-    assert np.isclose(opt.vary[2].step, 1e-15, atol=1e-17, rtol=0)
-    assert np.isclose(opt.vary[2].limits[0], -limitmcby, atol=1e-10, rtol=0)
-    assert np.isclose(opt.vary[2].limits[1], limitmcby, atol=1e-10, rtol=0)
+    xo.assert_allclose(opt.vary[0].step, 2e-15, atol=1e-17, rtol=0)
+    xo.assert_allclose(opt.vary[0].limits[0], -9e-5, atol=1e-10, rtol=0)
+    xo.assert_allclose(opt.vary[0].limits[1], 9e-5, atol=1e-10, rtol=0)
+    xo.assert_allclose(opt.vary[2].step, 1e-15, atol=1e-17, rtol=0)
+    xo.assert_allclose(opt.vary[2].limits[0], -limitmcby, atol=1e-10, rtol=0)
+    xo.assert_allclose(opt.vary[2].limits[1], limitmcby, atol=1e-10, rtol=0)
 
-    assert np.isclose(opt.targets[4].tol, 1.1e-10, atol=1e-14, rtol=0)
-    assert np.isclose(opt.targets[5].tol, 0.8e-10, atol=1e-14, rtol=0)
-    assert np.isclose(opt.targets[6].tol, 1.1e-10, atol=1e-14, rtol=0)
-    assert np.isclose(opt.targets[7].tol, 0.9e-10, atol=1e-14, rtol=0)
+    xo.assert_allclose(opt.targets[4].tol, 1.1e-10, atol=1e-14, rtol=0)
+    xo.assert_allclose(opt.targets[5].tol, 0.8e-10, atol=1e-14, rtol=0)
+    xo.assert_allclose(opt.targets[6].tol, 1.1e-10, atol=1e-14, rtol=0)
+    xo.assert_allclose(opt.targets[7].tol, 0.9e-10, atol=1e-14, rtol=0)
 
     # Set mcmbx by hand (as in mad-x script)
     testkqx8=abs(collider.varval['kqx.l8'])*7000./0.3
@@ -194,12 +196,12 @@ def test_ip_knob_matching_new_optimize_api(test_context):
     assert ll['tol_met', 10] != 'yyyyyyyy'
 
     # Check that mcbxs did not move
-    assert np.allclose(ll['vary_8', 1:], init_mcbx_plus, atol=1e-12, rtol=0)
-    assert np.allclose(ll['vary_9', 1:], init_mcbx_plus, atol=1e-12, rtol=0)
-    assert np.allclose(ll['vary_10', 1:], init_mcbx_plus, atol=1e-12, rtol=0)
-    assert np.allclose(ll['vary_11', 1:], -init_mcbx_plus, atol=1e-12, rtol=0)
-    assert np.allclose(ll['vary_12', 1:], -init_mcbx_plus, atol=1e-12, rtol=0)
-    assert np.allclose(ll['vary_13', 1:], -init_mcbx_plus, atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_8', 1:], init_mcbx_plus, atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_9', 1:], init_mcbx_plus, atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_10', 1:], init_mcbx_plus, atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_11', 1:], -init_mcbx_plus, atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_12', 1:], -init_mcbx_plus, atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_13', 1:], -init_mcbx_plus, atol=1e-12, rtol=0)
 
 
     # Link all mcbx stengths to the first one
@@ -223,11 +225,11 @@ def test_ip_knob_matching_new_optimize_api(test_context):
     assert np.all(ll['tol_met', -1] == 'yyyyyyyy')
 
     # Check imposed relationship among varys
-    assert np.isclose(ll['vary_8', 11], ll['vary_9', 11], atol=1e-12, rtol=0)
-    assert np.isclose(ll['vary_8', 11], ll['vary_10', 11], atol=1e-12, rtol=0)
-    assert np.isclose(ll['vary_8', 11], -ll['vary_11', 11], atol=1e-12, rtol=0)
-    assert np.isclose(ll['vary_8', 11], -ll['vary_12', 11], atol=1e-12, rtol=0)
-    assert np.isclose(ll['vary_8', 11], -ll['vary_13', 11], atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_8', 11], ll['vary_9', 11], atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_8', 11], ll['vary_10', 11], atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_8', 11], -ll['vary_11', 11], atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_8', 11], -ll['vary_12', 11], atol=1e-12, rtol=0)
+    xo.assert_allclose(ll['vary_8', 11], -ll['vary_13', 11], atol=1e-12, rtol=0)
 
     opt.generate_knob()
 
@@ -235,10 +237,10 @@ def test_ip_knob_matching_new_optimize_api(test_context):
     tw = collider.twiss()
     collider.vars['on_x8h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-10, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-10, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 100e-6, atol=1e-10, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], -100e-6, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 100e-6, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], -100e-6, atol=1e-10, rtol=0)
 
     # Match horizontal separation in ip8
     sep_match = 2e-3
@@ -297,20 +299,20 @@ def test_ip_knob_matching_new_optimize_api(test_context):
     tw = collider.twiss()
     collider.vars['on_sep8h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 1.5e-3, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], -1.5e-3, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 0, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], 0, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 1.5e-3, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], -1.5e-3, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 0, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], 0, atol=1e-9, rtol=0)
 
     # Check that on_x8h still works
     collider.vars['on_x8h'] = 100
     tw = collider.twiss()
     collider.vars['on_x8h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 100e-6, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], -100e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 0, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], 0, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 100e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], -100e-6, atol=1e-9, rtol=0)
 
     # Both knobs together
     collider.vars['on_x8h'] = 120
@@ -319,10 +321,10 @@ def test_ip_knob_matching_new_optimize_api(test_context):
     collider.vars['on_x8h'] = 0
     collider.vars['on_sep8h'] = 0
 
-    assert np.isclose(tw.lhcb1['x', 'ip8'], 1.7e-3, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['x', 'ip8'], -1.7e-3, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb1['px', 'ip8'], 120e-6, atol=1e-9, rtol=0)
-    assert np.isclose(tw.lhcb2['px', 'ip8'], -120e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['x', 'ip8'], 1.7e-3, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['x', 'ip8'], -1.7e-3, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb1['px', 'ip8'], 120e-6, atol=1e-9, rtol=0)
+    xo.assert_allclose(tw.lhcb2['px', 'ip8'], -120e-6, atol=1e-9, rtol=0)
 
 @for_all_test_contexts
 def test_match_ir8_optics_new_optimize_api(test_context):
@@ -332,25 +334,25 @@ def test_match_ir8_optics_new_optimize_api(test_context):
     collider.build_trackers(test_context)
 
     tw = collider.twiss()
-    assert np.isclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip2'], 10., atol=1e-5, rtol=0)
 
 
     nrj = 7000.
@@ -535,25 +537,25 @@ def test_match_ir8_optics_new_optimize_api(test_context):
     assert opt.log()['tol_met', -1] == 'yyyyyyyyyyyyyy'
 
 
-    assert np.isclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip2'], 10., atol=1e-5, rtol=0)
 
     # Beam 2
 
@@ -702,23 +704,23 @@ def test_match_ir8_optics_new_optimize_api(test_context):
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyyyyyyyyyyyy'
     assert opt.log()['tol_met', -1] == 'yyyyyyyyyyyyyy'
 
-    assert np.isclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip1'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip1'], 0.15, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip5'], 0.15, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip5'], 0.15, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip8'], 1.5, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip8'], 1.5, atol=1e-6, rtol=0)
 
-    assert np.isclose(tw.lhcb1['betx', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb1['bety', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb2['betx', 'ip2'], 10., atol=1e-5, rtol=0)
-    assert np.isclose(tw.lhcb2['bety', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb1['betx', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb1['bety', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb2['betx', 'ip2'], 10., atol=1e-5, rtol=0)
+    xo.assert_allclose(tw.lhcb2['bety', 'ip2'], 10., atol=1e-5, rtol=0)
 

--- a/tests/test_match_orbit_bump.py
+++ b/tests/test_match_orbit_bump.py
@@ -1,7 +1,9 @@
-import pathlib
 import json
+import pathlib
+
 import numpy as np
 
+import xobjects as xo
 import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
@@ -49,20 +51,20 @@ def test_match_orbit_bump(test_context):
 
     tw = line.twiss()
 
-    assert np.isclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
-    assert np.isclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
-    assert np.isclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
-    assert np.isclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
+    xo.assert_allclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
+    xo.assert_allclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
 
     # There is a bit of leakage in the horizontal plane (due to feed-down from sextupoles)
-    assert np.isclose(tw['x', 'mb.b28l8.b1'], tw_before['x', 'mb.b28l8.b1'], atol=100e-6)
-    assert np.isclose(tw['px', 'mb.b28l8.b1'], tw_before['px', 'mb.b28l8.b1'], atol=100e-7)
-    assert np.isclose(tw['x', 'mq.23l8.b1'], tw_before['x', 'mq.23l8.b1'], atol=100e-6)
-    assert np.isclose(tw['px', 'mq.23l8.b1'], tw_before['px', 'mq.23l8.b1'], atol=100e-7)
-    assert np.isclose(tw['x', 'mq.33l8.b1'], tw_before['x', 'mq.33l8.b1'], atol=100e-6)
-    assert np.isclose(tw['px', 'mq.33l8.b1'], tw_before['px', 'mq.33l8.b1'], atol=100e-7)
+    xo.assert_allclose(tw['x', 'mb.b28l8.b1'], tw_before['x', 'mb.b28l8.b1'], atol=100e-6)
+    xo.assert_allclose(tw['px', 'mb.b28l8.b1'], tw_before['px', 'mb.b28l8.b1'], atol=100e-7)
+    xo.assert_allclose(tw['x', 'mq.23l8.b1'], tw_before['x', 'mq.23l8.b1'], atol=100e-6)
+    xo.assert_allclose(tw['px', 'mq.23l8.b1'], tw_before['px', 'mq.23l8.b1'], atol=100e-7)
+    xo.assert_allclose(tw['x', 'mq.33l8.b1'], tw_before['x', 'mq.33l8.b1'], atol=100e-6)
+    xo.assert_allclose(tw['px', 'mq.33l8.b1'], tw_before['px', 'mq.33l8.b1'], atol=100e-7)
 
     # Now I match the bump including the horizontal plane
     # I start from scratch
@@ -104,20 +106,20 @@ def test_match_orbit_bump(test_context):
     assert isinstance(opt.actions[0].kwargs['_initial_particles'], xt.Particles)
 
     tw = line.twiss()
-    assert np.isclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
-    assert np.isclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
-    assert np.isclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
-    assert np.isclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
+    xo.assert_allclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
+    xo.assert_allclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
 
     # There is a bit of leakage in the horizontal plane (due to feed-down from sextupoles)
-    assert np.isclose(tw['x', 'mb.b28l8.b1'], tw_before['x', 'mb.b28l8.b1'], atol=50e-6)
-    assert np.isclose(tw['px', 'mb.b28l8.b1'], tw_before['px', 'mb.b28l8.b1'], atol=2e-6)
-    assert np.isclose(tw['x', 'mq.23l8.b1'], tw_before['x', 'mq.23l8.b1'], atol=1e-6)
-    assert np.isclose(tw['px', 'mq.23l8.b1'], tw_before['px', 'mq.23l8.b1'], atol=1e-7)
-    assert np.isclose(tw['x', 'mq.33l8.b1'], tw_before['x', 'mq.33l8.b1'], atol=1e-6)
-    assert np.isclose(tw['px', 'mq.33l8.b1'], tw_before['px', 'mq.33l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['x', 'mb.b28l8.b1'], tw_before['x', 'mb.b28l8.b1'], atol=50e-6)
+    xo.assert_allclose(tw['px', 'mb.b28l8.b1'], tw_before['px', 'mb.b28l8.b1'], atol=2e-6)
+    xo.assert_allclose(tw['x', 'mq.23l8.b1'], tw_before['x', 'mq.23l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['px', 'mq.23l8.b1'], tw_before['px', 'mq.23l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['x', 'mq.33l8.b1'], tw_before['x', 'mq.33l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['px', 'mq.33l8.b1'], tw_before['px', 'mq.33l8.b1'], atol=1e-7)
 
     # Same match but with init provided through a kwargs
     # I start from scratch
@@ -163,20 +165,20 @@ def test_match_orbit_bump(test_context):
     assert isinstance(opt.actions[0].kwargs['_initial_particles'], xt.Particles)
 
     tw = line.twiss()
-    assert np.isclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
-    assert np.isclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
-    assert np.isclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
-    assert np.isclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
+    xo.assert_allclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
+    xo.assert_allclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
 
     # There is a bit of leakage in the horizontal plane (due to feed-down from sextupoles)
-    assert np.isclose(tw['x', 'mb.b28l8.b1'], tw_before['x', 'mb.b28l8.b1'], atol=50e-6)
-    assert np.isclose(tw['px', 'mb.b28l8.b1'], tw_before['px', 'mb.b28l8.b1'], atol=2e-6)
-    assert np.isclose(tw['x', 'mq.23l8.b1'], tw_before['x', 'mq.23l8.b1'], atol=1e-6)
-    assert np.isclose(tw['px', 'mq.23l8.b1'], tw_before['px', 'mq.23l8.b1'], atol=1e-7)
-    assert np.isclose(tw['x', 'mq.33l8.b1'], tw_before['x', 'mq.33l8.b1'], atol=1e-6)
-    assert np.isclose(tw['px', 'mq.33l8.b1'], tw_before['px', 'mq.33l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['x', 'mb.b28l8.b1'], tw_before['x', 'mb.b28l8.b1'], atol=50e-6)
+    xo.assert_allclose(tw['px', 'mb.b28l8.b1'], tw_before['px', 'mb.b28l8.b1'], atol=2e-6)
+    xo.assert_allclose(tw['x', 'mq.23l8.b1'], tw_before['x', 'mq.23l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['px', 'mq.23l8.b1'], tw_before['px', 'mq.23l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['x', 'mq.33l8.b1'], tw_before['x', 'mq.33l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['px', 'mq.33l8.b1'], tw_before['px', 'mq.33l8.b1'], atol=1e-7)
 
 def test_match_orbit_bump_with_weights():
 
@@ -226,16 +228,16 @@ def test_match_orbit_bump_with_weights():
 
         tw = line.twiss()
 
-        assert np.isclose(tw['y', 'mq.33l8.b1'], 0, atol=1e-6, rtol=0)
-        assert np.isclose(tw['y', 'mq.17l8.b1'], 0, atol=1e-6, rtol=0)
-        assert np.isclose(tw['py', 'mq.17l8.b1'], 0, atol=1e-8, rtol=0)
-        assert np.isclose(tw['py', 'mq.33l8.b1'], 0, atol=1e-6, rtol=0)
+        xo.assert_allclose(tw['y', 'mq.33l8.b1'], 0, atol=1e-6, rtol=0)
+        xo.assert_allclose(tw['y', 'mq.17l8.b1'], 0, atol=1e-6, rtol=0)
+        xo.assert_allclose(tw['py', 'mq.17l8.b1'], 0, atol=1e-8, rtol=0)
+        xo.assert_allclose(tw['py', 'mq.33l8.b1'], 0, atol=1e-6, rtol=0)
 
-        assert np.isclose(tw['y', 'mb.b26l8.b1'], 3e-3, atol=1e-6, rtol=0)
-        assert np.isclose(tw['py', 'mb.b26l8.b1'], 0, atol=1e-8, rtol=0)
+        xo.assert_allclose(tw['y', 'mb.b26l8.b1'], 3e-3, atol=1e-6, rtol=0)
+        xo.assert_allclose(tw['py', 'mb.b26l8.b1'], 0, atol=1e-8, rtol=0)
 
-        assert np.isclose(tw['y', 'mq.30l8.b1'], -1e-3, atol=1e-6, rtol=0)
-        assert np.isclose(line.vars['acbv22.l8b1']._value, 38e-6, atol=0, rtol=0.02)
+        xo.assert_allclose(tw['y', 'mq.30l8.b1'], -1e-3, atol=1e-6, rtol=0)
+        xo.assert_allclose(line.vars['acbv22.l8b1']._value, 38e-6, atol=0, rtol=0.02)
 
         # Extract last twiss done by optimizer
         last_data = opt._err._last_data
@@ -306,12 +308,12 @@ def test_match_orbit_bump_within_multiline(test_context):
     tw_after_collider = collider.twiss()
     tw = tw_after_collider.lhcb1
 
-    assert np.isclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
-    assert np.isclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
-    assert np.isclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
-    assert np.isclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
+    xo.assert_allclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
+    xo.assert_allclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
 
 @for_all_test_contexts
 def test_bump_step_and_smooth_inequalities(test_context):
@@ -389,8 +391,8 @@ def test_bump_step_and_smooth_inequalities(test_context):
     assert tw['y', 'mb.b26l8.b1'] > 2.7e-3
     assert tw['y', 'mb.b25l8.b1'] > 2.7e-3
     assert tw['y', 'mq.24l8.b1'] < 3e-3 + 1e-6
-    assert np.isclose(tw['y', 'mq.17l8.b1'], tw_before['y', 'mq.17l8.b1'], rtol=0, atol=1e-7)
-    assert np.isclose(tw['py', 'mq.17l8.b1'], tw_before['py', 'mq.17l8.b1'], rtol=0, atol=1e-9)
+    xo.assert_allclose(tw['y', 'mq.17l8.b1'], tw_before['y', 'mq.17l8.b1'], rtol=0, atol=1e-7)
+    xo.assert_allclose(tw['py', 'mq.17l8.b1'], tw_before['py', 'mq.17l8.b1'], rtol=0, atol=1e-9)
 
     assert isinstance(opt.targets[0].value, xt.GreaterThan)
     assert isinstance(opt.targets[1].value, xt.GreaterThan)
@@ -479,8 +481,8 @@ def test_bump_step_and_smooth_inequalities(test_context):
     assert tw['y', 'mb.b25l8.b1'] > 2.7e-3 - 3e-6
     assert tw['y', 'mq.24l8.b1'] < 3e-3 + 3e-6
     assert tw['y', 'mq.26l8.b1'] < 6e-3 + 3e-6
-    assert np.isclose(tw['y', 'mq.17l8.b1'], tw_before['y', 'mq.17l8.b1'], rtol=0, atol=1e-7)
-    assert np.isclose(tw['py', 'mq.17l8.b1'], tw_before['py', 'mq.17l8.b1'], rtol=0, atol=1e-9)
+    xo.assert_allclose(tw['y', 'mq.17l8.b1'], tw_before['y', 'mq.17l8.b1'], rtol=0, atol=1e-7)
+    xo.assert_allclose(tw['py', 'mq.17l8.b1'], tw_before['py', 'mq.17l8.b1'], rtol=0, atol=1e-9)
 
     assert isinstance(opt.targets[0].value, xt.GreaterThan)
     assert isinstance(opt.targets[1].value, xt.GreaterThan)
@@ -502,10 +504,10 @@ def test_bump_step_and_smooth_inequalities(test_context):
     assert opt.targets[2].value.upper == 3e-3
     assert opt.targets[3].value.upper == 6e-3
 
-    assert np.isclose(opt.targets[0].value.sigma, 0.05 * 2.7e-3, atol=0, rtol=1e-10)
-    assert np.isclose(opt.targets[1].value.sigma, 0.01 * 2.7e-3, atol=0, rtol=1e-10)
-    assert np.isclose(opt.targets[2].value.sigma, 0.04 * 3e-3, atol=0, rtol=1e-10)
-    assert np.isclose(opt.targets[3].value.sigma, 0.01 * 6e-3, atol=0, rtol=1e-10)
+    xo.assert_allclose(opt.targets[0].value.sigma, 0.05 * 2.7e-3, atol=0, rtol=1e-10)
+    xo.assert_allclose(opt.targets[1].value.sigma, 0.01 * 2.7e-3, atol=0, rtol=1e-10)
+    xo.assert_allclose(opt.targets[2].value.sigma, 0.04 * 3e-3, atol=0, rtol=1e-10)
+    xo.assert_allclose(opt.targets[3].value.sigma, 0.01 * 6e-3, atol=0, rtol=1e-10)
 
     x_cut_norm = 1/16 + np.sqrt(33)/16
     poly = lambda x: 3 * x**3 - 2 * x**4
@@ -529,11 +531,11 @@ def test_bump_step_and_smooth_inequalities(test_context):
     mask_zero_gt = x_minus_edge_gt > 0
     assert np.all(residue_gt[mask_zero_gt] == 0)
     mask_linear_gt = x_minus_edge_gt < x_cut_gt
-    assert np.allclose(residue_gt[mask_linear_gt],
+    xo.assert_allclose(residue_gt[mask_linear_gt],
         -x_minus_edge_gt[mask_linear_gt] - x_cut_norm * sigma_gt + sigma_gt*poly(x_cut_norm),
         atol=0, rtol=1e-10)
     mask_poly_gt = (~mask_zero_gt) & (~mask_linear_gt)
-    assert np.allclose(residue_gt[mask_poly_gt],
+    xo.assert_allclose(residue_gt[mask_poly_gt],
         sigma_gt * poly(-x_minus_edge_gt[mask_poly_gt]/sigma_gt),
         atol=0, rtol=1e-10)
 
@@ -556,11 +558,11 @@ def test_bump_step_and_smooth_inequalities(test_context):
     mask_zero_lt = x_minus_edge_lt < 0
     assert np.all(residue_lt[mask_zero_lt] == 0)
     mask_linear_lt = x_minus_edge_lt > x_cut_lt
-    assert np.allclose(residue_lt[mask_linear_lt],
+    xo.assert_allclose(residue_lt[mask_linear_lt],
         x_minus_edge_lt[mask_linear_lt] - x_cut_norm * sigma_lt + sigma_lt*poly(x_cut_norm),
         atol=0, rtol=1e-10)
     mask_poly_lt = (~mask_zero_lt) & (~mask_linear_lt)
-    assert np.allclose(residue_lt[mask_poly_lt],
+    xo.assert_allclose(residue_lt[mask_poly_lt],
         sigma_lt * poly(x_minus_edge_lt[mask_poly_lt]/sigma_lt),
         atol=0, rtol=1e-10)
 
@@ -588,16 +590,16 @@ def test_match_bump_sets_implicit_end(test_context):
     opt.tag(tag='matched')
     opt.reload(0)
     tw_before = line.twiss(method='4d')
-    assert np.isclose(tw_before['y', 'mb.b28l8.b1'], 0, atol=1e-4)
+    xo.assert_allclose(tw_before['y', 'mb.b28l8.b1'], 0, atol=1e-4)
     opt.reload(tag='matched')
     tw = line.twiss(method='4d')
 
-    assert np.isclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
-    assert np.isclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
-    assert np.isclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
-    assert np.isclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
+    xo.assert_allclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
+    xo.assert_allclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
 
 @for_all_test_contexts
 def test_match_bump_sets_init_end(test_context):
@@ -623,16 +625,16 @@ def test_match_bump_sets_init_end(test_context):
     opt.tag(tag='matched')
     opt.reload(0)
     tw_before = line.twiss(method='4d')
-    assert np.isclose(tw_before['y', 'mb.b28l8.b1'], 0, atol=1e-4)
+    xo.assert_allclose(tw_before['y', 'mb.b28l8.b1'], 0, atol=1e-4)
     opt.reload(tag='matched')
     tw = line.twiss(method='4d')
 
-    assert np.isclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
-    assert np.isclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
-    assert np.isclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
-    assert np.isclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
+    xo.assert_allclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
+    xo.assert_allclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
 
 @for_all_test_contexts
 def test_match_bump_sets_init_middle(test_context):
@@ -658,16 +660,16 @@ def test_match_bump_sets_init_middle(test_context):
     opt.tag(tag='matched')
     opt.reload(0)
     tw_before = line.twiss(method='4d')
-    assert np.isclose(tw_before['y', 'mb.b28l8.b1'], 0, atol=1e-4)
+    xo.assert_allclose(tw_before['y', 'mb.b28l8.b1'], 0, atol=1e-4)
     opt.reload(tag='matched')
     tw = line.twiss(method='4d')
 
-    assert np.isclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
-    assert np.isclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
-    assert np.isclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
-    assert np.isclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
+    xo.assert_allclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
+    xo.assert_allclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
 
 @for_all_test_contexts
 def test_match_bump_sets_init_table(test_context):
@@ -694,16 +696,16 @@ def test_match_bump_sets_init_table(test_context):
     opt.tag(tag='matched')
     opt.reload(0)
     tw_before = line.twiss(method='4d')
-    assert np.isclose(tw_before['y', 'mb.b28l8.b1'], 0, atol=1e-4)
+    xo.assert_allclose(tw_before['y', 'mb.b28l8.b1'], 0, atol=1e-4)
     opt.reload(tag='matched')
     tw = line.twiss(method='4d')
 
-    assert np.isclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
-    assert np.isclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
-    assert np.isclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
-    assert np.isclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
-    assert np.isclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mb.b28l8.b1'], 3e-3, atol=1e-4)
+    xo.assert_allclose(tw['py', 'mb.b28l8.b1'], 0, atol=1e-6)
+    xo.assert_allclose(tw['y', 'mq.23l8.b1'], tw_before['y', 'mq.23l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.23l8.b1'], tw_before['py', 'mq.23l8.b1'], atol=1e-7)
+    xo.assert_allclose(tw['y', 'mq.33l8.b1'], tw_before['y', 'mq.33l8.b1'], atol=1e-6)
+    xo.assert_allclose(tw['py', 'mq.33l8.b1'], tw_before['py', 'mq.33l8.b1'], atol=1e-7)
 
 @for_all_test_contexts
 def test_match_bump_common_elements(test_context):
@@ -740,14 +742,14 @@ def test_match_bump_common_elements(test_context):
     assert isinstance(opt.actions[0].kwargs['_initial_particles'][1], xt.Particles)
 
     tw = collider.twiss()
-    assert np.isclose(tw.lhcb1['y', 'ip5'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb1['py', 'ip5'], 10e-6, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb1['y', 's.ds.r5.b1'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb1['py', 's.ds.r5.b1'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb2['y', 'ip5'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb2['py', 'ip5'], -10e-6, rtol=0, atol=1e-10)
-    assert np.isclose(tw.lhcb2['y', 's.ds.r5.b2'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb2['py', 's.ds.r5.b2'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb1['y', 'ip5'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb1['py', 'ip5'], 10e-6, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb1['y', 's.ds.r5.b1'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb1['py', 's.ds.r5.b1'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb2['y', 'ip5'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb2['py', 'ip5'], -10e-6, rtol=0, atol=1e-10)
+    xo.assert_allclose(tw.lhcb2['y', 's.ds.r5.b2'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb2['py', 's.ds.r5.b2'], 0, rtol=0, atol=1e-9)
 
 @for_all_test_contexts
 def test_match_bump_common_elements_callables_and_inequalities(test_context):
@@ -789,14 +791,14 @@ def test_match_bump_common_elements_callables_and_inequalities(test_context):
 
     tw = collider.twiss()
 
-    assert np.isclose(tw.lhcb1['y', 'ip5'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb1['py', 'ip5'], 10e-6, rtol=0, atol=1.1e-6)
-    assert np.isclose(tw.lhcb1['y', 's.ds.r5.b1'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb1['py', 's.ds.r5.b1'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb2['y', 'ip5'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb2['py', 'ip5'] + tw.lhcb1['py', 'ip5'], 0, rtol=0, atol=1e-10)
-    assert np.isclose(tw.lhcb2['y', 's.ds.r5.b2'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb2['py', 's.ds.r5.b2'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb1['y', 'ip5'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb1['py', 'ip5'], 10e-6, rtol=0, atol=1.1e-6)
+    xo.assert_allclose(tw.lhcb1['y', 's.ds.r5.b1'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb1['py', 's.ds.r5.b1'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb2['y', 'ip5'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb2['py', 'ip5'] + tw.lhcb1['py', 'ip5'], 0, rtol=0, atol=1e-10)
+    xo.assert_allclose(tw.lhcb2['y', 's.ds.r5.b2'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb2['py', 's.ds.r5.b2'], 0, rtol=0, atol=1e-9)
 
 @for_all_test_contexts
 def test_match_bump_common_elements_targets_from_tables(test_context):
@@ -846,11 +848,11 @@ def test_match_bump_common_elements_targets_from_tables(test_context):
 
     tw = collider.twiss()
 
-    assert np.isclose(tw.lhcb1['y', 'ip5'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb1['py', 'ip5'], 10e-6, rtol=0, atol=1.1e-6)
-    assert np.isclose(tw.lhcb1['y', 's.ds.r5.b1'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb1['py', 's.ds.r5.b1'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb2['y', 'ip5'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb2['py', 'ip5'] + tw.lhcb1['py', 'ip5'], 0, rtol=0, atol=1e-10)
-    assert np.isclose(tw.lhcb2['y', 's.ds.r5.b2'], 0, rtol=0, atol=1e-9)
-    assert np.isclose(tw.lhcb2['py', 's.ds.r5.b2'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb1['y', 'ip5'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb1['py', 'ip5'], 10e-6, rtol=0, atol=1.1e-6)
+    xo.assert_allclose(tw.lhcb1['y', 's.ds.r5.b1'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb1['py', 's.ds.r5.b1'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb2['y', 'ip5'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb2['py', 'ip5'] + tw.lhcb1['py', 'ip5'], 0, rtol=0, atol=1e-10)
+    xo.assert_allclose(tw.lhcb2['y', 's.ds.r5.b2'], 0, rtol=0, atol=1e-9)
+    xo.assert_allclose(tw.lhcb2['py', 's.ds.r5.b2'], 0, rtol=0, atol=1e-9)

--- a/tests/test_match_tune_chroma_cminus.py
+++ b/tests/test_match_tune_chroma_cminus.py
@@ -1,11 +1,10 @@
 import json
-import time
 import pathlib
+import time
 
-import numpy as np
-
-import xtrack as xt
+import xobjects as xo
 import xpart as xp
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
@@ -61,10 +60,10 @@ def test_match_tune_chromaticity(test_context):
     print(f"ksf.b1 = {line.vars['ksf.b1']._value}")
     print(f"ksd.b1 = {line.vars['ksd.b1']._value}")
 
-    assert np.isclose(tw_final['qx'], 62.315, atol=1e-7)
-    assert np.isclose(tw_final['qy'], 60.325, atol=1e-7)
-    assert np.isclose(tw_final['dqx'], 10.0, atol=0.05)
-    assert np.isclose(tw_final['dqy'], 12.0, atol=0.05)
+    xo.assert_allclose(tw_final['qx'], 62.315, atol=1e-7)
+    xo.assert_allclose(tw_final['qy'], 60.325, atol=1e-7)
+    xo.assert_allclose(tw_final['dqx'], 10.0, atol=0.05)
+    xo.assert_allclose(tw_final['dqy'], 12.0, atol=0.05)
 
 
     t1 = time.time()
@@ -92,10 +91,10 @@ def test_match_tune_chromaticity(test_context):
     print(f"ksf.b1 = {line.vars['ksf.b1']._value}")
     print(f"ksd.b1 = {line.vars['ksd.b1']._value}")
 
-    assert np.isclose(tw_final['qx'], 62.27, atol=1e-4)
-    assert np.isclose(tw_final['qy'], 60.28, atol=1e-4)
-    assert np.isclose(tw_final['dqx'], -5.0, atol=0.05)
-    assert np.isclose(tw_final['dqy'], -7.0, atol=0.05)
+    xo.assert_allclose(tw_final['qx'], 62.27, atol=1e-4)
+    xo.assert_allclose(tw_final['qy'], 60.28, atol=1e-4)
+    xo.assert_allclose(tw_final['dqx'], -5.0, atol=0.05)
+    xo.assert_allclose(tw_final['dqy'], -7.0, atol=0.05)
 
     # Trying 4d matching
     for ee in line.elements:
@@ -126,10 +125,10 @@ def test_match_tune_chromaticity(test_context):
     print(f"ksf.b1 = {line.vars['ksf.b1']._value}")
     print(f"ksd.b1 = {line.vars['ksd.b1']._value}")
 
-    assert np.isclose(tw_final['qx'], 62.29, atol=1e-4)
-    assert np.isclose(tw_final['qy'], 60.31, atol=1e-4)
-    assert np.isclose(tw_final['dqx'],  6.0, atol=0.05)
-    assert np.isclose(tw_final['dqy'],  4.0, atol=0.05)
+    xo.assert_allclose(tw_final['qx'], 62.29, atol=1e-4)
+    xo.assert_allclose(tw_final['qy'], 60.31, atol=1e-4)
+    xo.assert_allclose(tw_final['dqx'],  6.0, atol=0.05)
+    xo.assert_allclose(tw_final['dqy'],  4.0, atol=0.05)
 
 
 @for_all_test_contexts
@@ -201,15 +200,15 @@ def test_match_chroma_knob(test_context):
                     xt.Target('dqy', 3.0, tol=1e-6)])
 
     tw = line.twiss()
-    assert np.isclose(tw.dqx, 2.0, atol=1e-6)
-    assert np.isclose(tw.dqy, 2.0, atol=1e-6)
+    xo.assert_allclose(tw.dqx, 2.0, atol=1e-6)
+    xo.assert_allclose(tw.dqy, 2.0, atol=1e-6)
 
     line.vars['dqx.b1'] = 6.0
     line.vars['dqy.b1'] = 7.0
 
     tw = line.twiss()
-    assert np.isclose(tw.dqx, 6.0, atol=1e-4)
-    assert np.isclose(tw.dqy, 7.0, atol=1e-4)
+    xo.assert_allclose(tw.dqx, 6.0, atol=1e-4)
+    xo.assert_allclose(tw.dqy, 7.0, atol=1e-4)
 
 
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -10,11 +10,10 @@ import numpy as np
 import pytest
 from numpy.testing import assert_equal, assert_allclose
 
-import xtrack as xt
-import xpart as xp
 import xobjects as xo
+import xpart as xp
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
-
 
 test_data_folder = pathlib.Path(
         __file__).parent.joinpath('../test_data').absolute()
@@ -317,7 +316,7 @@ def test_collective_ebe_monitor(test_context, line0, particles0):
     )
     recoded_track_x_collective = line_collective.record_last_track.x
 
-    assert np.allclose(recoded_track_x, recoded_track_x_collective)
+    xo.assert_allclose(recoded_track_x, recoded_track_x_collective)
 
     # Element by element mode
     monitor_mode = 'ONE_TURN_EBE'
@@ -344,7 +343,7 @@ def test_collective_ebe_monitor(test_context, line0, particles0):
         turn_by_turn_monitor=monitor_mode,
     )
     recoded_track_x_collective = line_collective.record_last_track.x
-    assert np.allclose(recoded_track_x, recoded_track_x_collective)
+    xo.assert_allclose(recoded_track_x, recoded_track_x_collective)
 
 
 @for_all_test_contexts

--- a/tests/test_multispecies.py
+++ b/tests/test_multispecies.py
@@ -1,9 +1,11 @@
-import pytest
-import xtrack as xt
 import numpy as np
-
-from scipy.constants import e as qe
+import pytest
 from scipy.constants import c as clight
+from scipy.constants import e as qe
+
+import xobjects as xo
+import xtrack as xt
+
 
 def test_multispecies_multipole():
 
@@ -36,17 +38,17 @@ def test_multispecies_multipole():
     p1_ref2.chi = p1_ref2_charge_ratio / p1_ref2_mass_ratio
     p1_ref2.delta = P_p1 / p1_ref2_mass_ratio / p1_ref2.p0c - 1
 
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
 
-    assert np.isclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
 
     p1c = p1.p0c / p1.rpp * p1.mass_ratio
     p1c_ref2 = p1_ref2.p0c / p1_ref2.rpp * p1_ref2.mass_ratio
-    assert np.isclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
 
     L_bend = 1.
 
@@ -103,12 +105,12 @@ def test_multispecies_multipole():
     line_ref1.track(p1, ele_start=0, ele_stop='endmarker')
     line_ref2.track(p1_ref2, ele_start=0, ele_stop='endmarker')
 
-    assert np.isclose(p1.x, p1_ref2.x, atol=0, rtol=1e-14)
-    assert np.isclose(p1.y, p1_ref2.y, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.x, p1_ref2.x, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.y, p1_ref2.y, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
 
     # Check absolute time of arrival
     t0_ref1 = p1.s / (p1.beta0 * clight)           # Absolute reference time of arrival
@@ -116,7 +118,7 @@ def test_multispecies_multipole():
     dt_ref1 = -p1.zeta / (p1.beta0 * clight)           # Arrival time relative to reference
     dt_ref2 = -p1_ref2.zeta / (p1_ref2.beta0 * clight) # Arrival time relative to reference
 
-    assert np.isclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
+    xo.assert_allclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
 
 @pytest.mark.parametrize('model', ['expanded', 'bend-kick-bend', 'rot-kick-rot'])
 @pytest.mark.parametrize('B_T', [0.4, 0])
@@ -153,17 +155,17 @@ def test_multispecies_bend(model, B_T, hxl, G_Tm, S_Tm2):
     p1_ref2.chi = p1_ref2_charge_ratio / p1_ref2_mass_ratio
     p1_ref2.delta = P_p1 / p1_ref2_mass_ratio / p1_ref2.p0c - 1
 
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
 
-    assert np.isclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
 
     p1c = p1.p0c / p1.rpp * p1.mass_ratio
     p1c_ref2 = p1_ref2.p0c / p1_ref2.rpp * p1_ref2.mass_ratio
-    assert np.isclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
 
     L_bend = 1.
 
@@ -220,12 +222,12 @@ def test_multispecies_bend(model, B_T, hxl, G_Tm, S_Tm2):
     line_ref1.track(p1, ele_start=0, ele_stop='endmarker')
     line_ref2.track(p1_ref2, ele_start=0, ele_stop='endmarker')
 
-    assert np.isclose(p1.x, p1_ref2.x, atol=0, rtol=1e-10)
-    assert np.isclose(p1.y, p1_ref2.y, atol=0, rtol=1e-10)
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.x, p1_ref2.x, atol=0, rtol=1e-10)
+    xo.assert_allclose(p1.y, p1_ref2.y, atol=0, rtol=1e-10)
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
 
     # Check absolute time of arrival
     t0_ref1 = p1.s / (p1.beta0 * clight)           # Absolute reference time of arrival
@@ -233,7 +235,7 @@ def test_multispecies_bend(model, B_T, hxl, G_Tm, S_Tm2):
     dt_ref1 = -p1.zeta / (p1.beta0 * clight)           # Arrival time relative to reference
     dt_ref2 = -p1_ref2.zeta / (p1_ref2.beta0 * clight) # Arrival time relative to reference
 
-    assert np.isclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
+    xo.assert_allclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
 
 @pytest.mark.parametrize('model', ['full', 'linear'])
 @pytest.mark.parametrize('side', ['entry', 'exit'])
@@ -268,17 +270,17 @@ def test_multispecies_dipole_edge(model, side):
     p1_ref2.chi = p1_ref2_charge_ratio / p1_ref2_mass_ratio
     p1_ref2.delta = P_p1 / p1_ref2_mass_ratio / p1_ref2.p0c - 1
 
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
 
-    assert np.isclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
 
     p1c = p1.p0c / p1.rpp * p1.mass_ratio
     p1c_ref2 = p1_ref2.p0c / p1_ref2.rpp * p1_ref2.mass_ratio
-    assert np.isclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
 
     B_T = 0.4
     e1=0.1
@@ -310,12 +312,12 @@ def test_multispecies_dipole_edge(model, side):
     line_ref1.track(p1, ele_start=0, ele_stop='endmarker')
     line_ref2.track(p1_ref2, ele_start=0, ele_stop='endmarker')
 
-    assert np.isclose(p1.x, p1_ref2.x, atol=0, rtol=1e-5)
-    assert np.isclose(p1.y, p1_ref2.y, atol=0, rtol=1e-1)          #?????????????
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.x, p1_ref2.x, atol=0, rtol=1e-5)
+    xo.assert_allclose(p1.y, p1_ref2.y, atol=0, rtol=1e-1)          #?????????????
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
 
     # Check absolute time of arrival
     t0_ref1 = p1.s / (p1.beta0 * clight)           # Absolute reference time of arrival
@@ -323,7 +325,7 @@ def test_multispecies_dipole_edge(model, side):
     dt_ref1 = -p1.zeta / (p1.beta0 * clight)           # Arrival time relative to reference
     dt_ref2 = -p1_ref2.zeta / (p1_ref2.beta0 * clight) # Arrival time relative to reference
 
-    assert np.isclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
+    xo.assert_allclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
 
 
 def test_multispecies_quadrupole():
@@ -357,17 +359,17 @@ def test_multispecies_quadrupole():
     p1_ref2.chi = p1_ref2_charge_ratio / p1_ref2_mass_ratio
     p1_ref2.delta = P_p1 / p1_ref2_mass_ratio / p1_ref2.p0c - 1
 
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
 
-    assert np.isclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
 
     p1c = p1.p0c / p1.rpp * p1.mass_ratio
     p1c_ref2 = p1_ref2.p0c / p1_ref2.rpp * p1_ref2.mass_ratio
-    assert np.isclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
 
     model = 'bend-kick-bend'
     model = 'rot-kick-rot'
@@ -420,12 +422,12 @@ def test_multispecies_quadrupole():
     line_ref1.track(p1, ele_start=0, ele_stop='endmarker')
     line_ref2.track(p1_ref2, ele_start=0, ele_stop='endmarker')
 
-    assert np.isclose(p1.x, p1_ref2.x, atol=0, rtol=1e-10)
-    assert np.isclose(p1.y, p1_ref2.y, atol=0, rtol=1e-10)
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.x, p1_ref2.x, atol=0, rtol=1e-10)
+    xo.assert_allclose(p1.y, p1_ref2.y, atol=0, rtol=1e-10)
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
 
     # Check absolute time of arrival
     t0_ref1 = p1.s / (p1.beta0 * clight)           # Absolute reference time of arrival
@@ -433,7 +435,7 @@ def test_multispecies_quadrupole():
     dt_ref1 = -p1.zeta / (p1.beta0 * clight)           # Arrival time relative to reference
     dt_ref2 = -p1_ref2.zeta / (p1_ref2.beta0 * clight) # Arrival time relative to reference
 
-    assert np.isclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
+    xo.assert_allclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
 
 def test_multispecies_sextupole():
 
@@ -466,17 +468,17 @@ def test_multispecies_sextupole():
     p1_ref2.chi = p1_ref2_charge_ratio / p1_ref2_mass_ratio
     p1_ref2.delta = P_p1 / p1_ref2_mass_ratio / p1_ref2.p0c - 1
 
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
 
-    assert np.isclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
 
     p1c = p1.p0c / p1.rpp * p1.mass_ratio
     p1c_ref2 = p1_ref2.p0c / p1_ref2.rpp * p1_ref2.mass_ratio
-    assert np.isclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
 
     model = 'bend-kick-bend'
     model = 'rot-kick-rot'
@@ -528,12 +530,12 @@ def test_multispecies_sextupole():
     line_ref1.track(p1, ele_start=0, ele_stop='endmarker')
     line_ref2.track(p1_ref2, ele_start=0, ele_stop='endmarker')
 
-    assert np.isclose(p1.x, p1_ref2.x, atol=0, rtol=1e-10)
-    assert np.isclose(p1.y, p1_ref2.y, atol=0, rtol=1e-10)
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.x, p1_ref2.x, atol=0, rtol=1e-10)
+    xo.assert_allclose(p1.y, p1_ref2.y, atol=0, rtol=1e-10)
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
 
     # Check absolute time of arrival
     t0_ref1 = p1.s / (p1.beta0 * clight)           # Absolute reference time of arrival
@@ -541,7 +543,7 @@ def test_multispecies_sextupole():
     dt_ref1 = -p1.zeta / (p1.beta0 * clight)           # Arrival time relative to reference
     dt_ref2 = -p1_ref2.zeta / (p1_ref2.beta0 * clight) # Arrival time relative to reference
 
-    assert np.isclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
+    xo.assert_allclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
 
 def test_multispecies_octupole():
 
@@ -574,17 +576,17 @@ def test_multispecies_octupole():
     p1_ref2.chi = p1_ref2_charge_ratio / p1_ref2_mass_ratio
     p1_ref2.delta = P_p1 / p1_ref2_mass_ratio / p1_ref2.p0c - 1
 
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
 
-    assert np.isclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
 
     p1c = p1.p0c / p1.rpp * p1.mass_ratio
     p1c_ref2 = p1_ref2.p0c / p1_ref2.rpp * p1_ref2.mass_ratio
-    assert np.isclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
 
     L_bend = 1.
     O_Tm3 = 1
@@ -630,12 +632,12 @@ def test_multispecies_octupole():
     line_ref1.track(p1, ele_start=0, ele_stop='endmarker')
     line_ref2.track(p1_ref2, ele_start=0, ele_stop='endmarker')
 
-    assert np.isclose(p1.x, p1_ref2.x, atol=0, rtol=1e-12)
-    assert np.isclose(p1.y, p1_ref2.y, atol=0, rtol=1e-12)
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.x, p1_ref2.x, atol=0, rtol=1e-12)
+    xo.assert_allclose(p1.y, p1_ref2.y, atol=0, rtol=1e-12)
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
 
     # Check absolute time of arrival
     t0_ref1 = p1.s / (p1.beta0 * clight)           # Absolute reference time of arrival
@@ -643,7 +645,7 @@ def test_multispecies_octupole():
     dt_ref1 = -p1.zeta / (p1.beta0 * clight)           # Arrival time relative to reference
     dt_ref2 = -p1_ref2.zeta / (p1_ref2.beta0 * clight) # Arrival time relative to reference
 
-    assert np.isclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
+    xo.assert_allclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
 
 def test_multispecies_cavity():
 
@@ -676,17 +678,17 @@ def test_multispecies_cavity():
     p1_ref2.chi = p1_ref2_charge_ratio / p1_ref2_mass_ratio
     p1_ref2.delta = P_p1 / p1_ref2_mass_ratio / p1_ref2.p0c - 1
 
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
 
-    assert np.isclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.rpp, 1 / (1 + p1.delta), atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rpp, 1 / (1 + p1_ref2.delta), atol=0, rtol=1e-14)
 
     p1c = p1.p0c / p1.rpp * p1.mass_ratio
     p1c_ref2 = p1_ref2.p0c / p1_ref2.rpp * p1_ref2.mass_ratio
-    assert np.isclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1c, p1c_ref2, atol=0, rtol=1e-14)
 
     s_cav = 100
     frequency = 400e6
@@ -721,14 +723,14 @@ def test_multispecies_cavity():
     dt_ref1 = -p1.zeta / (p1.beta0 * clight)           # Arrival time relative to reference
     dt_ref2 = -p1_ref2.zeta / (p1_ref2.beta0 * clight) # Arrival time relative to reference
 
-    assert np.isclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
-    assert np.isclose(p1_ref2.zeta,
+    xo.assert_allclose(t0_ref1 + dt_ref1, t0_ref2 + dt_ref2, atol=1e-11, rtol=0)
+    xo.assert_allclose(p1_ref2.zeta,
         (1 - p1_ref2.beta0 / p1.beta0) * p1.s + p1_ref2.beta0 / p1.beta0 * p1.zeta,
         atol=1e-11, rtol=0)
 
-    assert np.isclose(p1.x, p1_ref2.x, atol=0, rtol=1e-12)
-    assert np.isclose(p1.y, p1_ref2.y, atol=0, rtol=1e-12)
-    assert np.isclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
-    assert np.isclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1.x, p1_ref2.x, atol=0, rtol=1e-12)
+    xo.assert_allclose(p1.y, p1_ref2.y, atol=0, rtol=1e-12)
+    xo.assert_allclose(p1_ref2.mass, p1.mass, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.charge, p1.charge, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.energy, p1.energy, atol=0, rtol=1e-14)
+    xo.assert_allclose(p1_ref2.rvv * p1_ref2.beta0, p1.rvv * p1.beta0, atol=0, rtol=1e-14)

--- a/tests/test_ps_against_ptc.py
+++ b/tests/test_ps_against_ptc.py
@@ -1,10 +1,11 @@
 import pathlib
-from cpymad.madx import Madx
+
 import numpy as np
+from cpymad.madx import Madx
+
+import xobjects as xo
 import xtrack as xt
-
 from xobjects.test_helpers import for_all_test_contexts
-
 
 test_data_folder = pathlib.Path(
     __file__).parent.joinpath('../test_data').absolute()
@@ -97,24 +98,24 @@ def test_ps_against_ptc(test_context):
     wx_ptc = np.sqrt(ax_ptc**2 + bx_ptc**2)
     wy_ptc = np.sqrt(ay_ptc**2 + by_ptc**2)
 
-    assert np.isclose(tw.qx, qx_ptc, atol=1e-4, rtol=0)
-    assert np.isclose(tw.qy, qy_ptc, atol=1e-4, rtol=0)
+    xo.assert_allclose(tw.qx, qx_ptc, atol=1e-4, rtol=0)
+    xo.assert_allclose(tw.qy, qy_ptc, atol=1e-4, rtol=0)
 
-    assert np.isclose(tw.dqx, dq1_ptc, atol=1e-2, rtol=0)
-    assert np.isclose(tw.dqy, dq2_ptc, atol=1e-2, rtol=0)
+    xo.assert_allclose(tw.dqx, dq1_ptc, atol=1e-2, rtol=0)
+    xo.assert_allclose(tw.dqy, dq2_ptc, atol=1e-2, rtol=0)
 
-    assert np.isclose(tw.dqx, dq1_ptc, atol=1e-2, rtol=0)
-    assert np.isclose(tw.dqy, dq2_ptc, atol=1e-2, rtol=0)
+    xo.assert_allclose(tw.dqx, dq1_ptc, atol=1e-2, rtol=0)
+    xo.assert_allclose(tw.dqy, dq2_ptc, atol=1e-2, rtol=0)
 
     nlchr = line.get_non_linear_chromaticity(method='4d')
-    assert np.isclose(nlchr['ddqx'], ddq1_ptc, atol=0, rtol=5e-3)
-    assert np.isclose(nlchr['ddqy'], ddq2_ptc, atol=0, rtol=5e-3)
+    xo.assert_allclose(nlchr['ddqx'], ddq1_ptc, atol=0, rtol=5e-3)
+    xo.assert_allclose(nlchr['ddqy'], ddq2_ptc, atol=0, rtol=5e-3)
 
-    assert np.isclose(nlchr['dqx'], dq1_ptc, atol=0, rtol=5e-3)
-    assert np.isclose(nlchr['dqy'], dq2_ptc, atol=0, rtol=5e-3)
+    xo.assert_allclose(nlchr['dqx'], dq1_ptc, atol=0, rtol=5e-3)
+    xo.assert_allclose(nlchr['dqy'], dq2_ptc, atol=0, rtol=5e-3)
 
-    assert np.allclose(nlchr.dnqx[:3], [tw.qx, nlchr.dqx, nlchr.ddqx], atol=0, rtol=1e-6)
-    assert np.allclose(nlchr.dnqy[:3], [tw.qy, nlchr.dqy, nlchr.ddqy], atol=0, rtol=1e-6)
+    xo.assert_allclose(nlchr.dnqx[:3], [tw.qx, nlchr.dqx, nlchr.ddqx], atol=0, rtol=1e-6)
+    xo.assert_allclose(nlchr.dnqy[:3], [tw.qy, nlchr.dqy, nlchr.ddqy], atol=0, rtol=1e-6)
 
     markers_ptc = tptc.rows[tptc.keyword == 'marker']
     markers_common_ptc = [nn for nn in markers_ptc.name if nn.split(':')[0] in tw.name]
@@ -122,14 +123,14 @@ def test_ps_against_ptc(test_context):
     mask_ptc = tptc.mask[markers_common_ptc]
     mask_xs = tw.mask[markers_common_xs]
 
-    assert np.allclose(tw.ax_chrom[mask_xs], ax_ptc[mask_ptc], atol=1e-2, rtol=0)
-    assert np.allclose(tw.bx_chrom[mask_xs], bx_ptc[mask_ptc], atol=1e-2, rtol=0)
-    assert np.allclose(tw.ay_chrom[mask_xs], ay_ptc[mask_ptc], atol=1e-2, rtol=0)
-    assert np.allclose(tw.by_chrom[mask_xs], by_ptc[mask_ptc], atol=1e-2, rtol=0)
-    assert np.allclose(tw.wx_chrom[mask_xs], wx_ptc[mask_ptc], atol=1e-2, rtol=0)
-    assert np.allclose(tw.wy_chrom[mask_xs], wy_ptc[mask_ptc], atol=1e-2, rtol=0)
+    xo.assert_allclose(tw.ax_chrom[mask_xs], ax_ptc[mask_ptc], atol=1e-2, rtol=0)
+    xo.assert_allclose(tw.bx_chrom[mask_xs], bx_ptc[mask_ptc], atol=1e-2, rtol=0)
+    xo.assert_allclose(tw.ay_chrom[mask_xs], ay_ptc[mask_ptc], atol=1e-2, rtol=0)
+    xo.assert_allclose(tw.by_chrom[mask_xs], by_ptc[mask_ptc], atol=1e-2, rtol=0)
+    xo.assert_allclose(tw.wx_chrom[mask_xs], wx_ptc[mask_ptc], atol=1e-2, rtol=0)
+    xo.assert_allclose(tw.wy_chrom[mask_xs], wy_ptc[mask_ptc], atol=1e-2, rtol=0)
 
-    assert np.allclose(tw.betx[mask_xs], betx[mask_ptc], rtol=1e-4, atol=0)
-    assert np.allclose(tw.bety[mask_xs], bety[mask_ptc], rtol=1e-4, atol=0)
-    assert np.allclose(tw.dx[mask_xs], dx_ptc[mask_ptc], rtol=1e-4, atol=1e-6)
-    assert np.allclose(tw.dy[mask_xs], dy_ptc[mask_ptc], rtol=1e-4, atol=1e-6)
+    xo.assert_allclose(tw.betx[mask_xs], betx[mask_ptc], rtol=1e-4, atol=0)
+    xo.assert_allclose(tw.bety[mask_xs], bety[mask_ptc], rtol=1e-4, atol=0)
+    xo.assert_allclose(tw.dx[mask_xs], dx_ptc[mask_ptc], rtol=1e-4, atol=1e-6)
+    xo.assert_allclose(tw.dy[mask_xs], dy_ptc[mask_ptc], rtol=1e-4, atol=1e-6)

--- a/tests/test_ps_multiturn_twiss.py
+++ b/tests/test_ps_multiturn_twiss.py
@@ -1,8 +1,10 @@
-import numpy as np
 import pathlib
-from cpymad.madx import Madx
-import xtrack as xt
 
+import numpy as np
+from cpymad.madx import Madx
+
+import xobjects as xo
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
 
@@ -63,15 +65,15 @@ def test_ps_multiturn_twiss(test_context):
 
     circum = line.get_length()
 
-    assert np.isclose(tw_mt.s[-1], 4 * circum, atol=1e-10, rtol=0)
-    assert np.isclose(tw_mt['s', '_turn_0'], 0, atol=1e-10, rtol=0)
-    assert np.isclose(tw_mt['s', '_turn_1'], circum, atol=1e-10, rtol=0)
-    assert np.isclose(tw_mt['s', '_turn_2'], 2 * circum, atol=1e-10, rtol=0)
-    assert np.isclose(tw_mt['s', '_turn_3'], 3 * circum, atol=1e-10, rtol=0)
-    assert np.isclose(tw_mt['s', '_end_point'], 4 * circum, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw_mt.s[-1], 4 * circum, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw_mt['s', '_turn_0'], 0, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw_mt['s', '_turn_1'], circum, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw_mt['s', '_turn_2'], 2 * circum, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw_mt['s', '_turn_3'], 3 * circum, atol=1e-10, rtol=0)
+    xo.assert_allclose(tw_mt['s', '_end_point'], 4 * circum, atol=1e-10, rtol=0)
 
-    assert np.isclose(tw_mt.mux[-1], 4 * tw.mux[-1], rtol=0, atol=0.05)
-    assert np.isclose(tw_mt.muy[-1], 4 * tw.muy[-1], rtol=0, atol=0.05)
+    xo.assert_allclose(tw_mt.mux[-1], 4 * tw.mux[-1], rtol=0, atol=0.05)
+    xo.assert_allclose(tw_mt.muy[-1], 4 * tw.muy[-1], rtol=0, atol=0.05)
 
     assert 'qx' in tw
     assert 'qy' in tw
@@ -83,11 +85,11 @@ def test_ps_multiturn_twiss(test_context):
     assert tw_mt['x', '_turn_2'] < -2e-2
     assert np.abs(tw_mt['x', '_turn_3']) < 1e-2
 
-    assert np.isclose(tw_mt.x[-1], tw_mt.x[0], rtol=0, atol=1e-8)
-    assert np.isclose(tw_mt.y[-1], tw_mt.y[0], rtol=0, atol=1e-8)
-    assert np.isclose(tw_mt.px[-1], tw_mt.px[0], rtol=0, atol=1e-10)
-    assert np.isclose(tw_mt.py[-1], tw_mt.py[0], rtol=0, atol=1e-10)
-    assert np.isclose(tw_mt.betx[-1], tw_mt.betx[0], rtol=0, atol=1e-5)
-    assert np.isclose(tw_mt.bety[-1], tw_mt.bety[0], rtol=0, atol=1e-5)
-    assert np.isclose(tw_mt.alfx[-1], tw_mt.alfx[0], rtol=0, atol=1e-5)
-    assert np.isclose(tw_mt.alfy[-1], tw_mt.alfy[0], rtol=0, atol=1e-5)
+    xo.assert_allclose(tw_mt.x[-1], tw_mt.x[0], rtol=0, atol=1e-8)
+    xo.assert_allclose(tw_mt.y[-1], tw_mt.y[0], rtol=0, atol=1e-8)
+    xo.assert_allclose(tw_mt.px[-1], tw_mt.px[0], rtol=0, atol=1e-10)
+    xo.assert_allclose(tw_mt.py[-1], tw_mt.py[0], rtol=0, atol=1e-10)
+    xo.assert_allclose(tw_mt.betx[-1], tw_mt.betx[0], rtol=0, atol=1e-5)
+    xo.assert_allclose(tw_mt.bety[-1], tw_mt.bety[0], rtol=0, atol=1e-5)
+    xo.assert_allclose(tw_mt.alfx[-1], tw_mt.alfx[0], rtol=0, atol=1e-5)
+    xo.assert_allclose(tw_mt.alfy[-1], tw_mt.alfy[0], rtol=0, atol=1e-5)

--- a/tests/test_psb_chicane.py
+++ b/tests/test_psb_chicane.py
@@ -1,19 +1,16 @@
 import json
 import pathlib
+
 import numpy as np
 import pandas as pd
-
 from cpymad.madx import Madx
 
-import xtrack as xt
-import xpart as xp
 import xdeps as xd
 import xobjects as xo
-from xtrack.slicing import Teapot, Strategy
-
+import xpart as xp
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
-
-from cpymad.madx import Madx
+from xtrack.slicing import Teapot, Strategy
 
 test_data_folder = pathlib.Path(
         __file__).parent.joinpath('../test_data').absolute()
@@ -76,66 +73,66 @@ def test_psb_chicane(test_context):
 
     line.vars['bsw_k2l'] = bsw_k2l_ref
     line.vars['bsw_k0l'] = bsw_k0l_ref
-    assert np.isclose(line['bi1.bsw1l1.1']._xobject.knl[2], bsw_k2l_ref, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.2']._xobject.knl[2], -bsw_k2l_ref, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.3']._xobject.knl[2], -bsw_k2l_ref, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.4']._xobject.knl[2], bsw_k2l_ref, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.1'].k0, bsw_k0l_ref / line['bi1.bsw1l1.1'].length, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.2'].k0, -bsw_k0l_ref / line['bi1.bsw1l1.2'].length, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.3'].k0, -bsw_k0l_ref / line['bi1.bsw1l1.3'].length, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.4'].k0, bsw_k0l_ref / line['bi1.bsw1l1.4'].length, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.1']._xobject.knl[2], bsw_k2l_ref, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.2']._xobject.knl[2], -bsw_k2l_ref, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.3']._xobject.knl[2], -bsw_k2l_ref, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.4']._xobject.knl[2], bsw_k2l_ref, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.1'].k0, bsw_k0l_ref / line['bi1.bsw1l1.1'].length, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.2'].k0, -bsw_k0l_ref / line['bi1.bsw1l1.2'].length, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.3'].k0, -bsw_k0l_ref / line['bi1.bsw1l1.3'].length, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.4'].k0, bsw_k0l_ref / line['bi1.bsw1l1.4'].length, rtol=0, atol=1e-10)
 
     tw = line.twiss()
-    assert np.isclose(tw['x', 'bi1.tstr1l1'], -0.045716, rtol=0, atol=1e-5)
-    assert np.isclose(tw['y', 'bi1.tstr1l1'], 0.0000000, rtol=0, atol=1e-5)
-    assert np.isclose(tw['betx', 'bi1.tstr1l1'], 5.203667, rtol=0, atol=1e-4)
-    assert np.isclose(tw['bety', 'bi1.tstr1l1'], 6.902887, rtol=0, atol=1e-4)
-    assert np.isclose(tw.qy, 4.474414126093382, rtol=0, atol=1e-6) # verify that it does not change from one version to the other
-    assert np.isclose(tw.qx, 4.396717774779403, rtol=0, atol=1e-6)
-    assert np.isclose(tw.dqy, -8.625637734560598, rtol=0, atol=1e-3)
-    assert np.isclose(tw.dqx, -3.5604677592626643, rtol=0, atol=1e-3)
+    xo.assert_allclose(tw['x', 'bi1.tstr1l1'], -0.045716, rtol=0, atol=1e-5)
+    xo.assert_allclose(tw['y', 'bi1.tstr1l1'], 0.0000000, rtol=0, atol=1e-5)
+    xo.assert_allclose(tw['betx', 'bi1.tstr1l1'], 5.203667, rtol=0, atol=1e-4)
+    xo.assert_allclose(tw['bety', 'bi1.tstr1l1'], 6.902887, rtol=0, atol=1e-4)
+    xo.assert_allclose(tw.qy, 4.474414126093382, rtol=0, atol=1e-6) # verify that it does not change from one version to the other
+    xo.assert_allclose(tw.qx, 4.396717774779403, rtol=0, atol=1e-6)
+    xo.assert_allclose(tw.dqy, -8.625637734560598, rtol=0, atol=1e-3)
+    xo.assert_allclose(tw.dqx, -3.5604677592626643, rtol=0, atol=1e-3)
 
     line.vars['bsw_k2l'] = bsw_k2l_ref / 3
-    assert np.isclose(line['bi1.bsw1l1.1']._xobject.knl[2], bsw_k2l_ref / 3, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.2']._xobject.knl[2], -bsw_k2l_ref / 3, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.3']._xobject.knl[2], -bsw_k2l_ref / 3, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.4']._xobject.knl[2], bsw_k2l_ref / 3, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.1'].k0, bsw_k0l_ref / line['bi1.bsw1l1.1'].length, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.2'].k0, -bsw_k0l_ref / line['bi1.bsw1l1.2'].length, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.3'].k0, -bsw_k0l_ref / line['bi1.bsw1l1.3'].length, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.4'].k0, bsw_k0l_ref / line['bi1.bsw1l1.4'].length, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.1']._xobject.knl[2], bsw_k2l_ref / 3, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.2']._xobject.knl[2], -bsw_k2l_ref / 3, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.3']._xobject.knl[2], -bsw_k2l_ref / 3, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.4']._xobject.knl[2], bsw_k2l_ref / 3, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.1'].k0, bsw_k0l_ref / line['bi1.bsw1l1.1'].length, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.2'].k0, -bsw_k0l_ref / line['bi1.bsw1l1.2'].length, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.3'].k0, -bsw_k0l_ref / line['bi1.bsw1l1.3'].length, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.4'].k0, bsw_k0l_ref / line['bi1.bsw1l1.4'].length, rtol=0, atol=1e-10)
 
     tw = line.twiss()
-    assert np.isclose(tw['x', 'bi1.tstr1l1'], -0.0458633, rtol=0, atol=1e-5)
-    assert np.isclose(tw['y', 'bi1.tstr1l1'], 0.0000000, rtol=0, atol=1e-5)
-    assert np.isclose(tw['betx', 'bi1.tstr1l1'], 5.266456, rtol=0, atol=1e-4)
-    assert np.isclose(tw['bety', 'bi1.tstr1l1'], 6.320286, rtol=0, atol=1e-4)
-    assert np.isclose(tw.qy, 4.471766776419623, rtol=0, atol=1e-6)
-    assert np.isclose(tw.qx, 4.398899960718224, rtol=0, atol=1e-6)
-    assert np.isclose(tw.dqy, -8.2058757683523, rtol=0, atol=1e-3)
-    assert np.isclose(tw.dqx, -3.563488925077962, rtol=0, atol=1e-3)
+    xo.assert_allclose(tw['x', 'bi1.tstr1l1'], -0.0458633, rtol=0, atol=1e-5)
+    xo.assert_allclose(tw['y', 'bi1.tstr1l1'], 0.0000000, rtol=0, atol=1e-5)
+    xo.assert_allclose(tw['betx', 'bi1.tstr1l1'], 5.266456, rtol=0, atol=1e-4)
+    xo.assert_allclose(tw['bety', 'bi1.tstr1l1'], 6.320286, rtol=0, atol=1e-4)
+    xo.assert_allclose(tw.qy, 4.471766776419623, rtol=0, atol=1e-6)
+    xo.assert_allclose(tw.qx, 4.398899960718224, rtol=0, atol=1e-6)
+    xo.assert_allclose(tw.dqy, -8.2058757683523, rtol=0, atol=1e-3)
+    xo.assert_allclose(tw.dqx, -3.563488925077962, rtol=0, atol=1e-3)
 
     # Switch off bsws
     line.vars['bsw_k0l'] = 0
     line.vars['bsw_k2l'] = 0
-    assert np.isclose(line['bi1.bsw1l1.1']._xobject.knl[2], 0, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.2']._xobject.knl[2], 0, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.3']._xobject.knl[2], 0, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.4']._xobject.knl[2], 0, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.1'].k0, 0, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.2'].k0, 0, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.3'].k0, 0, rtol=0, atol=1e-10)
-    assert np.isclose(line['bi1.bsw1l1.4'].k0, 0, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.1']._xobject.knl[2], 0, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.2']._xobject.knl[2], 0, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.3']._xobject.knl[2], 0, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.4']._xobject.knl[2], 0, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.1'].k0, 0, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.2'].k0, 0, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.3'].k0, 0, rtol=0, atol=1e-10)
+    xo.assert_allclose(line['bi1.bsw1l1.4'].k0, 0, rtol=0, atol=1e-10)
 
     tw = line.twiss()
-    assert np.isclose(tw['x', 'bi1.tstr1l1'], 0, rtol=0, atol=1e-5)
-    assert np.isclose(tw['y', 'bi1.tstr1l1'], 0, rtol=0, atol=1e-5)
-    assert np.isclose(tw['betx', 'bi1.tstr1l1'], 5.2996347, rtol=0, atol=1e-4)
-    assert np.isclose(tw['bety', 'bi1.tstr1l1'], 3.838857, rtol=0, atol=1e-4)
-    assert np.isclose(tw.qy, 4.45, rtol=0, atol=1e-6)
-    assert np.isclose(tw.qx, 4.4, rtol=0, atol=1e-6)
-    assert np.isclose(tw.dqy, -7.149781341846406, rtol=0, atol=1e-3)
-    assert np.isclose(tw.dqx, -3.5655757511587893, rtol=0, atol=1e-3)
+    xo.assert_allclose(tw['x', 'bi1.tstr1l1'], 0, rtol=0, atol=1e-5)
+    xo.assert_allclose(tw['y', 'bi1.tstr1l1'], 0, rtol=0, atol=1e-5)
+    xo.assert_allclose(tw['betx', 'bi1.tstr1l1'], 5.2996347, rtol=0, atol=1e-4)
+    xo.assert_allclose(tw['bety', 'bi1.tstr1l1'], 3.838857, rtol=0, atol=1e-4)
+    xo.assert_allclose(tw.qy, 4.45, rtol=0, atol=1e-6)
+    xo.assert_allclose(tw.qx, 4.4, rtol=0, atol=1e-6)
+    xo.assert_allclose(tw.dqy, -7.149781341846406, rtol=0, atol=1e-3)
+    xo.assert_allclose(tw.dqx, -3.5655757511587893, rtol=0, atol=1e-3)
 
 
     # Setup time-dependent functions
@@ -311,16 +308,16 @@ def test_psb_chicane(test_context):
         dqy_thin.append(tw_thin.dqy)
 
 
-    assert np.allclose(qx_thick, qx_ptc, atol=2e-4, rtol=0)
-    assert np.allclose(qy_thick, qy_ptc, atol=2e-4, rtol=0)
-    assert np.allclose(qx_thin, qx_ptc, atol=1e-3, rtol=0)
-    assert np.allclose(qy_thin, qy_ptc, atol=1e-3, rtol=0)
-    assert np.allclose(dqx_thick, dqx_ptc, atol=0.5, rtol=0)
-    assert np.allclose(dqy_thick, dqy_ptc, atol=0.5, rtol=0)
-    assert np.allclose(dqx_thin, dqx_ptc, atol=0.5, rtol=0)
-    assert np.allclose(dqy_thin, dqy_ptc, atol=0.5, rtol=0)
-    assert np.allclose(bety_at_scraper_thick, bety_at_scraper_ptc, atol=0, rtol=1e-2)
-    assert np.allclose(bety_at_scraper_thin, bety_at_scraper_ptc, atol=0, rtol=2e-2)
+    xo.assert_allclose(qx_thick, qx_ptc, atol=2e-4, rtol=0)
+    xo.assert_allclose(qy_thick, qy_ptc, atol=2e-4, rtol=0)
+    xo.assert_allclose(qx_thin, qx_ptc, atol=1e-3, rtol=0)
+    xo.assert_allclose(qy_thin, qy_ptc, atol=1e-3, rtol=0)
+    xo.assert_allclose(dqx_thick, dqx_ptc, atol=0.5, rtol=0)
+    xo.assert_allclose(dqy_thick, dqy_ptc, atol=0.5, rtol=0)
+    xo.assert_allclose(dqx_thin, dqx_ptc, atol=0.5, rtol=0)
+    xo.assert_allclose(dqy_thin, dqy_ptc, atol=0.5, rtol=0)
+    xo.assert_allclose(bety_at_scraper_thick, bety_at_scraper_ptc, atol=0, rtol=1e-2)
+    xo.assert_allclose(bety_at_scraper_thin, bety_at_scraper_ptc, atol=0, rtol=2e-2)
 
     # Check correction
     line.vars['on_chicane_beta_corr'] = 1
@@ -355,12 +352,12 @@ def test_psb_chicane(test_context):
     qy_thin_corr = np.array(qy_thin_corr)
     bety_at_scraper_thin_corr = np.array(bety_at_scraper_thin_corr)
 
-    assert np.allclose(qx_thick_corr, qx_ptc[-1], atol=3e-3, rtol=0)
-    assert np.allclose(qy_thick_corr, qy_ptc[-1], atol=3e-3, rtol=0)
-    assert np.allclose(qx_thin_corr, qx_ptc[-1], atol=3e-3, rtol=0)
-    assert np.allclose(qy_thin_corr, qy_ptc[-1], atol=3e-3, rtol=0)
-    assert np.allclose(bety_at_scraper_thick_corr, bety_at_scraper_ptc[-1], atol=0, rtol=3e-2)
-    assert np.allclose(bety_at_scraper_thin_corr, bety_at_scraper_ptc[-1], atol=0, rtol=3e-2)
+    xo.assert_allclose(qx_thick_corr, qx_ptc[-1], atol=3e-3, rtol=0)
+    xo.assert_allclose(qy_thick_corr, qy_ptc[-1], atol=3e-3, rtol=0)
+    xo.assert_allclose(qx_thin_corr, qx_ptc[-1], atol=3e-3, rtol=0)
+    xo.assert_allclose(qy_thin_corr, qy_ptc[-1], atol=3e-3, rtol=0)
+    xo.assert_allclose(bety_at_scraper_thick_corr, bety_at_scraper_ptc[-1], atol=0, rtol=3e-2)
+    xo.assert_allclose(bety_at_scraper_thin_corr, bety_at_scraper_ptc[-1], atol=0, rtol=3e-2)
 
     # Tracking with time-dependent variable
 
@@ -385,11 +382,11 @@ def test_psb_chicane(test_context):
     line.track(p, num_turns=6000, time=True)
     print(f'Done in {line.time_last_track:.4} s')
 
-    assert np.isclose(monitor.x[0, 0], -0.045936, rtol=0, atol=1e-5)
-    assert np.isclose(monitor.x[0, 300], -0.04522354, rtol=0, atol=1e-5)
-    assert np.isclose(monitor.x[0, 2500], -0.02256763, rtol=0, atol=1e-5)
-    assert np.isclose(monitor.x[0, 4500], -0.00143883, rtol=0, atol=1e-5)
-    assert np.isclose(monitor.x[0, 5500], 0.0, rtol=0, atol=1e-5)
+    xo.assert_allclose(monitor.x[0, 0], -0.045936, rtol=0, atol=1e-5)
+    xo.assert_allclose(monitor.x[0, 300], -0.04522354, rtol=0, atol=1e-5)
+    xo.assert_allclose(monitor.x[0, 2500], -0.02256763, rtol=0, atol=1e-5)
+    xo.assert_allclose(monitor.x[0, 4500], -0.00143883, rtol=0, atol=1e-5)
+    xo.assert_allclose(monitor.x[0, 5500], 0.0, rtol=0, atol=1e-5)
 
     # Test multiturn injection
     if isinstance(test_context, xo.ContextCpu):
@@ -448,5 +445,5 @@ def test_psb_chicane(test_context):
         assert np.all(monitor.at_element[monitor.state > 0] ==
                     line.element_names.index('monitor_at_end'))
 
-        assert np.allclose(monitor.s[monitor.state > 0],
+        xo.assert_allclose(monitor.s[monitor.state > 0],
                         line.get_s_position('monitor_at_end'), atol=1e-12)

--- a/tests/test_pyht_interface.py
+++ b/tests/test_pyht_interface.py
@@ -5,6 +5,7 @@
 
 import pathlib
 
+import xobjects as xo
 from xobjects.test_helpers import for_all_test_contexts
 
 
@@ -243,7 +244,7 @@ def test_instability_cpu_gpu(test_context):
     print(f"Growth rate {b*1E4} [$10^{-4}$/turn]")
 
     print(f'{gr_pyht=}, {gr_xtpyht=} {gr_pyht-gr_xtpyht=}')
-    assert np.isclose(gr_xtpyht, gr_pyht, rtol=1e-3, atol=1e-100)
+    xo.assert_allclose(gr_xtpyht, gr_pyht, rtol=1e-3, atol=1e-100)
 
     xp.disable_pyheadtail_interface() # would stay enabled for following tests
                                       # called by pytest

--- a/tests/test_radial_steering.py
+++ b/tests/test_radial_steering.py
@@ -1,8 +1,8 @@
-import numpy as np
 import pathlib
 
-import xtrack as xt
+import xobjects as xo
 import xpart as xp
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
@@ -59,5 +59,5 @@ def test_radial_steering(test_context):
     print(f'tw_6d_offmom.delta[0]: {tw_6d_offmom.delta[0]}')
     print(f'tw_6d_offmom.ptau[0]: {tw_6d_offmom.ptau[0]}')
 
-    assert np.isclose(delta_trim, tw_6d_offmom.delta[0], rtol=1e-3, atol=0)
-    assert np.isclose(dzeta, dzeta_from_twiss, rtol=1e-3, atol=0)
+    xo.assert_allclose(delta_trim, tw_6d_offmom.delta[0], rtol=1e-3, atol=0)
+    xo.assert_allclose(dzeta, dzeta_from_twiss, rtol=1e-3, atol=0)

--- a/tests/test_radiation.py
+++ b/tests/test_radiation.py
@@ -4,14 +4,15 @@
 # ######################################### #
 
 import pathlib
+
 import numpy as np
-from scipy.constants import e as qe
 from scipy.constants import c as clight
+from scipy.constants import e as qe
 from scipy.constants import epsilon_0, hbar
 
+import xobjects as xo
 import xpart as xp
 import xtrack as xt
-import xobjects as xo
 from xobjects.test_helpers import for_all_test_contexts
 from xpart.test_helpers import flaky_assertions, retry
 
@@ -65,7 +66,7 @@ def test_radiation(test_context):
     dct_ave = particles_ave.to_dict()
     dct_rng = particles_rnd.to_dict()
 
-    assert np.allclose(dct_ave['delta'], np.mean(dct_rng['delta']),
+    xo.assert_allclose(dct_ave['delta'], np.mean(dct_rng['delta']),
                     atol=0, rtol=5e-3)
 
     rho_0 = L_bend/theta_bend
@@ -76,7 +77,7 @@ def test_radiation(test_context):
     Delta_E_eV = -Ps*(L_bend/clight) / qe
     Delta_E_trk = (dct_ave['ptau']-dct_ave_before['ptau'])*dct_ave['p0c']
 
-    assert np.allclose(Delta_E_eV, Delta_E_trk, atol=0, rtol=4e-5)
+    xo.assert_allclose(Delta_E_eV, Delta_E_trk, atol=0, rtol=4e-5)
 
     # Check photons
     line=xt.Line(elements=[
@@ -108,7 +109,7 @@ def test_radiation(test_context):
                                                             )*particles_test.p0c
         n_recorded = record._index.num_recorded
         assert n_recorded < record_capacity
-        assert np.allclose(-np.sum(Delta_E_test),
+        xo.assert_allclose(-np.sum(Delta_E_test),
                         np.sum(record.photon_energy[:n_recorded]),
                         atol=0, rtol=1e-6)
 
@@ -131,8 +132,8 @@ def test_radiation(test_context):
     mean_photon_energy_sq = sum_photon_energy_sq / tot_n_recorded
     std_photon_energy = np.sqrt(mean_photon_energy_sq - mean_photon_energy**2)
 
-    assert np.isclose(mean_photon_energy, E_ave_eV, rtol=1e-2, atol=0)
-    assert np.isclose(std_photon_energy,
+    xo.assert_allclose(mean_photon_energy, E_ave_eV, rtol=1e-2, atol=0)
+    xo.assert_allclose(std_photon_energy,
                       np.sqrt(E_sq_ave_eV - E_ave_eV**2), rtol=2e-3, atol=0)
 
 
@@ -189,30 +190,30 @@ def test_ring_with_radiation(test_context):
     met = mad_emit_table
 
     with flaky_assertions():
-        assert np.isclose(tw['eneloss_turn'], mad_emit_summ.u0[0]*1e9,
+        xo.assert_allclose(tw['eneloss_turn'], mad_emit_summ.u0[0]*1e9,
                         rtol=3e-3, atol=0)
-        assert np.isclose(tw['damping_constants_s'][0],
+        xo.assert_allclose(tw['damping_constants_s'][0],
             met[met.loc[:, 'parameter']=='damping_constant']['mode1'].iloc[0],
             rtol=3e-3, atol=0
             )
-        assert np.isclose(tw['damping_constants_s'][1],
+        xo.assert_allclose(tw['damping_constants_s'][1],
             met[met.loc[:, 'parameter']=='damping_constant']['mode2'].iloc[0],
             rtol=1e-3, atol=0
             )
-        assert np.isclose(tw['damping_constants_s'][2],
+        xo.assert_allclose(tw['damping_constants_s'][2],
             met[met.loc[:, 'parameter']=='damping_constant']['mode3'].iloc[0],
             rtol=3e-3, atol=0
             )
 
-        assert np.isclose(tw['partition_numbers'][0],
+        xo.assert_allclose(tw['partition_numbers'][0],
             met[met.loc[:, 'parameter']=='damping_partion']['mode1'].iloc[0],
             rtol=3e-3, atol=0
             )
-        assert np.isclose(tw['partition_numbers'][1],
+        xo.assert_allclose(tw['partition_numbers'][1],
             met[met.loc[:, 'parameter']=='damping_partion']['mode2'].iloc[0],
             rtol=1e-3, atol=0
             )
-        assert np.isclose(tw['partition_numbers'][2],
+        xo.assert_allclose(tw['partition_numbers'][2],
             met[met.loc[:, 'parameter']=='damping_partion']['mode3'].iloc[0],
             rtol=3e-3, atol=0
             )
@@ -233,12 +234,12 @@ def test_ring_with_radiation(test_context):
     mon = line.record_last_track
 
     with flaky_assertions():
-        assert np.isclose(np.std(mon.zeta[:, 750:]),
+        xo.assert_allclose(np.std(mon.zeta[:, 750:]),
             np.sqrt(met[met.loc[:, 'parameter']=='emittance']['mode3'][0] * np.abs(tw['bets0'])),
             rtol=0.2, atol=0
             )
 
-        assert np.isclose(np.std(mon.x[:, 750:]),
+        xo.assert_allclose(np.std(mon.x[:, 750:]),
             np.sqrt(met[met.loc[:, 'parameter']=='emittance']['mode1'][0] * tw['betx'][0]),
             rtol=0.2, atol=0
             )
@@ -264,14 +265,14 @@ def test_ring_with_radiation(test_context):
     pgen.move(_context=xo.ContextCpu())
 
     with flaky_assertions():
-        assert np.isclose(np.std(pgen.x),
+        xo.assert_allclose(np.std(pgen.x),
                         np.sqrt(tw['dx'][0]**2*np.std(pgen.delta)**2
                                 + tw['betx'][0]*nemitt_x/mad.sequence.ring.beam.gamma),
                         atol=0, rtol=1e-2)
 
-        assert np.isclose(np.std(pgen.y),
+        xo.assert_allclose(np.std(pgen.y),
                         np.sqrt(tw['dy'][0]**2*np.std(pgen.delta)**2
                                 + tw['bety'][0]*nemitt_y/mad.sequence.ring.beam.gamma),
                         atol=0, rtol=1e-2)
 
-        assert np.isclose(np.std(pgen.zeta), sigma_z, atol=0, rtol=5e-3)
+        xo.assert_allclose(np.std(pgen.zeta), sigma_z, atol=0, rtol=5e-3)

--- a/tests/test_radiation_equilibrium_emittances.py
+++ b/tests/test_radiation_equilibrium_emittances.py
@@ -1,9 +1,10 @@
 import pathlib
-import pytest
 
 import numpy as np
-import xtrack as xt
+import pytest
+
 import xobjects as xo
+import xtrack as xt
 
 test_data_folder = pathlib.Path(
         __file__).parent.joinpath('../test_data').absolute()
@@ -119,34 +120,34 @@ def test_eq_emitt(conf):
     # for regression testing
     checked = False
     if not tilt_machine_by_90_degrees and not vertical_orbit_distortion and not wiggler_on:
-        assert np.isclose(ex, 7.0592e-10, atol=0,     rtol=1e-4)
-        assert np.isclose(ey, 0,          atol=1e-14, rtol=0)
-        assert np.isclose(ez, 3.6000e-6,  atol=0,     rtol=1e-4)
+        xo.assert_allclose(ex, 7.0592e-10, atol=0,     rtol=1e-4)
+        xo.assert_allclose(ey, 0,          atol=1e-14, rtol=0)
+        xo.assert_allclose(ez, 3.6000e-6,  atol=0,     rtol=1e-4)
         checked = True
     elif tilt_machine_by_90_degrees and not vertical_orbit_distortion and not wiggler_on:
-        assert np.isclose(ex, 0,          atol=1e-14, rtol=0)
-        assert np.isclose(ey, 7.0592e-10, atol=0,     rtol=1e-4)
-        assert np.isclose(ez, 3.6000e-6,  atol=0,     rtol=1e-4)
+        xo.assert_allclose(ex, 0,          atol=1e-14, rtol=0)
+        xo.assert_allclose(ey, 7.0592e-10, atol=0,     rtol=1e-4)
+        xo.assert_allclose(ez, 3.6000e-6,  atol=0,     rtol=1e-4)
         checked = True
     elif not tilt_machine_by_90_degrees and not vertical_orbit_distortion and wiggler_on:
-        assert np.isclose(ex, 6.9954e-10, atol=0,     rtol=1e-4)
-        assert np.isclose(ey, 5.8575e-13, atol=0,     rtol=4e-3)
-        assert np.isclose(ez, 3.8595e-6,  atol=0,     rtol=1e-4)
+        xo.assert_allclose(ex, 6.9954e-10, atol=0,     rtol=1e-4)
+        xo.assert_allclose(ey, 5.8575e-13, atol=0,     rtol=4e-3)
+        xo.assert_allclose(ez, 3.8595e-6,  atol=0,     rtol=1e-4)
         checked = True
     elif tilt_machine_by_90_degrees and not vertical_orbit_distortion and wiggler_on:
-        assert np.isclose(ex, 5.8575e-13, atol=0,     rtol=4e-3)  # Quite large, to be kept in mind
-        assert np.isclose(ey, 6.9955e-10, atol=0,     rtol=1e-4)
-        assert np.isclose(ez, 3.8595e-6,  atol=0,     rtol=1e-4)
+        xo.assert_allclose(ex, 5.8575e-13, atol=0,     rtol=4e-3)  # Quite large, to be kept in mind
+        xo.assert_allclose(ey, 6.9955e-10, atol=0,     rtol=1e-4)
+        xo.assert_allclose(ez, 3.8595e-6,  atol=0,     rtol=1e-4)
         checked = True
     elif not tilt_machine_by_90_degrees and vertical_orbit_distortion and not wiggler_on:
-        assert np.isclose(ex, 7.0576e-10, atol=0,     rtol=1e-4)
-        assert np.isclose(ey, 2.5039e-12, atol=0,     rtol=4e-3)
-        assert np.isclose(ez, 3.5766e-6,  atol=0,     rtol=1e-4)
+        xo.assert_allclose(ex, 7.0576e-10, atol=0,     rtol=1e-4)
+        xo.assert_allclose(ey, 2.5039e-12, atol=0,     rtol=4e-3)
+        xo.assert_allclose(ez, 3.5766e-6,  atol=0,     rtol=1e-4)
         checked = True
     elif tilt_machine_by_90_degrees and vertical_orbit_distortion and not wiggler_on:
-        assert np.isclose(ex, 2.5039e-12, atol=0,     rtol=4e-3)
-        assert np.isclose(ey, 7.0576e-10, atol=0,     rtol=1e-4)
-        assert np.isclose(ez, 3.5763e-6,  atol=0,     rtol=1e-4)
+        xo.assert_allclose(ex, 2.5039e-12, atol=0,     rtol=4e-3)
+        xo.assert_allclose(ey, 7.0576e-10, atol=0,     rtol=1e-4)
+        xo.assert_allclose(ez, 3.5763e-6,  atol=0,     rtol=1e-4)
         checked = True
     else:
         raise ValueError('Unknown configuration')
@@ -165,19 +166,19 @@ def test_eq_emitt(conf):
     assert 'dqx' not in tw_rad2
 
     if not vertical_orbit_distortion: # Known inconsistency to be investigated
-        assert np.isclose(tw_rad2.eq_gemitt_x, tw_rad.eq_gemitt_x, atol=1e-14, rtol=1.5e-2)
-        assert np.isclose(tw_rad2.eq_gemitt_y, tw_rad.eq_gemitt_y, atol=1e-14, rtol=1.5e-2)
-        assert np.isclose(tw_rad2.eq_gemitt_zeta, tw_rad.eq_gemitt_zeta, atol=1e-14, rtol=4e-2)
-        assert np.isclose(tw_rad2.eq_nemitt_x/tw_rad.gamma0, tw_rad.eq_nemitt_x/tw_rad.gamma0, atol=1e-15, rtol=1.5e-2)
-        assert np.isclose(tw_rad2.eq_nemitt_y/tw_rad.gamma0, tw_rad.eq_nemitt_y/tw_rad.gamma0, atol=1e-15, rtol=1.5e-2)
-        assert np.isclose(tw_rad2.eq_nemitt_zeta/tw_rad.gamma0, tw_rad.eq_nemitt_zeta/tw_rad.gamma0, atol=1e-15, rtol=4e-2)
+        xo.assert_allclose(tw_rad2.eq_gemitt_x, tw_rad.eq_gemitt_x, atol=1e-14, rtol=1.5e-2)
+        xo.assert_allclose(tw_rad2.eq_gemitt_y, tw_rad.eq_gemitt_y, atol=1e-14, rtol=1.5e-2)
+        xo.assert_allclose(tw_rad2.eq_gemitt_zeta, tw_rad.eq_gemitt_zeta, atol=1e-14, rtol=4e-2)
+        xo.assert_allclose(tw_rad2.eq_nemitt_x/tw_rad.gamma0, tw_rad.eq_nemitt_x/tw_rad.gamma0, atol=1e-15, rtol=1.5e-2)
+        xo.assert_allclose(tw_rad2.eq_nemitt_y/tw_rad.gamma0, tw_rad.eq_nemitt_y/tw_rad.gamma0, atol=1e-15, rtol=1.5e-2)
+        xo.assert_allclose(tw_rad2.eq_nemitt_zeta/tw_rad.gamma0, tw_rad.eq_nemitt_zeta/tw_rad.gamma0, atol=1e-15, rtol=4e-2)
 
-    assert np.isclose(tw_rad.eq_nemitt_x, tw_rad.eq_gemitt_x * (tw_rad.gamma0*tw_rad.beta0), atol=1e-16, rtol=0)
-    assert np.isclose(tw_rad.eq_nemitt_y, tw_rad.eq_gemitt_y * (tw_rad.gamma0*tw_rad.beta0), atol=1e-16, rtol=0)
-    assert np.isclose(tw_rad.eq_nemitt_zeta, tw_rad.eq_gemitt_zeta * (tw_rad.gamma0*tw_rad.beta0), atol=1e-16, rtol=0)
-    assert np.isclose(tw_rad2.eq_nemitt_x, tw_rad2.eq_gemitt_x * (tw_rad2.gamma0*tw_rad2.beta0), atol=1e-16, rtol=0)
-    assert np.isclose(tw_rad2.eq_nemitt_y, tw_rad2.eq_gemitt_y * (tw_rad2.gamma0*tw_rad2.beta0), atol=1e-16, rtol=0)
-    assert np.isclose(tw_rad2.eq_nemitt_zeta, tw_rad2.eq_gemitt_zeta * (tw_rad2.gamma0*tw_rad2.beta0), atol=1e-16, rtol=0)
+    xo.assert_allclose(tw_rad.eq_nemitt_x, tw_rad.eq_gemitt_x * (tw_rad.gamma0*tw_rad.beta0), atol=1e-16, rtol=0)
+    xo.assert_allclose(tw_rad.eq_nemitt_y, tw_rad.eq_gemitt_y * (tw_rad.gamma0*tw_rad.beta0), atol=1e-16, rtol=0)
+    xo.assert_allclose(tw_rad.eq_nemitt_zeta, tw_rad.eq_gemitt_zeta * (tw_rad.gamma0*tw_rad.beta0), atol=1e-16, rtol=0)
+    xo.assert_allclose(tw_rad2.eq_nemitt_x, tw_rad2.eq_gemitt_x * (tw_rad2.gamma0*tw_rad2.beta0), atol=1e-16, rtol=0)
+    xo.assert_allclose(tw_rad2.eq_nemitt_y, tw_rad2.eq_gemitt_y * (tw_rad2.gamma0*tw_rad2.beta0), atol=1e-16, rtol=0)
+    xo.assert_allclose(tw_rad2.eq_nemitt_zeta, tw_rad2.eq_gemitt_zeta * (tw_rad2.gamma0*tw_rad2.beta0), atol=1e-16, rtol=0)
 
     if conf['check_against_tracking']:
 
@@ -204,6 +205,6 @@ def test_eq_emitt(conf):
             assert np.min(np.abs(sigma_y_track/sigma_y_eq - 1.)) < 0.1
         assert np.min(np.abs(sigma_zeta_track/sigma_zeta_eq - 1.)) < 0.1
 
-        assert np.isclose(sigma_x_eq, np.mean(sigma_x_track), rtol=0.3, atol=1e-9)
-        assert np.isclose(sigma_y_eq, np.mean(sigma_y_track), rtol=0.3, atol=1e-9)
-        assert np.isclose(sigma_zeta_eq, np.mean(sigma_zeta_track), rtol=0.3, atol=1e-9)
+        xo.assert_allclose(sigma_x_eq, np.mean(sigma_x_track), rtol=0.3, atol=1e-9)
+        xo.assert_allclose(sigma_y_eq, np.mean(sigma_y_track), rtol=0.3, atol=1e-9)
+        xo.assert_allclose(sigma_zeta_eq, np.mean(sigma_zeta_track), rtol=0.3, atol=1e-9)

--- a/tests/test_random_gen.py
+++ b/tests/test_random_gen.py
@@ -3,15 +3,15 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
-from pathlib import Path
-
-import numpy as np
 import copy
 
+import numpy as np
+
 import xobjects as xo
-from xobjects.test_helpers import for_all_test_contexts
-import xtrack as xt
 import xpart as xp
+import xtrack as xt
+from xobjects.test_helpers import for_all_test_contexts
+
 
 @for_all_test_contexts
 def test_random_generation(test_context):
@@ -54,7 +54,7 @@ def test_random_generation(test_context):
         assert np.all(x>0)
         assert np.all(x<1)
         hstgm, bin_edges = np.histogram(x,  bins=50, range=(0, 1), density=True)
-        assert np.allclose(hstgm, 1, rtol=1e-10, atol=0.03)
+        xo.assert_allclose(hstgm, 1, rtol=1e-10, atol=0.03)
 
 
 @for_all_test_contexts
@@ -69,7 +69,7 @@ def test_direct_sampling(test_context):
         assert np.all(samples[i_part]>0)
         assert np.all(samples[i_part]<1)
         hstgm, bin_edges = np.histogram(samples[i_part],  bins=50, range=(0, 1), density=True)
-        assert np.allclose(hstgm, 1, rtol=1e-10, atol=0.03)
+        xo.assert_allclose(hstgm, 1, rtol=1e-10, atol=0.03)
 
 
 @for_all_test_contexts

--- a/tests/test_random_gen_exp.py
+++ b/tests/test_random_gen_exp.py
@@ -3,15 +3,15 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
-from pathlib import Path
-
-import numpy as np
 import copy
 
+import numpy as np
+
 import xobjects as xo
-from xobjects.test_helpers import for_all_test_contexts
-import xtrack as xt
 import xpart as xp
+import xtrack as xt
+from xobjects.test_helpers import for_all_test_contexts
+
 
 @for_all_test_contexts
 def test_random_generation(test_context):
@@ -55,7 +55,7 @@ def test_random_generation(test_context):
         hstgm, bin_edges = np.histogram(x,  bins=50, range=(0, 10), density=True)
         bin_centers = (bin_edges[:-1]+bin_edges[1:])/2
         exp = np.exp(-bin_centers)
-        assert np.allclose(hstgm, exp, rtol=1e-10, atol=1E-2)
+        xo.assert_allclose(hstgm, exp, rtol=1e-10, atol=1E-2)
 
 
 @for_all_test_contexts
@@ -71,7 +71,7 @@ def test_direct_sampling(test_context):
         hstgm, bin_edges = np.histogram(samples[i_part],  bins=50, range=(0, 10), density=True)
         bin_centers = (bin_edges[:-1]+bin_edges[1:])/2
         exp = np.exp(-bin_centers)
-        assert np.allclose(hstgm, exp, rtol=1e-10, atol=1E-2)
+        xo.assert_allclose(hstgm, exp, rtol=1e-10, atol=1E-2)
 
 
 @for_all_test_contexts

--- a/tests/test_random_gen_gauss.py
+++ b/tests/test_random_gen_gauss.py
@@ -3,15 +3,15 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
-from pathlib import Path
-
-import numpy as np
 import copy
 
+import numpy as np
+
 import xobjects as xo
-from xobjects.test_helpers import for_all_test_contexts
-import xtrack as xt
 import xpart as xp
+import xtrack as xt
+from xobjects.test_helpers import for_all_test_contexts
+
 
 @for_all_test_contexts
 def test_random_generation(test_context):
@@ -54,7 +54,7 @@ def test_random_generation(test_context):
         hstgm, bin_edges = np.histogram(x,  bins=50, range=(-3, 3), density=True)
         bin_centers = (bin_edges[:-1]+bin_edges[1:])/2
         gauss = np.exp(-bin_centers**2/2)/np.sqrt(2.0*np.pi)
-        assert np.allclose(hstgm, gauss, rtol=1e-10, atol=1E-2)
+        xo.assert_allclose(hstgm, gauss, rtol=1e-10, atol=1E-2)
 
 
 @for_all_test_contexts
@@ -69,7 +69,7 @@ def test_direct_sampling(test_context):
         hstgm, bin_edges = np.histogram(samples[i_part],  bins=50, range=(-3, 3), density=True)
         bin_centers = (bin_edges[:-1]+bin_edges[1:])/2
         gauss = np.exp(-bin_centers**2/2)/np.sqrt(2.0*np.pi)
-        assert np.allclose(hstgm, gauss, rtol=1e-10, atol=1E-2)
+        xo.assert_allclose(hstgm, gauss, rtol=1e-10, atol=1E-2)
 
 
 @for_all_test_contexts

--- a/tests/test_second_order_taylor_map.py
+++ b/tests/test_second_order_taylor_map.py
@@ -6,13 +6,11 @@
 import pathlib
 
 import numpy as np
-import copy
+from cpymad.madx import Madx
 
 import xobjects as xo
-from xobjects.test_helpers import for_all_test_contexts
 import xtrack as xt
-import xpart as xp
-from cpymad.madx import Madx
+from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
         __file__).parent.joinpath('../test_data').absolute()
@@ -39,26 +37,26 @@ def test_line_with_second_order_maps(test_context):
     tw = line.twiss()
     tw_map = line_maps.twiss()
 
-    assert np.allclose(tw_map.rows[ele_cut].s, tw.rows[ele_cut].s, rtol=0, atol=1e-12)
+    xo.assert_allclose(tw_map.rows[ele_cut].s, tw.rows[ele_cut].s, rtol=0, atol=1e-12)
 
-    assert np.allclose(tw_map.rows[ele_cut].x, tw.rows[ele_cut].x, rtol=0, atol=1e-12)
-    assert np.allclose(tw_map.rows[ele_cut].px, tw.rows[ele_cut].px, rtol=0, atol=1e-12)
-    assert np.allclose(tw_map.rows[ele_cut].y, tw.rows[ele_cut].y, rtol=0, atol=1e-12)
-    assert np.allclose(tw_map.rows[ele_cut].py, tw.rows[ele_cut].py, rtol=0, atol=1e-12)
-    assert np.allclose(tw_map.rows[ele_cut].zeta, tw.rows[ele_cut].zeta, rtol=0, atol=1e-10)
-    assert np.allclose(tw_map.rows[ele_cut].delta, tw.rows[ele_cut].delta, rtol=0, atol=1e-12)
+    xo.assert_allclose(tw_map.rows[ele_cut].x, tw.rows[ele_cut].x, rtol=0, atol=1e-12)
+    xo.assert_allclose(tw_map.rows[ele_cut].px, tw.rows[ele_cut].px, rtol=0, atol=1e-12)
+    xo.assert_allclose(tw_map.rows[ele_cut].y, tw.rows[ele_cut].y, rtol=0, atol=1e-12)
+    xo.assert_allclose(tw_map.rows[ele_cut].py, tw.rows[ele_cut].py, rtol=0, atol=1e-12)
+    xo.assert_allclose(tw_map.rows[ele_cut].zeta, tw.rows[ele_cut].zeta, rtol=0, atol=1e-10)
+    xo.assert_allclose(tw_map.rows[ele_cut].delta, tw.rows[ele_cut].delta, rtol=0, atol=1e-12)
 
-    assert np.allclose(tw_map.rows[ele_cut].betx, tw.rows[ele_cut].betx, rtol=1e-5, atol=0)
-    assert np.allclose(tw_map.rows[ele_cut].alfx, tw.rows[ele_cut].alfx, rtol=1e-5, atol=1e-6)
-    assert np.allclose(tw_map.rows[ele_cut].bety, tw.rows[ele_cut].bety, rtol=1e-5, atol=0)
-    assert np.allclose(tw_map.rows[ele_cut].alfy, tw.rows[ele_cut].alfy, rtol=1e-5, atol=1e-6)
+    xo.assert_allclose(tw_map.rows[ele_cut].betx, tw.rows[ele_cut].betx, rtol=1e-5, atol=0)
+    xo.assert_allclose(tw_map.rows[ele_cut].alfx, tw.rows[ele_cut].alfx, rtol=1e-5, atol=1e-6)
+    xo.assert_allclose(tw_map.rows[ele_cut].bety, tw.rows[ele_cut].bety, rtol=1e-5, atol=0)
+    xo.assert_allclose(tw_map.rows[ele_cut].alfy, tw.rows[ele_cut].alfy, rtol=1e-5, atol=1e-6)
 
-    assert np.isclose(np.mod(tw_map.qx, 1), np.mod(tw.qx, 1), rtol=0, atol=1e-7)
-    assert np.isclose(np.mod(tw_map.qy, 1), np.mod(tw.qy, 1), rtol=0, atol=1e-7)
-    assert np.isclose(tw_map.dqx, tw.dqx, rtol=0, atol=5e-2)
-    assert np.isclose(tw_map.dqy, tw.dqy, rtol=0, atol=5e-2)
-    assert np.isclose(tw_map.c_minus, tw.c_minus, rtol=0, atol=1e-5)
-    assert np.isclose(tw_map.circumference, tw.circumference, rtol=0, atol=5e-9)
+    xo.assert_allclose(np.mod(tw_map.qx, 1), np.mod(tw.qx, 1), rtol=0, atol=1e-7)
+    xo.assert_allclose(np.mod(tw_map.qy, 1), np.mod(tw.qy, 1), rtol=0, atol=1e-7)
+    xo.assert_allclose(tw_map.dqx, tw.dqx, rtol=0, atol=5e-2)
+    xo.assert_allclose(tw_map.dqy, tw.dqy, rtol=0, atol=5e-2)
+    xo.assert_allclose(tw_map.c_minus, tw.c_minus, rtol=0, atol=1e-5)
+    xo.assert_allclose(tw_map.circumference, tw.circumference, rtol=0, atol=5e-9)
 
 
 @for_all_test_contexts
@@ -170,7 +168,7 @@ def test_second_order_maps_against_madx(test_context):
             scaled_k = k[ii] / scale_out[ii]
             scaled_k_mad = sectmad[f'k{ii+1}', end] / scale_out[ii]
             # The following means that a the orbit kick is the same within 5e-5 sigmas
-            assert np.isclose(scaled_k, scaled_k_mad, atol=5e-5, rtol=0)
+            xo.assert_allclose(scaled_k, scaled_k_mad, atol=5e-5, rtol=0)
 
         # Check R
         for ii in range(6):
@@ -180,7 +178,7 @@ def test_second_order_maps_against_madx(test_context):
                                     scale_in[jj] / scale_out[ii])
                 # The following means that a change of one sigma in jj results
                 # in an error of less than 5e-4 sigmas on ii
-                assert np.isclose(scaled_rr, scaled_rr_mad, atol=5e-4, rtol=0)
+                xo.assert_allclose(scaled_rr, scaled_rr_mad, atol=5e-4, rtol=0)
 
         # Check T
         for ii in range(6):
@@ -192,6 +190,6 @@ def test_second_order_maps_against_madx(test_context):
                                     / scale_out[ii] * scale_in[jj] * scale_in[kk])
                     # The following means that a change of one sigma in jj, kk results
                     # in an error of less than 5e-4 sigmas on ii
-                    assert np.isclose(scaled_tt, scaled_tt_mad, atol=5e-4, rtol=0)
+                    xo.assert_allclose(scaled_tt, scaled_tt_mad, atol=5e-4, rtol=0)
 
 

--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -2,10 +2,12 @@
 # This file is part of the Xtrack Package.  #
 # Copyright (c) CERN, 2023.                 #
 # ######################################### #
-import numpy as np
-import pytest
 import math
 
+import numpy as np
+import pytest
+
+import xobjects as xo
 import xtrack as xt
 from xtrack.slicing import Strategy, Teapot, Uniform, Custom, Slicer
 
@@ -99,11 +101,11 @@ def test_slicing_custom():
     slicing_3 = Custom(at_s=[0.8, 2, 8], mode='thin')
     expected_dr_3 = [0.8/16, 1.2/16, 6/16, 8/16]
     result_dr_3 = slicing_3.drift_weights(element_length=elem_len_3)
-    assert np.allclose(expected_dr_3, result_dr_3, atol=1e-30)
+    xo.assert_allclose(expected_dr_3, result_dr_3, atol=1e-30)
 
     expected_el_3 = [1/3] * 3
     result_el_3 = slicing_3.element_weights(element_length=elem_len_3)
-    assert np.allclose(expected_el_3, result_el_3, atol=1e-30)
+    xo.assert_allclose(expected_el_3, result_el_3, atol=1e-30)
 
     elem_info = (1/3, False)
     expected_3 = [
@@ -121,7 +123,7 @@ def test_slicing_custom_thick():
     slicing_1 = Custom(at_s=[0.3], mode='thick')
     expected_dr_1 = [0.3 / 1.1, 0.8 / 1.1]
     result_dr_1 = slicing_1.drift_weights(element_length=elem_len_1)
-    assert np.allclose(expected_dr_1, result_dr_1, atol=1e-30)
+    xo.assert_allclose(expected_dr_1, result_dr_1, atol=1e-30)
 
     expected_1 = [
         (0.3 / 1.1, True),
@@ -134,7 +136,7 @@ def test_slicing_custom_thick():
     slicing_3 = Custom(at_s=[0.8, 2, 8])
     expected_dr_3 = [0.8/16, 1.2/16, 6/16, 8/16]
     result_dr_3 = slicing_3.drift_weights(element_length=elem_len_3)
-    assert np.allclose(expected_dr_3, result_dr_3, atol=1e-30)
+    xo.assert_allclose(expected_dr_3, result_dr_3, atol=1e-30)
 
     expected_3 = [
         (0.8/16, True),
@@ -394,8 +396,8 @@ def test_slicing_thick_bend_simple():
 
     # Make sure the order and the inverse factorial make sense:
     _fact = math.factorial
-    assert np.isclose(_fact(bend0._parent.order) * bend0._parent.inv_factorial_order, 1, atol=1e-16)
-    assert np.isclose(_fact(bend1._parent.order) * bend0._parent.inv_factorial_order, 1, atol=1e-16)
+    xo.assert_allclose(_fact(bend0._parent.order) * bend0._parent.inv_factorial_order, 1, atol=1e-16)
+    xo.assert_allclose(_fact(bend1._parent.order) * bend0._parent.inv_factorial_order, 1, atol=1e-16)
 
 
 def test_slicing_thick_bend_into_thick_bends_simple():
@@ -424,17 +426,17 @@ def test_slicing_thick_bend_into_thick_bends_simple():
     assert bend0._parent.k1 == bend1._parent.k1 == 0.2
 
     expected_knl = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
-    assert np.allclose(bend0._parent.knl, expected_knl, atol=1e-16)
-    assert np.allclose(bend1._parent.knl, expected_knl, atol=1e-16)
+    xo.assert_allclose(bend0._parent.knl, expected_knl, atol=1e-16)
+    xo.assert_allclose(bend1._parent.knl, expected_knl, atol=1e-16)
 
     expected_ksl = np.array([0.7, 0.6, 0.5, 0.4, 0.3, 0.2])
-    assert np.allclose(bend0._parent.ksl, expected_ksl, atol=1e-16)
-    assert np.allclose(bend1._parent.ksl, expected_ksl, atol=1e-16)
+    xo.assert_allclose(bend0._parent.ksl, expected_ksl, atol=1e-16)
+    xo.assert_allclose(bend1._parent.ksl, expected_ksl, atol=1e-16)
 
     # Make sure the order and the inverse factorial make sense:
     _fact = math.factorial
-    assert np.isclose(_fact(bend0._parent.order) * bend0._parent.inv_factorial_order, 1, atol=1e-16)
-    assert np.isclose(_fact(bend1._parent.order) * bend0._parent.inv_factorial_order, 1, atol=1e-16)
+    xo.assert_allclose(_fact(bend0._parent.order) * bend0._parent.inv_factorial_order, 1, atol=1e-16)
+    xo.assert_allclose(_fact(bend1._parent.order) * bend0._parent.inv_factorial_order, 1, atol=1e-16)
 
 
 def test_slicing_xdeps_consistency():

--- a/tests/test_solenoid_bz_map_vs_boris.py
+++ b/tests/test_solenoid_bz_map_vs_boris.py
@@ -1,13 +1,13 @@
 import numpy as np
-
 from scipy.constants import c as clight
 from scipy.constants import e as qe
 from scipy.constants import epsilon_0 as eps0
 
 import xobjects as xo
 import xtrack as xt
-from xtrack._temp.boris_and_solenoid_map.solenoid_field import SolenoidField
 from xobjects.test_helpers import for_all_test_contexts
+from xtrack._temp.boris_and_solenoid_map.solenoid_field import SolenoidField
+
 
 @for_all_test_contexts
 def test_solenoid_bz_map_vs_boris(test_context):
@@ -233,21 +233,21 @@ def test_solenoid_bz_map_vs_boris(test_context):
         this_dx_ds = dx_ds[i_part, :]
         this_dy_ds = dy_ds[i_part, :]
 
-        assert np.allclose(dx_ds_xsuite_check, dx_ds_boris_check, rtol=0,
+        xo.assert_allclose(dx_ds_xsuite_check, dx_ds_boris_check, rtol=0,
                 atol=2.8e-2 * (np.max(dx_ds_boris_check) - np.min(dx_ds_boris_check)))
-        assert np.allclose(dy_ds_xsuite_check, dy_ds_boris_check, rtol=0,
+        xo.assert_allclose(dy_ds_xsuite_check, dy_ds_boris_check, rtol=0,
                 atol=2.8e-2 * (np.max(dy_ds_boris_check) - np.min(dy_ds_boris_check)))
-        assert np.allclose(dE_ds_xsuite_check, dE_ds_boris_check, rtol=0,
+        xo.assert_allclose(dE_ds_xsuite_check, dE_ds_boris_check, rtol=0,
                 atol=1e-2 * (np.max(dE_ds_boris_check) - np.min(dE_ds_boris_check)))
 
-        assert np.allclose(ax_ref[i_part, :], mon.ax[i_part, :],
+        xo.assert_allclose(ax_ref[i_part, :], mon.ax[i_part, :],
                         rtol=0, atol=np.max(np.abs(ax_ref)*3e-2))
-        assert np.allclose(ay_ref[i_part, :], mon.ay[i_part, :],
+        xo.assert_allclose(ay_ref[i_part, :], mon.ay[i_part, :],
                         rtol=0, atol=np.max(np.abs(ay_ref)*3e-2))
 
-        assert np.allclose(this_emitted_dpx,
+        xo.assert_allclose(this_emitted_dpx,
                 this_dE_ds * this_dx_ds * np.diff(mon.s[i_part, :])/p.p0c[0],
                 rtol=0, atol=1e-4 * (np.max(this_emitted_dpx) - np.min(this_emitted_dpx)))
-        assert np.allclose(this_emitted_dpy,
+        xo.assert_allclose(this_emitted_dpy,
                 this_dE_ds * this_dy_ds * np.diff(mon.s[i_part, :])/p.p0c[0],
                 rtol=0, atol=2e-3 * (np.max(this_emitted_dpy) - np.min(this_emitted_dpy)))

--- a/tests/test_spacecharge_in_ring.py
+++ b/tests/test_spacecharge_in_ring.py
@@ -5,9 +5,10 @@
 
 import json
 import pathlib
-import pytest
 
 import numpy as np
+import pytest
+
 import xfields as xf
 import xobjects as xo
 import xpart as xp
@@ -208,8 +209,8 @@ def test_ring_with_spacecharge(test_context, mode):
           f'ey={(qy_probe - qy_target)/1e-3:.6f}e-3')
 
     with flaky_assertions():
-        assert np.isclose(qx_probe, qx_target, atol=5e-4, rtol=0)
-        assert np.isclose(qy_probe, qy_target, atol=5e-4, rtol=0)
+        xo.assert_allclose(qx_probe, qx_target, atol=5e-4, rtol=0)
+        xo.assert_allclose(qy_probe, qy_target, atol=5e-4, rtol=0)
 
     if mode == 'pic_average_transverse':
         sc_test = all_pics[50]
@@ -218,7 +219,7 @@ def test_ring_with_spacecharge(test_context, mode):
         for dtest in [sc_test.fieldmap.dphi_dx, sc_test.fieldmap.dphi_dy]:
             # Check that the normalized electric field is the same
             dtest = ctx2np(dtest)
-            assert np.allclose(
+            xo.assert_allclose(
                 dtest[:, :, 3] / np.max(dtest[:, :, 3]),
                 dtest[:, :, 4] / np.max(dtest[:, :, 4]),
                 atol=1e-10, rtol=1e-5)

--- a/tests/test_sps_thick.py
+++ b/tests/test_sps_thick.py
@@ -2,13 +2,13 @@ import pathlib
 
 import numpy as np
 import pytest
-
 from cpymad.madx import Madx
 
+import xobjects as xo
 import xpart as xp
 import xtrack as xt
-from xtrack.slicing import Strategy, Teapot
 from xobjects.test_helpers import for_all_test_contexts
+from xtrack.slicing import Strategy, Teapot
 
 test_data_folder = pathlib.Path(
         __file__).parent.joinpath('../test_data').absolute()
@@ -43,15 +43,15 @@ def test_sps_thick(test_context, deferred_expressions):
     assert line['mbb.10150'].model == 'adaptive'
 
     ang = line['mbb.10150'].k0 * line['mbb.10150'].length
-    assert np.isclose(line['mbb.10150'].edge_entry_angle, ang / 2, atol=1e-11, rtol=0)
-    assert np.isclose(line['mbb.10150'].edge_exit_angle, ang / 2, atol=1e-11, rtol=0)
+    xo.assert_allclose(line['mbb.10150'].edge_entry_angle, ang / 2, atol=1e-11, rtol=0)
+    xo.assert_allclose(line['mbb.10150'].edge_exit_angle, ang / 2, atol=1e-11, rtol=0)
 
     tw = line.twiss()
-    assert np.isclose(twmad.s[-1], tw.s[-1], atol=1e-9, rtol=0)
-    assert np.isclose(twmad.summary.q1, tw.qx, rtol=0, atol=1e-7)
-    assert np.isclose(twmad.summary.q2, tw.qy, rtol=0, atol=1e-7)
-    assert np.isclose(twmad.summary.dq1, tw.dqx, rtol=0, atol=0.2)
-    assert np.isclose(twmad.summary.dq2, tw.dqy, rtol=0, atol=0.2)
+    xo.assert_allclose(twmad.s[-1], tw.s[-1], atol=1e-9, rtol=0)
+    xo.assert_allclose(twmad.summary.q1, tw.qx, rtol=0, atol=1e-7)
+    xo.assert_allclose(twmad.summary.q2, tw.qy, rtol=0, atol=1e-7)
+    xo.assert_allclose(twmad.summary.dq1, tw.dqx, rtol=0, atol=0.2)
+    xo.assert_allclose(twmad.summary.dq2, tw.dqy, rtol=0, atol=0.2)
 
     line.configure_bend_model(edge='full', core='full')
 
@@ -61,11 +61,11 @@ def test_sps_thick(test_context, deferred_expressions):
     assert line['mbb.10150'].edge_exit_model == 'full'
     assert line['mbb.10150'].model == 'full'
 
-    assert np.isclose(twmad.s[-1], tw.s[-1], atol=1e-9, rtol=0)
-    assert np.isclose(twmad.summary.q1, tw.qx, rtol=0, atol=1e-7)
-    assert np.isclose(twmad.summary.q2, tw.qy, rtol=0, atol=1e-7)
-    assert np.isclose(twmad.summary.dq1, tw.dqx, rtol=0, atol=0.01)
-    assert np.isclose(twmad.summary.dq2, tw.dqy, rtol=0, atol=0.01)
+    xo.assert_allclose(twmad.s[-1], tw.s[-1], atol=1e-9, rtol=0)
+    xo.assert_allclose(twmad.summary.q1, tw.qx, rtol=0, atol=1e-7)
+    xo.assert_allclose(twmad.summary.q2, tw.qy, rtol=0, atol=1e-7)
+    xo.assert_allclose(twmad.summary.dq1, tw.dqx, rtol=0, atol=0.01)
+    xo.assert_allclose(twmad.summary.dq2, tw.dqy, rtol=0, atol=0.01)
 
     line.configure_bend_model(core='expanded')
 
@@ -75,11 +75,11 @@ def test_sps_thick(test_context, deferred_expressions):
     assert line['mbb.10150'].edge_exit_model == 'full'
     assert line['mbb.10150'].model == 'expanded'
 
-    assert np.isclose(twmad.s[-1], tw.s[-1], atol=1e-9, rtol=0)
-    assert np.isclose(twmad.summary.q1, tw.qx, rtol=0, atol=1e-7)
-    assert np.isclose(twmad.summary.q2, tw.qy, rtol=0, atol=1e-7)
-    assert np.isclose(twmad.summary.dq1, tw.dqx, rtol=0, atol=0.2)
-    assert np.isclose(twmad.summary.dq2, tw.dqy, rtol=0, atol=0.2)
+    xo.assert_allclose(twmad.s[-1], tw.s[-1], atol=1e-9, rtol=0)
+    xo.assert_allclose(twmad.summary.q1, tw.qx, rtol=0, atol=1e-7)
+    xo.assert_allclose(twmad.summary.q2, tw.qy, rtol=0, atol=1e-7)
+    xo.assert_allclose(twmad.summary.dq1, tw.dqx, rtol=0, atol=0.2)
+    xo.assert_allclose(twmad.summary.dq2, tw.dqy, rtol=0, atol=0.2)
 
     line.configure_bend_model(edge='linear')
 
@@ -171,19 +171,19 @@ def test_sps_thick(test_context, deferred_expressions):
 
     tw_edge_full = line.twiss()
 
-    assert np.isclose(twmad.s[-1], tw_edge_full.s[-1], atol=1e-9, rtol=0)
-    assert np.isclose(twmad.summary.q1, tw_edge_full.qx, rtol=0, atol=0.5e-3)
-    assert np.isclose(twmad.summary.q2, tw_edge_full.qy, rtol=0, atol=0.5e-3)
-    assert np.isclose(twmad.summary.dq1, tw_edge_full.dqx, rtol=0, atol=0.2)
-    assert np.isclose(twmad.summary.dq2, tw_edge_full.dqy, rtol=0, atol=0.2)
+    xo.assert_allclose(twmad.s[-1], tw_edge_full.s[-1], atol=1e-9, rtol=0)
+    xo.assert_allclose(twmad.summary.q1, tw_edge_full.qx, rtol=0, atol=0.5e-3)
+    xo.assert_allclose(twmad.summary.q2, tw_edge_full.qy, rtol=0, atol=0.5e-3)
+    xo.assert_allclose(twmad.summary.dq1, tw_edge_full.dqx, rtol=0, atol=0.2)
+    xo.assert_allclose(twmad.summary.dq2, tw_edge_full.dqy, rtol=0, atol=0.2)
 
     line.configure_bend_model(edge='linear')
     tw_edge_linear = line.twiss()
-    assert np.isclose(twmad.s[-1], tw_edge_linear.s[-1], atol=1e-9, rtol=0)
-    assert np.isclose(twmad.summary.q1, tw_edge_linear.qx, rtol=0, atol=0.5e-3)
-    assert np.isclose(twmad.summary.q2, tw_edge_linear.qy, rtol=0, atol=0.5e-3)
-    assert np.isclose(twmad.summary.dq1, tw_edge_linear.dqx, rtol=0, atol=0.2)
-    assert np.isclose(twmad.summary.dq2, tw_edge_linear.dqy, rtol=0, atol=0.2)
+    xo.assert_allclose(twmad.s[-1], tw_edge_linear.s[-1], atol=1e-9, rtol=0)
+    xo.assert_allclose(twmad.summary.q1, tw_edge_linear.qx, rtol=0, atol=0.5e-3)
+    xo.assert_allclose(twmad.summary.q2, tw_edge_linear.qy, rtol=0, atol=0.5e-3)
+    xo.assert_allclose(twmad.summary.dq1, tw_edge_linear.dqx, rtol=0, atol=0.2)
+    xo.assert_allclose(twmad.summary.dq2, tw_edge_linear.dqy, rtol=0, atol=0.2)
 
     tw_backwards = line.twiss(start=line.element_names[0],
                 end=line.element_names[-1],

--- a/tests/test_tapering.py
+++ b/tests/test_tapering.py
@@ -1,6 +1,9 @@
 import json
 import pathlib
+
 import numpy as np
+
+import xobjects as xo
 import xtrack as xt
 
 test_data_folder = pathlib.Path(
@@ -78,48 +81,48 @@ def test_tapering_and_twiss_with_radiation():
         assert np.sum(mask_taperable) == 17420
 
         delta_taper = line.attr['delta_taper']
-        assert np.allclose(delta_taper[mask_taperable],
+        xo.assert_allclose(delta_taper[mask_taperable],
             0.5*(tw.delta[:-1] + tw.delta[1:])[mask_taperable], rtol=0, atol=1e-6)
 
-        assert np.isclose(tw.delta[0], 0, rtol=0, atol=1e-6)
-        assert np.isclose(tw.delta[-1], 0, rtol=0, atol=1e-6)
+        xo.assert_allclose(tw.delta[0], 0, rtol=0, atol=1e-6)
+        xo.assert_allclose(tw.delta[-1], 0, rtol=0, atol=1e-6)
 
-        assert np.isclose(tw.qx, tw_no_rad.qx, rtol=0, atol=conf['q_atol'])
-        assert np.isclose(tw.qy, tw_no_rad.qy, rtol=0, atol=conf['q_atol'])
+        xo.assert_allclose(tw.qx, tw_no_rad.qx, rtol=0, atol=conf['q_atol'])
+        xo.assert_allclose(tw.qy, tw_no_rad.qy, rtol=0, atol=conf['q_atol'])
 
-        assert np.isclose(tw.dqx, tw_no_rad.dqx, rtol=0, atol=1.5e-2*tw.qx)
-        assert np.isclose(tw.dqy, tw_no_rad.dqy, rtol=0, atol=1.5e-2*tw.qy)
+        xo.assert_allclose(tw.dqx, tw_no_rad.dqx, rtol=0, atol=1.5e-2*tw.qx)
+        xo.assert_allclose(tw.dqy, tw_no_rad.dqy, rtol=0, atol=1.5e-2*tw.qy)
 
-        assert np.allclose(tw.x, tw_no_rad.x, rtol=0, atol=1e-7)
-        assert np.allclose(tw.y, tw_no_rad.y, rtol=0, atol=1e-7)
+        xo.assert_allclose(tw.x, tw_no_rad.x, rtol=0, atol=1e-7)
+        xo.assert_allclose(tw.y, tw_no_rad.y, rtol=0, atol=1e-7)
 
-        assert np.allclose(tw.betx*p0corr, tw_no_rad.betx, rtol=conf['beta_rtol'], atol=0)
-        assert np.allclose(tw.bety*p0corr, tw_no_rad.bety, rtol=conf['beta_rtol'], atol=0)
+        xo.assert_allclose(tw.betx*p0corr, tw_no_rad.betx, rtol=conf['beta_rtol'], atol=0)
+        xo.assert_allclose(tw.bety*p0corr, tw_no_rad.bety, rtol=conf['beta_rtol'], atol=0)
 
-        assert np.allclose(tw.dx, tw.dx, rtol=0.0, atol=0.1e-3)
+        xo.assert_allclose(tw.dx, tw.dx, rtol=0.0, atol=0.1e-3)
 
-        assert np.allclose(tw.dy, tw.dy, rtol=0.0, atol=0.1e-3)
+        xo.assert_allclose(tw.dy, tw.dy, rtol=0.0, atol=0.1e-3)
 
-        assert np.allclose(tw.s[i_ele], tws.s, rtol=0, atol=1e-7)
-        assert np.allclose(tw.x[i_ele], tws.x, rtol=0, atol=1e-7)
-        assert np.allclose(tw.y[i_ele], tws.y, rtol=0, atol=1e-7)
-        assert np.allclose(tw.betx[i_ele], tws.betx, rtol=1e-3, atol=0)
-        assert np.allclose(tw.bety[i_ele], tws.bety, rtol=1e-3, atol=0)
+        xo.assert_allclose(tw.s[i_ele], tws.s, rtol=0, atol=1e-7)
+        xo.assert_allclose(tw.x[i_ele], tws.x, rtol=0, atol=1e-7)
+        xo.assert_allclose(tw.y[i_ele], tws.y, rtol=0, atol=1e-7)
+        xo.assert_allclose(tw.betx[i_ele], tws.betx, rtol=1e-3, atol=0)
+        xo.assert_allclose(tw.bety[i_ele], tws.bety, rtol=1e-3, atol=0)
 
         eneloss = tw.eneloss_turn
         assert eneloss/line.particle_ref.energy0 > 0.01
-        assert np.isclose(
+        xo.assert_allclose(
             line['rf'].voltage*np.sin((line['rf'].lag + line['rf'].lag_taper)/180*np.pi),
             eneloss/4, rtol=1e-5)
-        assert np.isclose(
+        xo.assert_allclose(
             line['rf1'].voltage*np.sin((line['rf'].lag + line['rf'].lag_taper)/180*np.pi),
             eneloss/4, rtol=1e-5)
-        assert np.isclose(
+        xo.assert_allclose(
             line['rf2a'].voltage*np.sin((line['rf'].lag + line['rf'].lag_taper)/180*np.pi),
             eneloss/4*0.6, rtol=1e-5)
-        assert np.isclose(
+        xo.assert_allclose(
             line['rf2b'].voltage*np.sin((line['rf'].lag + line['rf'].lag_taper)/180*np.pi),
             eneloss/4*0.4, rtol=1e-5)
-        assert np.isclose(
+        xo.assert_allclose(
             line['rf3'].voltage*np.sin((line['rf'].lag + line['rf'].lag_taper)/180*np.pi),
             eneloss/4, rtol=1e-5)

--- a/tests/test_thick_lhc.py
+++ b/tests/test_thick_lhc.py
@@ -1,14 +1,13 @@
 import pathlib
 
 from cpymad.madx import Madx
-import xtrack as xt
-import xpart as xp
+
 import xdeps as xd
-from xtrack.slicing import Teapot, Strategy
-
+import xobjects as xo
+import xpart as xp
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
-
-import numpy as np
+from xtrack.slicing import Teapot, Strategy
 
 test_data_folder = pathlib.Path(
         __file__).parent.joinpath('../test_data').absolute()
@@ -57,14 +56,14 @@ def test_madloader_lhc_thick(test_context):
     print(f'dqy xsuite:      {tw0.dqy}')
     print(f'dqy mad nochrom: {twmad.summary.dq2}')
 
-    assert np.isclose(tw0.dqx, twmad.summary.dq1, atol=0.2, rtol=0)
-    assert np.isclose(tw0.dqy, twmad.summary.dq2, atol=0.2, rtol=0)
-    assert np.isclose(tw0.qx, twmad.summary.q1, atol=1e-6, rtol=0)
-    assert np.isclose(tw0.qy, twmad.summary.q2, atol=1e-6, rtol=0)
-    assert np.isclose(tw0['betx', 'ip1'], tmad['betx', 'ip1:1'], atol=0, rtol=1e-5)
-    assert np.isclose(tw0['bety', 'ip1'], tmad['bety', 'ip1:1'], atol=0, rtol=1e-5)
-    assert np.isclose(tw0['betx', 'ip5'], tmad['betx', 'ip5:1'], atol=0, rtol=1e-5)
-    assert np.isclose(tw0['bety', 'ip5'], tmad['bety', 'ip5:1'], atol=0, rtol=1e-5)
+    xo.assert_allclose(tw0.dqx, twmad.summary.dq1, atol=0.2, rtol=0)
+    xo.assert_allclose(tw0.dqy, twmad.summary.dq2, atol=0.2, rtol=0)
+    xo.assert_allclose(tw0.qx, twmad.summary.q1, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw0.qy, twmad.summary.q2, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw0['betx', 'ip1'], tmad['betx', 'ip1:1'], atol=0, rtol=1e-5)
+    xo.assert_allclose(tw0['bety', 'ip1'], tmad['bety', 'ip1:1'], atol=0, rtol=1e-5)
+    xo.assert_allclose(tw0['betx', 'ip5'], tmad['betx', 'ip5:1'], atol=0, rtol=1e-5)
+    xo.assert_allclose(tw0['bety', 'ip5'], tmad['bety', 'ip5:1'], atol=0, rtol=1e-5)
 
 
 @for_all_test_contexts
@@ -99,18 +98,18 @@ def test_slicing_lhc_thick(test_context):
     beta_beat_y_at_ips = [tw['bety', f'ip{nn}'] / tw_thick['bety', f'ip{nn}'] - 1
                             for nn in range(1, 9)]
 
-    assert np.allclose(beta_beat_x_at_ips, 0, atol=3e-3)
-    assert np.allclose(beta_beat_y_at_ips, 0, atol=3e-3)
+    xo.assert_allclose(beta_beat_x_at_ips, 0, atol=3e-3)
+    xo.assert_allclose(beta_beat_y_at_ips, 0, atol=3e-3)
 
     # Checks on orbit knobs
-    assert np.isclose(tw_thick['px', 'ip1'], 0, rtol=0, atol=1e-7)
-    assert np.isclose(tw_thick['py', 'ip1'], 0, rtol=0, atol=1e-7)
-    assert np.isclose(tw_thick['px', 'ip5'], 0, rtol=0, atol=1e-7)
-    assert np.isclose(tw_thick['py', 'ip5'], 0, rtol=0, atol=1e-7)
-    assert np.isclose(tw['px', 'ip1'], 0, rtol=0, atol=1e-7)
-    assert np.isclose(tw['py', 'ip1'], 0, rtol=0, atol=1e-7)
-    assert np.isclose(tw['px', 'ip5'], 0, rtol=0, atol=1e-7)
-    assert np.isclose(tw['py', 'ip5'], 0, rtol=0, atol=1e-7)
+    xo.assert_allclose(tw_thick['px', 'ip1'], 0, rtol=0, atol=1e-7)
+    xo.assert_allclose(tw_thick['py', 'ip1'], 0, rtol=0, atol=1e-7)
+    xo.assert_allclose(tw_thick['px', 'ip5'], 0, rtol=0, atol=1e-7)
+    xo.assert_allclose(tw_thick['py', 'ip5'], 0, rtol=0, atol=1e-7)
+    xo.assert_allclose(tw['px', 'ip1'], 0, rtol=0, atol=1e-7)
+    xo.assert_allclose(tw['py', 'ip1'], 0, rtol=0, atol=1e-7)
+    xo.assert_allclose(tw['px', 'ip5'], 0, rtol=0, atol=1e-7)
+    xo.assert_allclose(tw['py', 'ip5'], 0, rtol=0, atol=1e-7)
 
     line.vars['on_x1'] = 50
     line.vars['on_x5'] = 60
@@ -120,14 +119,14 @@ def test_slicing_lhc_thick(test_context):
     tw = line.twiss()
     tw_thick = line_thick.twiss()
 
-    assert np.isclose(tw_thick['px', 'ip1'], 50e-6, rtol=0, atol=5e-7)
-    assert np.isclose(tw_thick['py', 'ip1'], 0, rtol=0, atol=5e-7)
-    assert np.isclose(tw_thick['px', 'ip5'], 0, rtol=0, atol=5e-7)
-    assert np.isclose(tw_thick['py', 'ip5'], 60e-6, rtol=0, atol=5e-7)
-    assert np.isclose(tw['px', 'ip1'], 50e-6, rtol=0, atol=5e-7)
-    assert np.isclose(tw['py', 'ip1'], 0, rtol=0, atol=5e-7)
-    assert np.isclose(tw['px', 'ip5'], 0, rtol=0, atol=5e-7)
-    assert np.isclose(tw['py', 'ip5'], 60e-6, rtol=0, atol=5e-7)
+    xo.assert_allclose(tw_thick['px', 'ip1'], 50e-6, rtol=0, atol=5e-7)
+    xo.assert_allclose(tw_thick['py', 'ip1'], 0, rtol=0, atol=5e-7)
+    xo.assert_allclose(tw_thick['px', 'ip5'], 0, rtol=0, atol=5e-7)
+    xo.assert_allclose(tw_thick['py', 'ip5'], 60e-6, rtol=0, atol=5e-7)
+    xo.assert_allclose(tw['px', 'ip1'], 50e-6, rtol=0, atol=5e-7)
+    xo.assert_allclose(tw['py', 'ip1'], 0, rtol=0, atol=5e-7)
+    xo.assert_allclose(tw['px', 'ip5'], 0, rtol=0, atol=5e-7)
+    xo.assert_allclose(tw['py', 'ip5'], 60e-6, rtol=0, atol=5e-7)
 
     line_thick.match(
         vary=[
@@ -158,20 +157,20 @@ def test_slicing_lhc_thick(test_context):
     tw = line.twiss()
     tw_thick = line_thick.twiss()
 
-    assert np.isclose(tw_thick.qx, 62.27, rtol=0, atol=1e-4)
-    assert np.isclose(tw_thick.qy, 60.29, rtol=0, atol=1e-4)
-    assert np.isclose(tw_thick.dqx, 10.0, rtol=0, atol=0.05)
-    assert np.isclose(tw_thick.dqy, 12.0, rtol=0, atol=0.05)
-    assert np.isclose(tw.qx, 62.27, rtol=0, atol=1e-4)
-    assert np.isclose(tw.qy, 60.29, rtol=0, atol=1e-4)
-    assert np.isclose(tw.dqx, 10.0, rtol=0, atol=0.05)
-    assert np.isclose(tw.dqy, 12.0, rtol=0, atol=0.05)
+    xo.assert_allclose(tw_thick.qx, 62.27, rtol=0, atol=1e-4)
+    xo.assert_allclose(tw_thick.qy, 60.29, rtol=0, atol=1e-4)
+    xo.assert_allclose(tw_thick.dqx, 10.0, rtol=0, atol=0.05)
+    xo.assert_allclose(tw_thick.dqy, 12.0, rtol=0, atol=0.05)
+    xo.assert_allclose(tw.qx, 62.27, rtol=0, atol=1e-4)
+    xo.assert_allclose(tw.qy, 60.29, rtol=0, atol=1e-4)
+    xo.assert_allclose(tw.dqx, 10.0, rtol=0, atol=0.05)
+    xo.assert_allclose(tw.dqy, 12.0, rtol=0, atol=0.05)
 
-    assert np.isclose(line.vars['kqtf.b1']._value, line_thick.vars['kqtf.b1']._value,
+    xo.assert_allclose(line.vars['kqtf.b1']._value, line_thick.vars['kqtf.b1']._value,
                         rtol=0.03, atol=0)
-    assert np.isclose(line.vars['kqtd.b1']._value, line_thick.vars['kqtd.b1']._value,
+    xo.assert_allclose(line.vars['kqtd.b1']._value, line_thick.vars['kqtd.b1']._value,
                         rtol=0.03, atol=0)
-    assert np.isclose(line.vars['ksf.b1']._value, line_thick.vars['ksf.b1']._value,
+    xo.assert_allclose(line.vars['ksf.b1']._value, line_thick.vars['ksf.b1']._value,
                         rtol=0.03, atol=0)
-    assert np.isclose(line.vars['ksd.b1']._value, line_thick.vars['ksd.b1']._value,
+    xo.assert_allclose(line.vars['ksd.b1']._value, line_thick.vars['ksd.b1']._value,
                         rtol=0.03, atol=0)

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -4,13 +4,14 @@
 # ######################################### #
 import json
 import pathlib
-import pytest
 
-from cpymad.madx import Madx
 import numpy as np
+import pytest
+from cpymad.madx import Madx
+
 import xobjects as xo
-import xtrack as xt
 import xpart as xp
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
@@ -33,7 +34,7 @@ def test_simple_collective_line(test_context):
     particles.move(_context=xo.ContextCpu())
 
     assert np.all(particles.at_turn == num_turns)
-    assert np.allclose(particles.s, 10 * num_turns, rtol=0, atol=1e-14)
+    xo.assert_allclose(particles.s, 10 * num_turns, rtol=0, atol=1e-14)
 
 
 
@@ -494,12 +495,12 @@ def test_optimize_for_tracking(test_context, multiline):
     assert np.all(p_no_optimized.state == 1)
     assert np.all(p_optimized.state == 1)
 
-    assert np.allclose(p_no_optimized.x, p_optimized.x, rtol=0, atol=1e-14)
-    assert np.allclose(p_no_optimized.y, p_optimized.y, rtol=0, atol=1e-14)
-    assert np.allclose(p_no_optimized.px, p_optimized.px, rtol=0, atol=1e-14)
-    assert np.allclose(p_no_optimized.py, p_optimized.py, rtol=0, atol=1e-14)
-    assert np.allclose(p_no_optimized.zeta, p_optimized.zeta, rtol=0, atol=1e-10)
-    assert np.allclose(p_no_optimized.delta, p_optimized.delta, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_no_optimized.x, p_optimized.x, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_no_optimized.y, p_optimized.y, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_no_optimized.px, p_optimized.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_no_optimized.py, p_optimized.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(p_no_optimized.zeta, p_optimized.zeta, rtol=0, atol=1e-10)
+    xo.assert_allclose(p_no_optimized.delta, p_optimized.delta, rtol=0, atol=1e-14)
 
 
 @for_all_test_contexts
@@ -523,12 +524,12 @@ def test_backtrack_with_flag(test_context):
     line.track(p, backtrack=True, turn_by_turn_monitor='ONE_TURN_EBE')
     mon_backtrack = line.record_last_track
 
-    assert np.allclose(mon_forward.x, mon_backtrack.x, rtol=0, atol=1e-10)
-    assert np.allclose(mon_forward.y, mon_backtrack.y, rtol=0, atol=1e-10)
-    assert np.allclose(mon_forward.px, mon_backtrack.px, rtol=0, atol=1e-10)
-    assert np.allclose(mon_forward.py, mon_backtrack.py, rtol=0, atol=1e-10)
-    assert np.allclose(mon_forward.zeta, mon_backtrack.zeta, rtol=0, atol=1e-10)
-    assert np.allclose(mon_forward.delta, mon_backtrack.delta, rtol=0, atol=1e-10)
+    xo.assert_allclose(mon_forward.x, mon_backtrack.x, rtol=0, atol=1e-10)
+    xo.assert_allclose(mon_forward.y, mon_backtrack.y, rtol=0, atol=1e-10)
+    xo.assert_allclose(mon_forward.px, mon_backtrack.px, rtol=0, atol=1e-10)
+    xo.assert_allclose(mon_forward.py, mon_backtrack.py, rtol=0, atol=1e-10)
+    xo.assert_allclose(mon_forward.zeta, mon_backtrack.zeta, rtol=0, atol=1e-10)
+    xo.assert_allclose(mon_forward.delta, mon_backtrack.delta, rtol=0, atol=1e-10)
 
 
 @for_all_test_contexts
@@ -549,7 +550,7 @@ def test_tracking_with_progress(test_context, with_progress, turns, collective):
     particles.move(xo.ContextCpu())
 
     assert np.all(particles.at_turn == turns)
-    assert np.allclose(particles.s, 10 * turns, rtol=0, atol=1e-14)
+    xo.assert_allclose(particles.s, 10 * turns, rtol=0, atol=1e-14)
 
 
 @for_all_test_contexts
@@ -576,7 +577,7 @@ def test_tbt_monitor_with_progress(test_context, ele_start, ele_stop, expected_x
     assert monitor_recorded_x.shape == (1, len(expected_x) - 1)
 
     recorded_x = np.concatenate([monitor_recorded_x[0], p.x])
-    assert np.allclose(recorded_x, expected_x, atol=1e-16)
+    xo.assert_allclose(recorded_x, expected_x, atol=1e-16)
 
 
 @pytest.fixture
@@ -642,7 +643,7 @@ def test_track_log_and_merit_function(pimms_mad, test_context):
     x_expected = [line.vars[kk]._value for kk in ['ksf', 'ksd', 'kqfa', 'kqfb', 'kqd']]
     x_expected[4] /= 10  # include the weight
     x_start = merit_function.get_x()
-    assert np.allclose(x_start, x_expected, atol=1e-14)
+    xo.assert_allclose(x_start, x_expected, atol=1e-14)
 
     expected_limits = [
         [-1e200, 1e200],  # default
@@ -651,7 +652,7 @@ def test_track_log_and_merit_function(pimms_mad, test_context):
         [0, 1],
         [-0.1, 0],
     ]
-    assert np.allclose(merit_function.get_x_limits(), expected_limits, atol=1e-14)
+    xo.assert_allclose(merit_function.get_x_limits(), expected_limits, atol=1e-14)
 
     # Below numbers obtained by first only matching the tunes, then the above
     x_optimized = [-1.40251213, 0.81823393, 0.31196667, 0.52478984, -0.052393429]
@@ -710,15 +711,15 @@ def test_track_log_and_merit_function(pimms_mad, test_context):
     (slope, _), residual, _, _, _ = fit
     assert slope > 0
     assert residual < 1e-28
-    assert np.isclose(line.log_last_track['kqfa'][0], kqfa_before, atol=1e-14, rtol=0)
-    assert np.isclose(line.log_last_track['kqfa'][-1], line.vv['kqfa'], atol=1e-14, rtol=0)
+    xo.assert_allclose(line.log_last_track['kqfa'][0], kqfa_before, atol=1e-14, rtol=0)
+    xo.assert_allclose(line.log_last_track['kqfa'][-1], line.vv['kqfa'], atol=1e-14, rtol=0)
 
     # Check that intensity is decreasing
     intensity = np.array(line.log_last_track['intensity'])
     assert np.all(intensity[:-1] - intensity[1:] >= 0)
-    assert np.isclose(intensity[0], intensity_before, atol=1e-14, rtol=0)
+    xo.assert_allclose(intensity[0], intensity_before, atol=1e-14, rtol=0)
     # The last log point is from the beginning of the last turn:
-    assert np.isclose(intensity[-1], intensity_after, atol=0, rtol=1e-2)
+    xo.assert_allclose(intensity[-1], intensity_after, atol=0, rtol=1e-2)
 
 
 @for_all_test_contexts

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -1,14 +1,14 @@
-import pathlib
 import json
+import pathlib
 from itertools import product
 
-import pytest
 import numpy as np
+import pytest
 from cpymad.madx import Madx
 
+import xobjects as xo
 import xpart as xp
 import xtrack as xt
-import xobjects as xo
 from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
@@ -38,18 +38,18 @@ def test_twiss_4d_fodo_vs_beta_rel(test_context):
         tw_4d_list.append(tw)
 
     for tw in tw_4d_list:
-        assert np.allclose(tw.betx, tw_4d_list[0].betx, atol=1e-12, rtol=0)
-        assert np.allclose(tw.bety, tw_4d_list[0].bety, atol=1e-12, rtol=0)
-        assert np.allclose(tw.alfx, tw_4d_list[0].alfx, atol=1e-12, rtol=0)
-        assert np.allclose(tw.alfy, tw_4d_list[0].alfy, atol=1e-12, rtol=0)
-        assert np.allclose(tw.dx, tw_4d_list[0].dx, atol=1e-8, rtol=0)
-        assert np.allclose(tw.dy, tw_4d_list[0].dy, atol=1e-8, rtol=0)
-        assert np.allclose(tw.dpx, tw_4d_list[0].dpx, atol=1e-8, rtol=0)
-        assert np.allclose(tw.dpy, tw_4d_list[0].dpy, atol=1e-8, rtol=0)
-        assert np.isclose(tw.qx, tw_4d_list[0].qx, atol=1e-7, rtol=0)
-        assert np.isclose(tw.qy, tw_4d_list[0].qy, atol=1e-7, rtol=0)
-        assert np.isclose(tw.dqx, tw_4d_list[0].dqx, atol=1e-4, rtol=0)
-        assert np.isclose(tw.dqy, tw_4d_list[0].dqy, atol=1e-4, rtol=0)
+        xo.assert_allclose(tw.betx, tw_4d_list[0].betx, atol=1e-12, rtol=0)
+        xo.assert_allclose(tw.bety, tw_4d_list[0].bety, atol=1e-12, rtol=0)
+        xo.assert_allclose(tw.alfx, tw_4d_list[0].alfx, atol=1e-12, rtol=0)
+        xo.assert_allclose(tw.alfy, tw_4d_list[0].alfy, atol=1e-12, rtol=0)
+        xo.assert_allclose(tw.dx, tw_4d_list[0].dx, atol=1e-8, rtol=0)
+        xo.assert_allclose(tw.dy, tw_4d_list[0].dy, atol=1e-8, rtol=0)
+        xo.assert_allclose(tw.dpx, tw_4d_list[0].dpx, atol=1e-8, rtol=0)
+        xo.assert_allclose(tw.dpy, tw_4d_list[0].dpy, atol=1e-8, rtol=0)
+        xo.assert_allclose(tw.qx, tw_4d_list[0].qx, atol=1e-7, rtol=0)
+        xo.assert_allclose(tw.qy, tw_4d_list[0].qy, atol=1e-7, rtol=0)
+        xo.assert_allclose(tw.dqx, tw_4d_list[0].dqx, atol=1e-4, rtol=0)
+        xo.assert_allclose(tw.dqy, tw_4d_list[0].dqy, atol=1e-4, rtol=0)
 
 
 @for_all_test_contexts
@@ -85,14 +85,14 @@ def test_coupled_beta(test_context):
         beta12_mad_at_ips = tw_mad_coupling.loc[[ip + ':1' for ip in ips], 'beta12'].values
         beta21_mad_at_ips = tw_mad_coupling.loc[[ip + ':1' for ip in ips], 'beta21'].values
 
-        assert np.allclose(betx2_at_ips, beta12_mad_at_ips, rtol=1e-4, atol=0)
-        assert np.allclose(bety1_at_ips, beta21_mad_at_ips, rtol=1e-4, atol=0)
+        xo.assert_allclose(betx2_at_ips, beta12_mad_at_ips, rtol=1e-4, atol=0)
+        xo.assert_allclose(bety1_at_ips, beta21_mad_at_ips, rtol=1e-4, atol=0)
 
         #cmin_ref = mad.table.summ.dqmin[0] # dqmin is not calculated correctly in madx
                                             # (https://github.com/MethodicalAcceleratorDesign/MAD-X/issues/1152)
         cmin_ref = 0.001972093557# obtained with madx with trial and error
 
-        assert np.isclose(tw.c_minus, cmin_ref, rtol=0, atol=1e-5)
+        xo.assert_allclose(tw.c_minus, cmin_ref, rtol=0, atol=1e-5)
 
 
 @for_all_test_contexts
@@ -125,13 +125,13 @@ def test_twiss_zeta0_delta0(test_context):
     phi_c_ip5 = ((tw1.loc['ip5', 'y'] - tw2.loc['ip5', 'y'])
                  / (tw1.loc['ip5', 'zeta'] - tw2.loc['ip5', 'zeta']))
 
-    assert np.isclose(phi_c_ip1, -190e-6, atol=1e-7, rtol=0)
-    assert np.isclose(phi_c_ip5, -190e-6, atol=1e-7, rtol=0)
+    xo.assert_allclose(phi_c_ip1, -190e-6, atol=1e-7, rtol=0)
+    xo.assert_allclose(phi_c_ip5, -190e-6, atol=1e-7, rtol=0)
 
     # Check crab dispersion
     tw6d = line.twiss()
-    assert np.isclose(tw6d['dx_zeta', 'ip1'], -190e-6, atol=1e-7, rtol=0)
-    assert np.isclose(tw6d['dy_zeta', 'ip5'], -190e-6, atol=1e-7, rtol=0)
+    xo.assert_allclose(tw6d['dx_zeta', 'ip1'], -190e-6, atol=1e-7, rtol=0)
+    xo.assert_allclose(tw6d['dy_zeta', 'ip5'], -190e-6, atol=1e-7, rtol=0)
 
 @for_all_test_contexts
 def test_get_normalized_coordinates(test_context):
@@ -156,10 +156,10 @@ def test_get_normalized_coordinates(test_context):
     norm_coord = tw.get_normalized_coordinates(particles, nemitt_x=2.5e-6,
                                             nemitt_y=1e-6)
 
-    assert np.allclose(norm_coord['x_norm'], [-1, 0, 0.5], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord['y_norm'], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord['px_norm'], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord['py_norm'], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord['x_norm'], [-1, 0, 0.5], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord['y_norm'], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord['px_norm'], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord['py_norm'], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
 
 
     # Introduce a non-zero closed orbit
@@ -176,10 +176,10 @@ def test_get_normalized_coordinates(test_context):
     norm_coord1 = tw1.get_normalized_coordinates(particles1, nemitt_x=2.5e-6,
                                                 nemitt_y=1e-6)
 
-    assert np.allclose(norm_coord1['x_norm'], [-1, 0, 0.5], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord1['y_norm'], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord1['px_norm'], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord1['py_norm'], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord1['x_norm'], [-1, 0, 0.5], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord1['y_norm'], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord1['px_norm'], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord1['py_norm'], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
 
     # Check computation at different locations
 
@@ -203,18 +203,18 @@ def test_get_normalized_coordinates(test_context):
                                                 nemitt_y=1e-6)
 
     assert particles23._capacity == 20
-    assert np.allclose(norm_coord23['x_norm'][:3], [-1, 0, 0.5], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord23['x_norm'][3:6], [-1, 0, 0.5], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord23['x_norm'][6:], xt.particles.LAST_INVALID_STATE)
-    assert np.allclose(norm_coord23['y_norm'][:3], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord23['y_norm'][3:6], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord23['y_norm'][6:], xt.particles.LAST_INVALID_STATE)
-    assert np.allclose(norm_coord23['px_norm'][:3], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord23['px_norm'][3:6], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord23['px_norm'][6:], xt.particles.LAST_INVALID_STATE)
-    assert np.allclose(norm_coord23['py_norm'][:3], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord23['py_norm'][3:6], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
-    assert np.allclose(norm_coord23['py_norm'][6:], xt.particles.LAST_INVALID_STATE)
+    xo.assert_allclose(norm_coord23['x_norm'][:3], [-1, 0, 0.5], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord23['x_norm'][3:6], [-1, 0, 0.5], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord23['x_norm'][6:], xt.particles.LAST_INVALID_STATE)
+    xo.assert_allclose(norm_coord23['y_norm'][:3], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord23['y_norm'][3:6], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord23['y_norm'][6:], xt.particles.LAST_INVALID_STATE)
+    xo.assert_allclose(norm_coord23['px_norm'][:3], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord23['px_norm'][3:6], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord23['px_norm'][6:], xt.particles.LAST_INVALID_STATE)
+    xo.assert_allclose(norm_coord23['py_norm'][:3], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord23['py_norm'][3:6], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord23['py_norm'][6:], xt.particles.LAST_INVALID_STATE)
 
     particles23.move(_context=xo.context_default)
     assert np.all(particles23.at_element[:3] == line.element_names.index('s.ds.r3.b1'))
@@ -311,15 +311,15 @@ def test_get_R_matrix():
         lam_ref = eig(Rot_ref[2*i_mode:2*i_mode+2, 2*i_mode:2*i_mode+2])[0][0]
         lam_prod = eig(Rot_prod[2*i_mode:2*i_mode+2, 2*i_mode:2*i_mode+2])[0][0]
 
-        assert np.isclose(np.abs(np.angle(lam_ref)) / 2 / np.pi,
+        xo.assert_allclose(np.abs(np.angle(lam_ref)) / 2 / np.pi,
                         np.abs(np.angle(lam_prod)) / 2 / np.pi,
                         rtol=0, atol=1e-6)
 
-        assert np.isclose(
+        xo.assert_allclose(
             norm(W_prod[:, 2*i_mode] - W_ref[:, 2*i_mode], ord=2)
             / norm(W_ref[:, 2*i_mode], ord=2),
             0, rtol=0, atol=5e-4)
-        assert np.isclose(
+        xo.assert_allclose(
             norm(W_prod[:4, 2*i_mode] - W_ref[:4, 2*i_mode], ord=2)
             / norm(W_ref[:4, 2*i_mode], ord=2),
             0, rtol=0, atol=1e-4)
@@ -351,11 +351,11 @@ def test_get_R_matrix():
         lam_prod_4d = eig(
             Rot_prod_4d[2*i_mode:2*i_mode+2, 2*i_mode:2*i_mode+2])[0][0]
 
-        assert np.isclose(np.abs(np.angle(lam_ref_4d)) / 2 / np.pi,
+        xo.assert_allclose(np.abs(np.angle(lam_ref_4d)) / 2 / np.pi,
                         np.abs(np.angle(lam_prod_4d)) / 2 / np.pi,
                         rtol=0, atol=1e-6)
 
-        assert np.isclose(
+        xo.assert_allclose(
             norm(W_prod_4d[:, 2*i_mode] - W_ref_4d[:, 2*i_mode], ord=2)
             / norm(W_ref_4d[:, 2*i_mode], ord=2),
             0, rtol=0, atol=5e-5)
@@ -443,15 +443,15 @@ def test_periodic_cell_twiss(test_context):
         assert tw_cell_periodic.orientation == 'forward'
         assert tw_cell_periodic.reference_frame == {'b1':'proper', 'b2':'reverse'}[beam_name]
 
-        assert np.allclose(tw_cell_periodic.betx, tw_cell.betx, atol=0, rtol=1e-6)
-        assert np.allclose(tw_cell_periodic.bety, tw_cell.bety, atol=0, rtol=1e-6)
-        assert np.allclose(tw_cell_periodic.dx, tw_cell.dx, atol=1e-4, rtol=0)
+        xo.assert_allclose(tw_cell_periodic.betx, tw_cell.betx, atol=0, rtol=1e-6)
+        xo.assert_allclose(tw_cell_periodic.bety, tw_cell.bety, atol=0, rtol=1e-6)
+        xo.assert_allclose(tw_cell_periodic.dx, tw_cell.dx, atol=1e-4, rtol=0)
 
         assert tw_cell_periodic['mux', 0] == 0
         assert tw_cell_periodic['muy', 0] == 0
-        assert np.isclose(tw_cell_periodic.mux[-1],
+        xo.assert_allclose(tw_cell_periodic.mux[-1],
                 tw['mux', end_cell] - tw['mux', start_cell], rtol=0, atol=1e-6)
-        assert np.isclose(tw_cell_periodic.muy[-1],
+        xo.assert_allclose(tw_cell_periodic.muy[-1],
                 tw['muy', end_cell] - tw['muy', start_cell], rtol=0, atol=1e-6)
 
         twinit_start_cell = tw_cell_periodic.get_twiss_init(start_cell)
@@ -475,8 +475,8 @@ def test_periodic_cell_twiss(test_context):
         mux_arc_from_cell = tw_to_end_arc['mux', end_arc] - tw_to_start_arc['mux', start_arc]
         muy_arc_from_cell = tw_to_end_arc['muy', end_arc] - tw_to_start_arc['muy', start_arc]
 
-        assert np.isclose(mux_arc_from_cell, mux_arc_target, rtol=1e-6)
-        assert np.isclose(muy_arc_from_cell, muy_arc_target, rtol=1e-6)
+        xo.assert_allclose(mux_arc_from_cell, mux_arc_target, rtol=1e-6)
+        xo.assert_allclose(muy_arc_from_cell, muy_arc_target, rtol=1e-6)
 
 
         dp_test = 1e-4
@@ -502,14 +502,14 @@ def test_periodic_cell_twiss(test_context):
                             ) / 2 / dp_test
 
         if beam_name == 'b1':
-            assert np.isclose(dqx_expected, 0.22855, rtol=0, atol=1e-4) # to catch regressions
-            assert np.isclose(dqy_expected, 0.26654, rtol=0, atol=1e-4) # to catch regressions
+            xo.assert_allclose(dqx_expected, 0.22855, rtol=0, atol=1e-4) # to catch regressions
+            xo.assert_allclose(dqy_expected, 0.26654, rtol=0, atol=1e-4) # to catch regressions
         else:
-            assert np.isclose(dqx_expected, -0.479425, rtol=0, atol=1e-4)
-            assert np.isclose(dqy_expected, 0.543953, rtol=0, atol=1e-4)
+            xo.assert_allclose(dqx_expected, -0.479425, rtol=0, atol=1e-4)
+            xo.assert_allclose(dqy_expected, 0.543953, rtol=0, atol=1e-4)
 
-        assert np.isclose(tw_cell_periodic.dqx, dqx_expected, rtol=0, atol=1e-4)
-        assert np.isclose(tw_cell_periodic.dqy, dqy_expected, rtol=0, atol=1e-4)
+        xo.assert_allclose(tw_cell_periodic.dqx, dqx_expected, rtol=0, atol=1e-4)
+        xo.assert_allclose(tw_cell_periodic.dqy, dqy_expected, rtol=0, atol=1e-4)
 
 @pytest.fixture(scope='module')
 def collider_for_test_twiss_range():
@@ -630,31 +630,31 @@ def test_twiss_range(test_context, cycle_to, line_name, check, init_at_edge, col
     tw_init_ip5 = tw.get_twiss_init('ip5')
     tw_init_ip6 = tw.get_twiss_init('ip6')
 
-    assert np.isclose(tw_init_ip5.betx, tw['betx', 'ip5'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip5.bety, tw['bety', 'ip5'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip5.alfx, tw['alfx', 'ip5'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip5.alfy, tw['alfy', 'ip5'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip5.dx,   tw['dx', 'ip5'],   atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip5.dy,   tw['dy', 'ip5'],   atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip5.dpx,  tw['dpx', 'ip5'],  atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip5.dpy,  tw['dpy', 'ip5'],  atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip5.ax_chrom, tw['ax_chrom', 'ip5'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip5.ay_chrom, tw['ay_chrom', 'ip5'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip5.bx_chrom, tw['bx_chrom', 'ip5'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip5.by_chrom, tw['by_chrom', 'ip5'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip5.betx, tw['betx', 'ip5'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip5.bety, tw['bety', 'ip5'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip5.alfx, tw['alfx', 'ip5'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip5.alfy, tw['alfy', 'ip5'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip5.dx,   tw['dx', 'ip5'],   atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip5.dy,   tw['dy', 'ip5'],   atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip5.dpx,  tw['dpx', 'ip5'],  atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip5.dpy,  tw['dpy', 'ip5'],  atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip5.ax_chrom, tw['ax_chrom', 'ip5'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip5.ay_chrom, tw['ay_chrom', 'ip5'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip5.bx_chrom, tw['bx_chrom', 'ip5'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip5.by_chrom, tw['by_chrom', 'ip5'], atol=0, rtol=1e-7)
 
-    assert np.isclose(tw_init_ip6.betx, tw['betx', 'ip6'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip6.bety, tw['bety', 'ip6'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip6.alfx, tw['alfx', 'ip6'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip6.alfy, tw['alfy', 'ip6'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip6.dx,   tw['dx', 'ip6'],   atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip6.dy,   tw['dy', 'ip6'],   atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip6.dpx,  tw['dpx', 'ip6'],  atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip6.dpy,  tw['dpy', 'ip6'],  atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip6.ax_chrom, tw['ax_chrom', 'ip6'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip6.ay_chrom, tw['ay_chrom', 'ip6'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip6.bx_chrom, tw['bx_chrom', 'ip6'], atol=0, rtol=1e-7)
-    assert np.isclose(tw_init_ip6.by_chrom, tw['by_chrom', 'ip6'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip6.betx, tw['betx', 'ip6'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip6.bety, tw['bety', 'ip6'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip6.alfx, tw['alfx', 'ip6'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip6.alfy, tw['alfy', 'ip6'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip6.dx,   tw['dx', 'ip6'],   atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip6.dy,   tw['dy', 'ip6'],   atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip6.dpx,  tw['dpx', 'ip6'],  atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip6.dpy,  tw['dpy', 'ip6'],  atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip6.ax_chrom, tw['ax_chrom', 'ip6'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip6.ay_chrom, tw['ay_chrom', 'ip6'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip6.bx_chrom, tw['bx_chrom', 'ip6'], atol=0, rtol=1e-7)
+    xo.assert_allclose(tw_init_ip6.by_chrom, tw['by_chrom', 'ip6'], atol=0, rtol=1e-7)
 
     if init_at_edge:
         estart_user = 'ip5'
@@ -744,7 +744,7 @@ def test_twiss_range(test_context, cycle_to, line_name, check, init_at_edge, col
     else:
         raise ValueError(f'Unknown config {check}')
 
-    assert np.isclose(tw_test['s', name_init], tw['s', name_init], 1e-10)
+    xo.assert_allclose(tw_test['s', name_init], tw['s', name_init], 1e-10)
 
     assert tw_init_ip5.reference_frame == (
         {'lhcb1': 'proper', 'lhcb2': 'reverse'}[line_name])
@@ -785,7 +785,7 @@ def test_twiss_range(test_context, cycle_to, line_name, check, init_at_edge, col
             continue # some tested separately
         atol = atols.get(kk, atol_default)
         rtol = rtols.get(kk, rtol_default)
-        assert np.allclose(
+        xo.assert_allclose(
             tw_test._data[kk], tw_part._data[kk], rtol=rtol, atol=atol)
 
     assert tw_test.values_at == tw_part.values_at == 'entry'
@@ -864,36 +864,36 @@ def test_twiss_against_matrix(test_context):
     tw4d = line.twiss(method='4d')
     tw6d = line.twiss()
 
-    assert np.isclose(tw6d.qs, 0.0004, atol=1e-7, rtol=0)
-    assert np.isclose(tw6d.bets0, 1e-3, atol=1e-7, rtol=0)
+    xo.assert_allclose(tw6d.qs, 0.0004, atol=1e-7, rtol=0)
+    xo.assert_allclose(tw6d.bets0, 1e-3, atol=1e-7, rtol=0)
 
     for tw in [tw4d, tw6d]:
 
-        assert np.isclose(tw.qx, 0.4 + 0.21, atol=1e-7, rtol=0)
-        assert np.isclose(tw.qy, 0.3 + 0.32, atol=1e-7, rtol=0)
+        xo.assert_allclose(tw.qx, 0.4 + 0.21, atol=1e-7, rtol=0)
+        xo.assert_allclose(tw.qy, 0.3 + 0.32, atol=1e-7, rtol=0)
 
-        assert np.isclose(tw.dqx, 2, atol=1e-5, rtol=0)
-        assert np.isclose(tw.dqy, 3, atol=1e-5, rtol=0)
+        xo.assert_allclose(tw.dqx, 2, atol=1e-5, rtol=0)
+        xo.assert_allclose(tw.dqy, 3, atol=1e-5, rtol=0)
 
-        assert np.allclose(tw.s, [0, 0.1, 0.1 + 0.2], atol=1e-7, rtol=0)
-        assert np.allclose(tw.mux, [0, 0.4, 0.4 + 0.21], atol=1e-7, rtol=0)
-        assert np.allclose(tw.muy, [0, 0.3, 0.3 + 0.32], atol=1e-7, rtol=0)
+        xo.assert_allclose(tw.s, [0, 0.1, 0.1 + 0.2], atol=1e-7, rtol=0)
+        xo.assert_allclose(tw.mux, [0, 0.4, 0.4 + 0.21], atol=1e-7, rtol=0)
+        xo.assert_allclose(tw.muy, [0, 0.3, 0.3 + 0.32], atol=1e-7, rtol=0)
 
-        assert np.allclose(tw.betx, [1, 2, 1], atol=1e-7, rtol=0)
-        assert np.allclose(tw.bety, [3, 4, 3], atol=1e-7, rtol=0)
+        xo.assert_allclose(tw.betx, [1, 2, 1], atol=1e-7, rtol=0)
+        xo.assert_allclose(tw.bety, [3, 4, 3], atol=1e-7, rtol=0)
 
-        assert np.allclose(tw.alfx, [0, 0.1, 0], atol=1e-7, rtol=0)
-        assert np.allclose(tw.alfy, [0.2, 0, 0.2], atol=1e-7, rtol=0)
+        xo.assert_allclose(tw.alfx, [0, 0.1, 0], atol=1e-7, rtol=0)
+        xo.assert_allclose(tw.alfy, [0.2, 0, 0.2], atol=1e-7, rtol=0)
 
-        assert np.allclose(tw.dx, [10, 0, 10], atol=1e-4, rtol=0)
-        assert np.allclose(tw.dy, [0, 20, 0], atol=1e-4, rtol=0)
-        assert np.allclose(tw.dpx, [0.7, -0.3, 0.7], atol=1e-5, rtol=0)
-        assert np.allclose(tw.dpy, [0.4, -0.6, 0.4], atol=1e-5, rtol=0)
+        xo.assert_allclose(tw.dx, [10, 0, 10], atol=1e-4, rtol=0)
+        xo.assert_allclose(tw.dy, [0, 20, 0], atol=1e-4, rtol=0)
+        xo.assert_allclose(tw.dpx, [0.7, -0.3, 0.7], atol=1e-5, rtol=0)
+        xo.assert_allclose(tw.dpy, [0.4, -0.6, 0.4], atol=1e-5, rtol=0)
 
-        assert np.allclose(tw.x, [1e-3, 2e-3, 1e-3], atol=1e-7, rtol=0)
-        assert np.allclose(tw.px, [2e-6, -3e-6, 2e-6], atol=1e-12, rtol=0)
-        assert np.allclose(tw.y, [3e-3, 4e-3, 3e-3], atol=1e-7, rtol=0)
-        assert np.allclose(tw.py, [4e-6, -5e-6, 4e-6], atol=1e-12, rtol=0)
+        xo.assert_allclose(tw.x, [1e-3, 2e-3, 1e-3], atol=1e-7, rtol=0)
+        xo.assert_allclose(tw.px, [2e-6, -3e-6, 2e-6], atol=1e-12, rtol=0)
+        xo.assert_allclose(tw.y, [3e-3, 4e-3, 3e-3], atol=1e-7, rtol=0)
+        xo.assert_allclose(tw.py, [4e-6, -5e-6, 4e-6], atol=1e-12, rtol=0)
 
 @for_all_test_contexts
 @pytest.mark.parametrize('machine', ['sps', 'psb'])
@@ -992,13 +992,13 @@ def test_longitudinal_plane_against_matrix(machine, test_context):
         line_matrix.track(particle0_matrix.copy(), num_turns=num_turns, turn_by_turn_monitor=True)
         mon_matrix = line_matrix.record_last_track
 
-        assert np.allclose(np.max(mon.zeta), np.max(mon_matrix.zeta), rtol=1e-2, atol=0)
-        assert np.allclose(np.max(mon.pzeta), np.max(mon_matrix.pzeta), rtol=1e-2, atol=0)
-        assert np.allclose(np.max(mon.x), np.max(mon_matrix.x), rtol=1e-2, atol=0)
+        xo.assert_allclose(np.max(mon.zeta), np.max(mon_matrix.zeta), rtol=1e-2, atol=0)
+        xo.assert_allclose(np.max(mon.pzeta), np.max(mon_matrix.pzeta), rtol=1e-2, atol=0)
+        xo.assert_allclose(np.max(mon.x), np.max(mon_matrix.x), rtol=1e-2, atol=0)
 
-        assert np.allclose(mon.zeta, mon_matrix.zeta, rtol=0, atol=5e-2*np.max(mon.zeta.T))
-        assert np.allclose(mon.pzeta, mon_matrix.pzeta, rtol=0, atol=5e-2*np.max(mon.pzeta[:]))
-        assert np.allclose(mon.x, mon_matrix.x, rtol=0, atol=5e-2*np.max(mon.x.T)) # There is some phase difference...
+        xo.assert_allclose(mon.zeta, mon_matrix.zeta, rtol=0, atol=5e-2*np.max(mon.zeta.T))
+        xo.assert_allclose(mon.pzeta, mon_matrix.pzeta, rtol=0, atol=5e-2*np.max(mon.pzeta[:]))
+        xo.assert_allclose(mon.x, mon_matrix.x, rtol=0, atol=5e-2*np.max(mon.x.T)) # There is some phase difference...
 
         # Match Gaussian distributions
         p_line = xp.generate_matched_gaussian_bunch(num_particles=1000000,
@@ -1009,12 +1009,12 @@ def test_longitudinal_plane_against_matrix(machine, test_context):
         p_line.move(_context=xo.context_default)
         p_matrix.move(_context=xo.context_default)
 
-        assert np.isclose(np.std(p_line.zeta), np.std(p_matrix.zeta), rtol=1e-2)
-        assert np.isclose(np.std(p_line.pzeta), np.std(p_matrix.pzeta), rtol=2e-2)
-        assert np.isclose(np.std(p_line.x), np.std(p_matrix.x), rtol=1e-2)
-        assert np.isclose(np.std(p_line.px), np.std(p_matrix.px), rtol=1e-2)
-        assert np.isclose(np.std(p_line.y), np.std(p_matrix.y), rtol=1e-2)
-        assert np.isclose(np.std(p_line.py), np.std(p_matrix.py), rtol=1e-2)
+        xo.assert_allclose(np.std(p_line.zeta), np.std(p_matrix.zeta), rtol=1e-2)
+        xo.assert_allclose(np.std(p_line.pzeta), np.std(p_matrix.pzeta), rtol=2e-2)
+        xo.assert_allclose(np.std(p_line.x), np.std(p_matrix.x), rtol=1e-2)
+        xo.assert_allclose(np.std(p_line.px), np.std(p_matrix.px), rtol=1e-2)
+        xo.assert_allclose(np.std(p_line.y), np.std(p_matrix.y), rtol=1e-2)
+        xo.assert_allclose(np.std(p_line.py), np.std(p_matrix.py), rtol=1e-2)
 
         # Compare twiss
         tw_line = line.twiss()
@@ -1038,24 +1038,24 @@ def test_longitudinal_plane_against_matrix(machine, test_context):
         matrix_frac_qx = np.mod(tw_matrix.qx, 1)
         matrix_frac_qy = np.mod(tw_matrix.qy, 1)
 
-        assert np.isclose(line_frac_qx, matrix_frac_qx, atol=1e-5, rtol=0)
-        assert np.isclose(line_frac_qy, matrix_frac_qy, atol=1e-5, rtol=0)
-        assert np.isclose(tw_line.betx[0], tw_matrix.betx[0], atol=1e-5, rtol=0)
-        assert np.isclose(tw_line.alfx[0], tw_matrix.alfx[0], atol=1e-5, rtol=0)
-        assert np.isclose(tw_line.bety[0], tw_matrix.bety[0], atol=1e-5, rtol=0)
-        assert np.isclose(tw_line.alfy[0], tw_matrix.alfy[0], atol=1e-5, rtol=0)
-        assert np.isclose(tw_line.dx[0], tw_matrix.dx[0], atol=1e-5, rtol=0)
-        assert np.isclose(tw_line.dpx[0], tw_matrix.dpx[0], atol=1e-5, rtol=0)
-        assert np.isclose(tw_line.dy[0], tw_matrix.dy[0], atol=1e-5, rtol=0)
-        assert np.isclose(tw_line.dpy[0], tw_matrix.dpy[0], atol=1e-5, rtol=0)
+        xo.assert_allclose(line_frac_qx, matrix_frac_qx, atol=1e-5, rtol=0)
+        xo.assert_allclose(line_frac_qy, matrix_frac_qy, atol=1e-5, rtol=0)
+        xo.assert_allclose(tw_line.betx[0], tw_matrix.betx[0], atol=1e-5, rtol=0)
+        xo.assert_allclose(tw_line.alfx[0], tw_matrix.alfx[0], atol=1e-5, rtol=0)
+        xo.assert_allclose(tw_line.bety[0], tw_matrix.bety[0], atol=1e-5, rtol=0)
+        xo.assert_allclose(tw_line.alfy[0], tw_matrix.alfy[0], atol=1e-5, rtol=0)
+        xo.assert_allclose(tw_line.dx[0], tw_matrix.dx[0], atol=1e-5, rtol=0)
+        xo.assert_allclose(tw_line.dpx[0], tw_matrix.dpx[0], atol=1e-5, rtol=0)
+        xo.assert_allclose(tw_line.dy[0], tw_matrix.dy[0], atol=1e-5, rtol=0)
+        xo.assert_allclose(tw_line.dpy[0], tw_matrix.dpy[0], atol=1e-5, rtol=0)
 
         assert tw_matrix.s[0] == 0
-        assert np.isclose(tw_matrix.s[-1], tw_line.circumference, rtol=0, atol=1e-6)
-        assert np.allclose(tw_matrix.bets0, tw_line.bets0, rtol=1e-2, atol=0)
+        xo.assert_allclose(tw_matrix.s[-1], tw_line.circumference, rtol=0, atol=1e-6)
+        xo.assert_allclose(tw_matrix.bets0, tw_line.bets0, rtol=1e-2, atol=0)
 
-        assert np.allclose(np.squeeze(mon.zeta), np.squeeze(mon_matrix.zeta),
+        xo.assert_allclose(np.squeeze(mon.zeta), np.squeeze(mon_matrix.zeta),
                         rtol=0, atol=2e-2*np.max(np.squeeze(mon.zeta)))
-        assert np.allclose(np.squeeze(mon.pzeta), np.squeeze(mon_matrix.pzeta),
+        xo.assert_allclose(np.squeeze(mon.pzeta), np.squeeze(mon_matrix.pzeta),
                             rtol=0, atol=3e-2*np.max(np.squeeze(mon.pzeta)))
 
         particles_matrix = xp.generate_matched_gaussian_bunch(num_particles=1000000,
@@ -1067,9 +1067,9 @@ def test_longitudinal_plane_against_matrix(machine, test_context):
         particles_matrix.move(_context=xo.context_default)
         particles_line.move(_context=xo.context_default)
 
-        assert np.isclose(np.std(particles_matrix.zeta), np.std(particles_line.zeta),
+        xo.assert_allclose(np.std(particles_matrix.zeta), np.std(particles_line.zeta),
                         atol=0, rtol=2e-2)
-        assert np.isclose(np.std(particles_matrix.pzeta), np.std(particles_line.pzeta),
+        xo.assert_allclose(np.std(particles_matrix.pzeta), np.std(particles_line.pzeta),
             atol=0, rtol=(25e-2 if longitudinal_mode.startswith('linear') else 2e-2))
 
 @for_all_test_contexts
@@ -1145,7 +1145,7 @@ def test_custom_twiss_init(test_context):
             continue # tested separately
         atol = atols.get(kk, atol_default)
         rtol = rtols.get(kk, rtol_default)
-        assert np.allclose(
+        xo.assert_allclose(
             tw_test._data[kk], tw_part._data[kk], rtol=rtol, atol=atol)
 
     assert tw_test.values_at == tw_part.values_at == 'entry'
@@ -1160,7 +1160,7 @@ def test_custom_twiss_init(test_context):
         this_test = W_matrix_test[ss, :, :]
 
         for ii in range(4):
-            assert np.isclose((np.linalg.norm(this_part[ii, :] - this_test[ii, :])
+            xo.assert_allclose((np.linalg.norm(this_part[ii, :] - this_test[ii, :])
                             /np.linalg.norm(this_part[ii, :])), 0, atol=3e-4)
 
 @for_all_test_contexts
@@ -1191,26 +1191,26 @@ def test_crab_dispersion(test_context):
     tw6d_rf_on_crab_off = line.twiss()
     tw4d_rf_on_crab_off = line.twiss(method='4d')
 
-    assert np.allclose(tw4d_rf_on['delta'], 0, rtol=0, atol=1e-12)
-    assert np.allclose(tw4d_rf_off['delta'], 0, rtol=0, atol=1e-12)
-    assert np.allclose(tw4d_rf_on_crab_off['delta'], 0, rtol=0, atol=1e-12)
+    xo.assert_allclose(tw4d_rf_on['delta'], 0, rtol=0, atol=1e-12)
+    xo.assert_allclose(tw4d_rf_off['delta'], 0, rtol=0, atol=1e-12)
+    xo.assert_allclose(tw4d_rf_on_crab_off['delta'], 0, rtol=0, atol=1e-12)
 
-    assert np.isclose(tw6d_rf_on['dx_zeta', 'ip1'], -190e-6, rtol=1e-4, atol=0)
-    assert np.isclose(tw6d_rf_on['dy_zeta', 'ip5'], -190e-6, rtol=1e-4, atol=0)
-    assert np.isclose(tw4d_rf_on['dx_zeta', 'ip1'], -190e-6, rtol=1e-4, atol=0)
-    assert np.isclose(tw4d_rf_on['dy_zeta', 'ip5'], -190e-6, rtol=1e-4, atol=0)
-    assert np.isclose(tw4d_rf_off['dx_zeta', 'ip1'], -190e-6, rtol=1e-4, atol=0)
-    assert np.isclose(tw4d_rf_off['dy_zeta', 'ip5'], -190e-6, rtol=1e-4, atol=0)
+    xo.assert_allclose(tw6d_rf_on['dx_zeta', 'ip1'], -190e-6, rtol=1e-4, atol=0)
+    xo.assert_allclose(tw6d_rf_on['dy_zeta', 'ip5'], -190e-6, rtol=1e-4, atol=0)
+    xo.assert_allclose(tw4d_rf_on['dx_zeta', 'ip1'], -190e-6, rtol=1e-4, atol=0)
+    xo.assert_allclose(tw4d_rf_on['dy_zeta', 'ip5'], -190e-6, rtol=1e-4, atol=0)
+    xo.assert_allclose(tw4d_rf_off['dx_zeta', 'ip1'], -190e-6, rtol=1e-4, atol=0)
+    xo.assert_allclose(tw4d_rf_off['dy_zeta', 'ip5'], -190e-6, rtol=1e-4, atol=0)
 
-    assert np.allclose(tw6d_rf_on_crab_off['dx_zeta'], 0, rtol=0, atol=1e-8)
-    assert np.allclose(tw6d_rf_on_crab_off['dy_zeta'], 0, rtol=0, atol=1e-8)
-    assert np.allclose(tw4d_rf_on_crab_off['dx_zeta'], 0, rtol=0, atol=1e-8)
-    assert np.allclose(tw4d_rf_on_crab_off['dy_zeta'], 0, rtol=0, atol=1e-8)
+    xo.assert_allclose(tw6d_rf_on_crab_off['dx_zeta'], 0, rtol=0, atol=1e-8)
+    xo.assert_allclose(tw6d_rf_on_crab_off['dy_zeta'], 0, rtol=0, atol=1e-8)
+    xo.assert_allclose(tw4d_rf_on_crab_off['dx_zeta'], 0, rtol=0, atol=1e-8)
+    xo.assert_allclose(tw4d_rf_on_crab_off['dy_zeta'], 0, rtol=0, atol=1e-8)
 
-    assert np.allclose(tw6d_rf_on['dx_zeta'], tw4d_rf_on['dx_zeta'], rtol=0, atol=1e-7)
-    assert np.allclose(tw6d_rf_on['dy_zeta'], tw4d_rf_on['dy_zeta'], rtol=0, atol=1e-7)
-    assert np.allclose(tw6d_rf_on['dx_zeta'], tw4d_rf_off['dx_zeta'], rtol=0, atol=1e-7)
-    assert np.allclose(tw6d_rf_on['dy_zeta'], tw4d_rf_off['dy_zeta'], rtol=0, atol=1e-7)
+    xo.assert_allclose(tw6d_rf_on['dx_zeta'], tw4d_rf_on['dx_zeta'], rtol=0, atol=1e-7)
+    xo.assert_allclose(tw6d_rf_on['dy_zeta'], tw4d_rf_on['dy_zeta'], rtol=0, atol=1e-7)
+    xo.assert_allclose(tw6d_rf_on['dx_zeta'], tw4d_rf_off['dx_zeta'], rtol=0, atol=1e-7)
+    xo.assert_allclose(tw6d_rf_on['dy_zeta'], tw4d_rf_off['dy_zeta'], rtol=0, atol=1e-7)
 
 @for_all_test_contexts
 def test_momentum_crab_dispersion(test_context):
@@ -1232,8 +1232,8 @@ def test_momentum_crab_dispersion(test_context):
     dpx_dzeta_expected = (tw4d_plus.px -  tw4d_minus.px) / (2*dz)
     dpy_dzeta_expected = (tw4d_plus.py -  tw4d_minus.py) / (2*dz)
 
-    assert np.allclose(tw6d['dpx_zeta'], dpx_dzeta_expected, rtol=0, atol=1e-7)
-    assert np.allclose(tw6d['dpy_zeta'], dpy_dzeta_expected, rtol=0, atol=1e-7)
+    xo.assert_allclose(tw6d['dpx_zeta'], dpx_dzeta_expected, rtol=0, atol=1e-7)
+    xo.assert_allclose(tw6d['dpy_zeta'], dpy_dzeta_expected, rtol=0, atol=1e-7)
 
 
 @for_all_test_contexts
@@ -1268,10 +1268,10 @@ def test_twiss_init_file(test_context):
         elif key == 'particle_on_co':
             loaded_pco = getattr(tw_init_loaded, key)
             for field in particle_check_fields:
-                assert np.isclose(getattr(val, field), getattr(loaded_pco, field),
-                                  atol=1e-9, rtol=0).all()
+                xo.assert_allclose(getattr(val, field), getattr(loaded_pco, field),
+                                  atol=1e-9, rtol=0)
         else:
-            assert np.isclose(tw_init_loaded.__dict__[key], val,  atol=1e-9, rtol=0).all()
+            xo.assert_allclose(tw_init_loaded.__dict__[key], val,  atol=1e-9, rtol=0)
 
     tw = line.twiss(start=location, end='ip7', init=tw_init_loaded)
 
@@ -1282,10 +1282,10 @@ def test_twiss_init_file(test_context):
     loc_check = line.element_names[line.element_names.index(location) + 300]
     for var in check_vars:
         # Check at starting point
-        assert np.isclose(tw[var, location], tw_full[var, location], atol=1e-9, rtol=0)
+        xo.assert_allclose(tw[var, location], tw_full[var, location], atol=1e-9, rtol=0)
 
         # Check at a point in a downstream arc
-        assert np.isclose(tw[var, loc_check], tw_full[var, loc_check], atol=2e-7, rtol=0)
+        xo.assert_allclose(tw[var, loc_check], tw_full[var, loc_check], atol=2e-7, rtol=0)
 
     twinit_file.unlink()
 
@@ -1341,50 +1341,50 @@ def test_custom_twiss_init(test_context):
         tw = line.twiss(start=location, end='ip7', init=tw_init_custom)
 
         # Check at starting point
-        assert np.isclose(tw['betx', location], betx0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['bety', location], bety0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['alfx', location], alfx0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['alfy', location], alfy0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['dx', location], dx0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['dpx', location], dpx0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['dy', location], dy0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['dpy', location], dpy0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['mux', location], mux0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['muy', location], muy0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['x', location], x0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['px', location], px0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['y', location], y0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['py', location], py0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['betx', location], betx0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['bety', location], bety0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['alfx', location], alfx0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['alfy', location], alfy0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['dx', location], dx0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['dpx', location], dpx0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['dy', location], dy0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['dpy', location], dpy0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['mux', location], mux0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['muy', location], muy0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['x', location], x0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['px', location], px0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['y', location], y0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['py', location], py0, atol=1e-9, rtol=0)
 
         # Check at a point in a downstream arc
         loc_check = f'mb.a24l7.{bn}..0'
-        assert np.isclose(tw['betx', loc_check], tw_full['betx', loc_check],
+        xo.assert_allclose(tw['betx', loc_check], tw_full['betx', loc_check],
                             atol=5e-6, rtol=0)
-        assert np.isclose(tw['bety', loc_check], tw_full['bety', loc_check],
+        xo.assert_allclose(tw['bety', loc_check], tw_full['bety', loc_check],
                             atol=5e-6, rtol=0)
-        assert np.isclose(tw['alfx', loc_check], tw_full['alfx', loc_check],
+        xo.assert_allclose(tw['alfx', loc_check], tw_full['alfx', loc_check],
                             atol=1e-7, rtol=0)
-        assert np.isclose(tw['alfy', loc_check], tw_full['alfy', loc_check],
+        xo.assert_allclose(tw['alfy', loc_check], tw_full['alfy', loc_check],
                             atol=1e-7, rtol=0)
-        assert np.isclose(tw['dx', loc_check], tw_full['dx', loc_check],
+        xo.assert_allclose(tw['dx', loc_check], tw_full['dx', loc_check],
                             atol=5e-8, rtol=0)
-        assert np.isclose(tw['dpx', loc_check], tw_full['dpx', loc_check],
+        xo.assert_allclose(tw['dpx', loc_check], tw_full['dpx', loc_check],
                             atol=1e-8, rtol=0)
-        assert np.isclose(tw['dy', loc_check], tw_full['dy', loc_check],
+        xo.assert_allclose(tw['dy', loc_check], tw_full['dy', loc_check],
                             atol=5e-8, rtol=0)
-        assert np.isclose(tw['dpy', loc_check], tw_full['dpy', loc_check],
+        xo.assert_allclose(tw['dpy', loc_check], tw_full['dpy', loc_check],
                             atol=1e-8, rtol=0)
-        assert np.isclose(tw['mux', loc_check], tw_full['mux', loc_check],
+        xo.assert_allclose(tw['mux', loc_check], tw_full['mux', loc_check],
                             atol=3e-9, rtol=0)
-        assert np.isclose(tw['muy', loc_check], tw_full['muy', loc_check],
+        xo.assert_allclose(tw['muy', loc_check], tw_full['muy', loc_check],
                             atol=3e-9, rtol=0)
-        assert np.isclose(tw['x', loc_check], tw_full['x', loc_check],
+        xo.assert_allclose(tw['x', loc_check], tw_full['x', loc_check],
                             atol=1e-9, rtol=0)
-        assert np.isclose(tw['px', loc_check], tw_full['px', loc_check],
+        xo.assert_allclose(tw['px', loc_check], tw_full['px', loc_check],
                             atol=1e-9, rtol=0)
-        assert np.isclose(tw['y', loc_check], tw_full['y', loc_check],
+        xo.assert_allclose(tw['y', loc_check], tw_full['y', loc_check],
                             atol=1e-9, rtol=0)
-        assert np.isclose(tw['py', loc_check], tw_full['py', loc_check],
+        xo.assert_allclose(tw['py', loc_check], tw_full['py', loc_check],
                             atol=1e-9, rtol=0)
 
         # twiss with boundary confitions at the end of the range
@@ -1397,49 +1397,49 @@ def test_custom_twiss_init(test_context):
         tw = line.twiss(start='ip4', end=location, init=tw_init_custom)
 
         # Check at end point
-        assert np.isclose(tw['betx', location], betx0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['bety', location], bety0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['alfx', location], alfx0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['alfy', location], alfy0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['dx', location], dx0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['dpx', location], dpx0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['dy', location], dy0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['dpy', location], dpy0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['mux', location], mux0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['muy', location], muy0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['x', location], x0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['px', location], px0, atol=1e-9, rtol=0)
-        assert np.isclose(tw['y', location], y0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['betx', location], betx0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['bety', location], bety0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['alfx', location], alfx0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['alfy', location], alfy0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['dx', location], dx0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['dpx', location], dpx0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['dy', location], dy0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['dpy', location], dpy0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['mux', location], mux0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['muy', location], muy0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['x', location], x0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['px', location], px0, atol=1e-9, rtol=0)
+        xo.assert_allclose(tw['y', location], y0, atol=1e-9, rtol=0)
 
         # Check at a point in an upstream arc
         loc_check = f'mb.a24r4.{bn}..0'
-        assert np.isclose(tw['betx', loc_check], tw_full['betx', loc_check],
+        xo.assert_allclose(tw['betx', loc_check], tw_full['betx', loc_check],
                             atol=5e-6, rtol=0)
-        assert np.isclose(tw['bety', loc_check], tw_full['bety', loc_check],
+        xo.assert_allclose(tw['bety', loc_check], tw_full['bety', loc_check],
                             atol=5e-6, rtol=0)
-        assert np.isclose(tw['alfx', loc_check], tw_full['alfx', loc_check],
+        xo.assert_allclose(tw['alfx', loc_check], tw_full['alfx', loc_check],
                             atol=5e-8, rtol=0)
-        assert np.isclose(tw['alfy', loc_check], tw_full['alfy', loc_check],
+        xo.assert_allclose(tw['alfy', loc_check], tw_full['alfy', loc_check],
                             atol=5e-8, rtol=0)
-        assert np.isclose(tw['dx', loc_check], tw_full['dx', loc_check],
+        xo.assert_allclose(tw['dx', loc_check], tw_full['dx', loc_check],
                             atol=1e-8, rtol=0)
-        assert np.isclose(tw['dpx', loc_check], tw_full['dpx', loc_check],
+        xo.assert_allclose(tw['dpx', loc_check], tw_full['dpx', loc_check],
                             atol=1e-8, rtol=0)
-        assert np.isclose(tw['dy', loc_check], tw_full['dy', loc_check],
+        xo.assert_allclose(tw['dy', loc_check], tw_full['dy', loc_check],
                             atol=1e-8, rtol=0)
-        assert np.isclose(tw['dpy', loc_check], tw_full['dpy', loc_check],
+        xo.assert_allclose(tw['dpy', loc_check], tw_full['dpy', loc_check],
                             atol=1e-8, rtol=0)
-        assert np.isclose(tw['mux', loc_check], tw_full['mux', loc_check],
+        xo.assert_allclose(tw['mux', loc_check], tw_full['mux', loc_check],
                             atol=5e-9, rtol=0)
-        assert np.isclose(tw['muy', loc_check], tw_full['muy', loc_check],
+        xo.assert_allclose(tw['muy', loc_check], tw_full['muy', loc_check],
                             atol=5e-9, rtol=0)
-        assert np.isclose(tw['x', loc_check], tw_full['x', loc_check],
+        xo.assert_allclose(tw['x', loc_check], tw_full['x', loc_check],
                             atol=1e-9, rtol=0)
-        assert np.isclose(tw['px', loc_check], tw_full['px', loc_check],
+        xo.assert_allclose(tw['px', loc_check], tw_full['px', loc_check],
                             atol=1e-9, rtol=0)
-        assert np.isclose(tw['y', loc_check], tw_full['y', loc_check],
+        xo.assert_allclose(tw['y', loc_check], tw_full['y', loc_check],
                             atol=1e-9, rtol=0)
-        assert np.isclose(tw['py', loc_check], tw_full['py', loc_check],
+        xo.assert_allclose(tw['py', loc_check], tw_full['py', loc_check],
                             atol=1e-9, rtol=0)
 
 @for_all_test_contexts
@@ -1476,10 +1476,10 @@ def test_adaptive_steps_for_rmatrix(test_context):
     expected_dx_b2 = 0.01 * np.sqrt(1e-6 * 0.15 / collider.lhcb1.particle_ref._xobject.gamma0[0])
     expected_dy_b2 = 0.01 * np.sqrt(2e-8 * 0.15 / collider.lhcb2.particle_ref._xobject.gamma0[0])
 
-    assert np.isclose(tw.lhcb1.steps_r_matrix['dx'], expected_dx_b1, atol=0, rtol=1e-4)
-    assert np.isclose(tw.lhcb1.steps_r_matrix['dy'], expected_dy_b1, atol=0, rtol=1e-4)
-    assert np.isclose(tw.lhcb2.steps_r_matrix['dx'], expected_dx_b2, atol=0, rtol=1e-4)
-    assert np.isclose(tw.lhcb2.steps_r_matrix['dy'], expected_dy_b2, atol=0, rtol=1e-4)
+    xo.assert_allclose(tw.lhcb1.steps_r_matrix['dx'], expected_dx_b1, atol=0, rtol=1e-4)
+    xo.assert_allclose(tw.lhcb1.steps_r_matrix['dy'], expected_dy_b1, atol=0, rtol=1e-4)
+    xo.assert_allclose(tw.lhcb2.steps_r_matrix['dx'], expected_dx_b2, atol=0, rtol=1e-4)
+    xo.assert_allclose(tw.lhcb2.steps_r_matrix['dy'], expected_dy_b2, atol=0, rtol=1e-4)
 
 @for_all_test_contexts
 def test_longitudinal_beam_sizes(test_context):
@@ -1501,8 +1501,8 @@ def test_longitudinal_beam_sizes(test_context):
     beam_sizes = tw.get_beam_covariance(nemitt_x=nemitt_x, nemitt_y=nemitt_y,
                                         gemitt_zeta=gemitt_zeta)
 
-    assert np.allclose(beam_sizes.sigma_pzeta, 2e-4, atol=0, rtol=2e-5)
-    assert np.allclose(
+    xo.assert_allclose(beam_sizes.sigma_pzeta, 2e-4, atol=0, rtol=2e-5)
+    xo.assert_allclose(
         beam_sizes.sigma_zeta / beam_sizes.sigma_pzeta, tw.bets0, atol=0, rtol=5e-5)
 
 @for_all_test_contexts
@@ -1558,34 +1558,34 @@ def test_second_order_chromaticity_and_dispersion(test_context):
     pxs_qx = np.polyfit(delta, qx_xs, 3)
     pxs_qy = np.polyfit(delta, qy_xs, 3)
 
-    assert np.allclose(delta, nlchr.delta0, atol=1e-6, rtol=0)
-    assert np.allclose(tw['dx', location], pxs_x[-2], atol=0, rtol=1e-4)
-    assert np.allclose(tw['dpx', location], pxs_px[-2], atol=0, rtol=1e-4)
-    assert np.allclose(tw['dy', location], pxs_y[-2], atol=0, rtol=1e-4)
-    assert np.allclose(tw['dpy', location], pxs_py[-2], atol=0, rtol=1e-4)
-    assert np.allclose(tw['ddx', location], 2*pxs_x[-3], atol=0, rtol=1e-4)
-    assert np.allclose(tw['ddpx', location], 2*pxs_px[-3], atol=0, rtol=1e-4)
-    assert np.allclose(tw['ddy', location], 2*pxs_y[-3], atol=0, rtol=1e-4)
-    assert np.allclose(tw['ddpy', location], 2*pxs_py[-3], atol=0, rtol=1e-4)
-    assert np.isclose(tw['dqx'], pxs_qx[-2], atol=0, rtol=1e-3)
-    assert np.isclose(tw['ddqx'], pxs_qx[-3]*2, atol=0, rtol=1e-2)
-    assert np.isclose(tw['dqy'], pxs_qy[-2], atol=0, rtol=1e-3)
-    assert np.isclose(tw['ddqy'], pxs_qy[-3]*2, atol=0, rtol=1e-2)
+    xo.assert_allclose(delta, nlchr.delta0, atol=1e-6, rtol=0)
+    xo.assert_allclose(tw['dx', location], pxs_x[-2], atol=0, rtol=1e-4)
+    xo.assert_allclose(tw['dpx', location], pxs_px[-2], atol=0, rtol=1e-4)
+    xo.assert_allclose(tw['dy', location], pxs_y[-2], atol=0, rtol=1e-4)
+    xo.assert_allclose(tw['dpy', location], pxs_py[-2], atol=0, rtol=1e-4)
+    xo.assert_allclose(tw['ddx', location], 2*pxs_x[-3], atol=0, rtol=1e-4)
+    xo.assert_allclose(tw['ddpx', location], 2*pxs_px[-3], atol=0, rtol=1e-4)
+    xo.assert_allclose(tw['ddy', location], 2*pxs_y[-3], atol=0, rtol=1e-4)
+    xo.assert_allclose(tw['ddpy', location], 2*pxs_py[-3], atol=0, rtol=1e-4)
+    xo.assert_allclose(tw['dqx'], pxs_qx[-2], atol=0, rtol=1e-3)
+    xo.assert_allclose(tw['ddqx'], pxs_qx[-3]*2, atol=0, rtol=1e-2)
+    xo.assert_allclose(tw['dqy'], pxs_qy[-2], atol=0, rtol=1e-3)
+    xo.assert_allclose(tw['ddqy'], pxs_qy[-3]*2, atol=0, rtol=1e-2)
 
-    assert np.isclose(nlchr['dqx'], pxs_qx[-2], atol=0, rtol=2e-3)
-    assert np.isclose(nlchr['dqy'], pxs_qy[-2], atol=0, rtol=2e-3)
-    assert np.isclose(nlchr['ddqx'], pxs_qx[-3]*2, atol=0, rtol=1e-4)
-    assert np.isclose(nlchr['ddqy'], pxs_qy[-3]*2, atol=0, rtol=1e-4)
+    xo.assert_allclose(nlchr['dqx'], pxs_qx[-2], atol=0, rtol=2e-3)
+    xo.assert_allclose(nlchr['dqy'], pxs_qy[-2], atol=0, rtol=2e-3)
+    xo.assert_allclose(nlchr['ddqx'], pxs_qx[-3]*2, atol=0, rtol=1e-4)
+    xo.assert_allclose(nlchr['ddqy'], pxs_qy[-3]*2, atol=0, rtol=1e-4)
 
     tw_part = tw.rows['ip4':'ip6']
-    assert np.allclose(tw_part['ddx'], tw_fw.rows[:-1]['ddx'], atol=1e-2, rtol=0)
-    assert np.allclose(tw_part['ddy'], tw_fw.rows[:-1]['ddy'], atol=1e-2, rtol=0)
-    assert np.allclose(tw_part['ddpx'], tw_fw.rows[:-1]['ddpx'], atol=1e-3, rtol=0)
-    assert np.allclose(tw_part['ddpy'], tw_fw.rows[:-1]['ddpy'], atol=1e-3, rtol=0)
-    assert np.allclose(tw_part['dx'], tw_bw.rows[:-1]['dx'], atol=1e-2, rtol=0)
-    assert np.allclose(tw_part['dy'], tw_bw.rows[:-1]['dy'], atol=1e-2, rtol=0)
-    assert np.allclose(tw_part['dpx'], tw_bw.rows[:-1]['dpx'], atol=1e-3, rtol=0)
-    assert np.allclose(tw_part['dpy'], tw_bw.rows[:-1]['dpy'], atol=1e-3, rtol=0)
+    xo.assert_allclose(tw_part['ddx'], tw_fw.rows[:-1]['ddx'], atol=1e-2, rtol=0)
+    xo.assert_allclose(tw_part['ddy'], tw_fw.rows[:-1]['ddy'], atol=1e-2, rtol=0)
+    xo.assert_allclose(tw_part['ddpx'], tw_fw.rows[:-1]['ddpx'], atol=1e-3, rtol=0)
+    xo.assert_allclose(tw_part['ddpy'], tw_fw.rows[:-1]['ddpy'], atol=1e-3, rtol=0)
+    xo.assert_allclose(tw_part['dx'], tw_bw.rows[:-1]['dx'], atol=1e-2, rtol=0)
+    xo.assert_allclose(tw_part['dy'], tw_bw.rows[:-1]['dy'], atol=1e-2, rtol=0)
+    xo.assert_allclose(tw_part['dpx'], tw_bw.rows[:-1]['dpx'], atol=1e-3, rtol=0)
+    xo.assert_allclose(tw_part['dpy'], tw_bw.rows[:-1]['dpy'], atol=1e-3, rtol=0)
 
 @for_all_test_contexts
 def test_twiss_strength_reverse_vs_madx(test_context):

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -1729,5 +1729,9 @@ def test_twiss_range_start_end(test_context, line_name, reverse, section, collid
     for kk in tw_test._data.keys():
         if kk in ('particle_on_co', '_action'):
             continue
-        assert np.all(tw_test._data[kk] == tw_ref._data[kk]), (
-            'Issues with variable: ' + kk)
+
+        if kk in ('name', 'method', 'values_at', 'radiation_method', 'reference_frame'):
+            assert np.all(tw_test._data[kk] == tw_ref._data[kk])
+            continue
+
+        xo.assert_allclose(tw_test._data[kk], tw_ref._data[kk], rtol=0, atol=1e-14)

--- a/tests/test_twiss_vs_madx_psb.py
+++ b/tests/test_twiss_vs_madx_psb.py
@@ -1,12 +1,11 @@
 import pathlib
-import json
 
 import numpy as np
 from cpymad.madx import Madx
 
+import xobjects as xo
 import xpart as xp
 import xtrack as xt
-import xobjects as xo
 from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
@@ -32,17 +31,17 @@ def test_twiss_psb(test_context):
     # With the approximation beta ~= beta0 we have delta ~= pzeta ~= 1/beta0 ptau
     # ==> ptau ~= beta0 delta ==> dptau / ddelta~= beta0
 
-    assert np.isclose(tw.dqx, twmad.summary.dq1 * beta0, rtol=0, atol=1e-5)
-    assert np.isclose(tw.dqy, twmad.summary.dq2 * beta0, rtol=0, atol=1e-5)
+    xo.assert_allclose(tw.dqx, twmad.summary.dq1 * beta0, rtol=0, atol=1e-5)
+    xo.assert_allclose(tw.dqy, twmad.summary.dq2 * beta0, rtol=0, atol=1e-5)
 
     dx_ref = np.interp(tw.s, twmad.s, twmad.dx * beta0)
     betx_ref = np.interp(tw.s, twmad.s, twmad.betx)
     bety_ref = np.interp(tw.s, twmad.s, twmad.bety)
 
-    assert np.allclose(tw.dx, dx_ref, rtol=0, atol=1e-3)
-    assert np.allclose(tw.betx, betx_ref, rtol=1e-5, atol=0)
-    assert np.allclose(tw.bety, bety_ref, rtol=1e-5, atol=0)
+    xo.assert_allclose(tw.dx, dx_ref, rtol=0, atol=1e-3)
+    xo.assert_allclose(tw.betx, betx_ref, rtol=1e-5, atol=0)
+    xo.assert_allclose(tw.bety, bety_ref, rtol=1e-5, atol=0)
 
-    assert np.isclose(tw.momentum_compaction_factor, twmad.summary.alfa,
+    xo.assert_allclose(tw.momentum_compaction_factor, twmad.summary.alfa,
                       atol=0, rtol=5e-3)
 

--- a/tests/test_var_cache.py
+++ b/tests/test_var_cache.py
@@ -1,11 +1,9 @@
 import pathlib
 
-import numpy as np
-
-import xtrack as xt
-import xpart as xp
 import xdeps as xd
-
+import xobjects as xo
+import xpart as xp
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
@@ -55,9 +53,9 @@ def test_var_cache(test_context):
     assert collider.vars['on_x1']._value == 11
     assert collider.vars['on_x5']._value == 55
 
-    assert np.isclose(
+    xo.assert_allclose(
         collider['lhcb1'].twiss()['px', 'ip1'], 11e-6, atol=1e-9, rtol=0)
-    assert np.isclose(
+    xo.assert_allclose(
         collider['lhcb1'].twiss()['py', 'ip5'], 55e-6, atol=1e-9, rtol=0)
 
     collider.vars['on_x1'] = 234
@@ -66,14 +64,14 @@ def test_var_cache(test_context):
     assert collider.vars['on_x1']._value == 234
     assert collider.vars['on_x5']._value == 123
 
-    assert np.isclose(
+    xo.assert_allclose(
         collider['lhcb1'].twiss()['px', 'ip1'], 234e-6, atol=1e-9, rtol=0)
-    assert np.isclose(
+    xo.assert_allclose(
         collider['lhcb1'].twiss()['py', 'ip5'], 123e-6, atol=1e-9, rtol=0)
 
     collider.vars['on_x2'] = 234
 
-    assert np.isclose(
+    xo.assert_allclose(
         collider['lhcb1'].twiss()['py', 'ip2'], 234e-6, atol=1e-9, rtol=0)
 
     collider.vars.cache_active = False
@@ -124,9 +122,9 @@ def test_var_cache(test_context):
     assert line.vars['on_x1']._value == 11
     assert line.vars['on_x5']._value == 55
 
-    assert np.isclose(
+    xo.assert_allclose(
         line.twiss()['px', 'ip1'], 11e-6, atol=1e-9, rtol=0)
-    assert np.isclose(
+    xo.assert_allclose(
         line.twiss()['py', 'ip5'], 55e-6, atol=1e-9, rtol=0)
 
     line.vars['on_x1'] = 234
@@ -135,14 +133,14 @@ def test_var_cache(test_context):
     assert line.vars['on_x1']._value == 234
     assert line.vars['on_x5']._value == 123
 
-    assert np.isclose(
+    xo.assert_allclose(
         line.twiss()['px', 'ip1'], 234e-6, atol=1e-9, rtol=0)
-    assert np.isclose(
+    xo.assert_allclose(
         line.twiss()['py', 'ip5'], 123e-6, atol=1e-9, rtol=0)
 
     line.vars['on_x2'] = 234
 
-    assert np.isclose(
+    xo.assert_allclose(
         line.twiss()['py', 'ip2'], 234e-6, atol=1e-9, rtol=0)
 
     line.vars.cache_active = False
@@ -186,9 +184,9 @@ def test_var_cache(test_context):
     assert line.vars['on_x1']._value == 11
     assert line.vars['on_x5']._value == 55
 
-    assert np.isclose(
+    xo.assert_allclose(
         line.twiss()['px', 'ip1'], 11e-6, atol=1e-9, rtol=0)
-    assert np.isclose(
+    xo.assert_allclose(
         line.twiss()['py', 'ip5'], 55e-6, atol=1e-9, rtol=0)
 
     line.vars['on_x1'] = 234
@@ -197,14 +195,14 @@ def test_var_cache(test_context):
     assert line.vars['on_x1']._value == 234
     assert line.vars['on_x5']._value == 123
 
-    assert np.isclose(
+    xo.assert_allclose(
         line.twiss()['px', 'ip1'], 234e-6, atol=1e-9, rtol=0)
-    assert np.isclose(
+    xo.assert_allclose(
         line.twiss()['py', 'ip5'], 123e-6, atol=1e-9, rtol=0)
 
     line.vars['on_x2'] = 234
 
-    assert np.isclose(
+    xo.assert_allclose(
         line.twiss()['py', 'ip2'], 234e-6, atol=1e-9, rtol=0)
 
     line.vars.cache_active = False

--- a/tests/test_vs_madx.py
+++ b/tests/test_vs_madx.py
@@ -4,16 +4,15 @@
 # ######################################### #
 
 import pathlib
+
 import numpy as np
 import pytest
-
-import xobjects as xo
-import xtrack as xt
-import xpart as xp
-from xobjects.test_helpers import for_all_test_contexts
-
 from cpymad.madx import Madx
 
+import xobjects as xo
+import xpart as xp
+import xtrack as xt
+from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
         __file__).parent.joinpath('../test_data').absolute()
@@ -193,14 +192,14 @@ def test_twiss_and_survey(
 
         # Check against mad
         for twtst in [twxt, twxt4d]:
-            assert np.isclose(mad_ref.table.summ.q1[0], twtst['qx'], rtol=1e-4, atol=0)
-            assert np.isclose(mad_ref.table.summ.q2[0], twtst['qy'], rtol=1e-4, atol=0)
-            assert np.isclose(mad_ref.table.summ.dq1, twtst['dqx'], atol=0.1, rtol=0)
-            assert np.isclose(mad_ref.table.summ.dq2, twtst['dqy'], atol=0.1, rtol=0)
-            assert np.isclose(mad_ref.table.summ.alfa[0],
+            xo.assert_allclose(mad_ref.table.summ.q1[0], twtst['qx'], rtol=1e-4, atol=0)
+            xo.assert_allclose(mad_ref.table.summ.q2[0], twtst['qy'], rtol=1e-4, atol=0)
+            xo.assert_allclose(mad_ref.table.summ.dq1, twtst['dqx'], atol=0.1, rtol=0)
+            xo.assert_allclose(mad_ref.table.summ.dq2, twtst['dqy'], atol=0.1, rtol=0)
+            xo.assert_allclose(mad_ref.table.summ.alfa[0],
                 twtst['momentum_compaction_factor'], atol=7e-8, rtol=0)
             if twtst is not tw4d_part:
-                assert np.isclose(twxt['qs'], 0.0021, atol=1e-4, rtol=0)
+                xo.assert_allclose(twxt['qs'], 0.0021, atol=1e-4, rtol=0)
 
 
         for is_part, twtst in zip([False, False, True, True],
@@ -239,23 +238,23 @@ def test_twiss_and_survey(
                 mad_shift_x = eemad.align_errors.dx if eemad.align_errors else 0
                 mad_shift_y = eemad.align_errors.dy if eemad.align_errors else 0
 
-                assert np.isclose(twtst['s'][ixt], twmad['s'][imad],
+                xo.assert_allclose(twtst['s'][ixt], twmad['s'][imad],
                                 atol=1e-6, rtol=0)
-                assert np.isclose(twtst['betx'][ixt], twmad['betx'][imad],
+                xo.assert_allclose(twtst['betx'][ixt], twmad['betx'][imad],
                                 atol=0, rtol=7e-4)
-                assert np.isclose(twtst['bety'][ixt], twmad['bety'][imad],
+                xo.assert_allclose(twtst['bety'][ixt], twmad['bety'][imad],
                                 atol=0, rtol=7e-4)
-                assert np.isclose(twtst['alfx'][ixt], twmad['alfx'][imad],
+                xo.assert_allclose(twtst['alfx'][ixt], twmad['alfx'][imad],
                                 atol=1e-1, rtol=0)
-                assert np.isclose(twtst['alfy'][ixt], twmad['alfy'][imad],
+                xo.assert_allclose(twtst['alfy'][ixt], twmad['alfy'][imad],
                                 atol=1e-1, rtol=0)
-                assert np.isclose(twtst['dx'][ixt], twmad['dx'][imad],
+                xo.assert_allclose(twtst['dx'][ixt], twmad['dx'][imad],
                                 atol=1e-2, rtol=0)
-                assert np.isclose(twtst['dy'][ixt], twmad['dy'][imad],
+                xo.assert_allclose(twtst['dy'][ixt], twmad['dy'][imad],
                                 atol=1e-2, rtol=0)
-                assert np.isclose(twtst['dpx'][ixt], twmad['dpx'][imad],
+                xo.assert_allclose(twtst['dpx'][ixt], twmad['dpx'][imad],
                                 atol=3e-4, rtol=0)
-                assert np.isclose(twtst['dpy'][ixt], twmad['dpy'][imad],
+                xo.assert_allclose(twtst['dpy'][ixt], twmad['dpy'][imad],
                                 atol=3e-4, rtol=0)
 
                 if is_part:
@@ -270,91 +269,91 @@ def test_twiss_and_survey(
                     muy0_mad = 0
                     mux0_tst = 0
                     muy0_tst = 0
-                assert np.isclose(twtst['mux'][ixt] - mux0_tst,
+                xo.assert_allclose(twtst['mux'][ixt] - mux0_tst,
                                   twmad['mux'][imad] - mux0_mad,
                                   atol=1e-4, rtol=0)
-                assert np.isclose(twtst['muy'][ixt] - muy0_tst,
+                xo.assert_allclose(twtst['muy'][ixt] - muy0_tst,
                                   twmad['muy'][imad] - muy0_mad,
                                   atol=1e-4, rtol=0)
 
-                assert np.isclose(twtst['s'][ixt], twmad['s'][imad],
+                xo.assert_allclose(twtst['s'][ixt], twmad['s'][imad],
                                 atol=5e-6, rtol=0)
 
                 # I check the orbit relative to sigma to be more accurate at the IP
                 sigx = np.sqrt(twmad['sig11'][imad])
                 sigy = np.sqrt(twmad['sig33'][imad])
 
-                assert np.isclose(twtst['x'][ixt], twmad['x'][imad],
+                xo.assert_allclose(twtst['x'][ixt], twmad['x'][imad],
                                 atol=0.03*sigx, rtol=0)
-                assert np.isclose(twtst['y'][ixt],
+                xo.assert_allclose(twtst['y'][ixt],
                                 (twmad['y'][imad]),
                                 atol=0.03*sigy, rtol=0)
 
-                assert np.isclose(twtst['px'][ixt], twmad['px'][imad],
+                xo.assert_allclose(twtst['px'][ixt], twmad['px'][imad],
                                 atol=2e-7, rtol=0)
-                assert np.isclose(twtst['py'][ixt], twmad['py'][imad],
+                xo.assert_allclose(twtst['py'][ixt], twmad['py'][imad],
                                 atol=2e-7, rtol=0)
 
-                assert np.isclose(Sigmas.Sigma11[ixt], twmad['sig11'][imad], atol=5e-10)
-                assert np.isclose(Sigmas.Sigma12[ixt], twmad['sig12'][imad], atol=3e-12)
-                assert np.isclose(Sigmas.Sigma22[ixt], twmad['sig22'][imad], atol=1e-12)
-                assert np.isclose(Sigmas.Sigma33[ixt], twmad['sig33'][imad], atol=5e-10)
-                assert np.isclose(Sigmas.Sigma34[ixt], twmad['sig34'][imad], atol=3e-12)
-                assert np.isclose(Sigmas.Sigma44[ixt], twmad['sig44'][imad], atol=1e-12)
+                xo.assert_allclose(Sigmas.Sigma11[ixt], twmad['sig11'][imad], atol=5e-10)
+                xo.assert_allclose(Sigmas.Sigma12[ixt], twmad['sig12'][imad], atol=3e-12)
+                xo.assert_allclose(Sigmas.Sigma22[ixt], twmad['sig22'][imad], atol=1e-12)
+                xo.assert_allclose(Sigmas.Sigma33[ixt], twmad['sig33'][imad], atol=5e-10)
+                xo.assert_allclose(Sigmas.Sigma34[ixt], twmad['sig34'][imad], rtol=1e-4, atol=3e-12)
+                xo.assert_allclose(Sigmas.Sigma44[ixt], twmad['sig44'][imad], atol=1e-12)
 
                 if twtst not in [twxt4d, tw4d_part]: # 4d less precise due to different momentum (coupling comes from feeddown)
-                    assert np.isclose(Sigmas.Sigma13[ixt], twmad['sig13'][imad], atol=5e-10)
-                    assert np.isclose(Sigmas.Sigma14[ixt], twmad['sig14'][imad], atol=2e-12)
-                    assert np.isclose(Sigmas.Sigma23[ixt], twmad['sig23'][imad], atol=1e-12)
-                    assert np.isclose(Sigmas.Sigma24[ixt], twmad['sig24'][imad], atol=1e-12)
+                    xo.assert_allclose(Sigmas.Sigma13[ixt], twmad['sig13'][imad], atol=5e-10)
+                    xo.assert_allclose(Sigmas.Sigma14[ixt], twmad['sig14'][imad], atol=2e-12)
+                    xo.assert_allclose(Sigmas.Sigma23[ixt], twmad['sig23'][imad], atol=1e-12)
+                    xo.assert_allclose(Sigmas.Sigma24[ixt], twmad['sig24'][imad], atol=1e-12)
 
                 # check matrix is symmetric
-                assert np.isclose(Sigmas.Sigma12[ixt], Sigmas.Sigma21[ixt], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma13[ixt], Sigmas.Sigma31[ixt], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma14[ixt], Sigmas.Sigma41[ixt], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma23[ixt], Sigmas.Sigma32[ixt], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma24[ixt], Sigmas.Sigma42[ixt], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma34[ixt], Sigmas.Sigma43[ixt], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma12[ixt], Sigmas.Sigma21[ixt], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma13[ixt], Sigmas.Sigma31[ixt], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma14[ixt], Sigmas.Sigma41[ixt], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma23[ixt], Sigmas.Sigma32[ixt], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma24[ixt], Sigmas.Sigma42[ixt], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma34[ixt], Sigmas.Sigma43[ixt], atol=1e-16)
 
                 # check matrix consistency with Sigma.Sigma
-                assert np.isclose(Sigmas.Sigma11[ixt], Sigmas.Sigma[ixt][0, 0], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma12[ixt], Sigmas.Sigma[ixt][0, 1], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma13[ixt], Sigmas.Sigma[ixt][0, 2], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma14[ixt], Sigmas.Sigma[ixt][0, 3], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma21[ixt], Sigmas.Sigma[ixt][1, 0], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma22[ixt], Sigmas.Sigma[ixt][1, 1], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma23[ixt], Sigmas.Sigma[ixt][1, 2], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma24[ixt], Sigmas.Sigma[ixt][1, 3], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma31[ixt], Sigmas.Sigma[ixt][2, 0], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma32[ixt], Sigmas.Sigma[ixt][2, 1], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma33[ixt], Sigmas.Sigma[ixt][2, 2], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma34[ixt], Sigmas.Sigma[ixt][2, 3], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma41[ixt], Sigmas.Sigma[ixt][3, 0], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma42[ixt], Sigmas.Sigma[ixt][3, 1], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma43[ixt], Sigmas.Sigma[ixt][3, 2], atol=1e-16)
-                assert np.isclose(Sigmas.Sigma44[ixt], Sigmas.Sigma[ixt][3, 3], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma11[ixt], Sigmas.Sigma[ixt][0, 0], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma12[ixt], Sigmas.Sigma[ixt][0, 1], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma13[ixt], Sigmas.Sigma[ixt][0, 2], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma14[ixt], Sigmas.Sigma[ixt][0, 3], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma21[ixt], Sigmas.Sigma[ixt][1, 0], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma22[ixt], Sigmas.Sigma[ixt][1, 1], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma23[ixt], Sigmas.Sigma[ixt][1, 2], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma24[ixt], Sigmas.Sigma[ixt][1, 3], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma31[ixt], Sigmas.Sigma[ixt][2, 0], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma32[ixt], Sigmas.Sigma[ixt][2, 1], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma33[ixt], Sigmas.Sigma[ixt][2, 2], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma34[ixt], Sigmas.Sigma[ixt][2, 3], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma41[ixt], Sigmas.Sigma[ixt][3, 0], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma42[ixt], Sigmas.Sigma[ixt][3, 1], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma43[ixt], Sigmas.Sigma[ixt][3, 2], atol=1e-16)
+                xo.assert_allclose(Sigmas.Sigma44[ixt], Sigmas.Sigma[ixt][3, 3], atol=1e-16)
 
                 # Check sigma_x, sigma_y
-                assert np.isclose(Sigmas.sigma_x[ixt], np.sqrt(Sigmas.Sigma11[ixt]), atol=1e-16)
-                assert np.isclose(Sigmas.sigma_y[ixt], np.sqrt(Sigmas.Sigma33[ixt]), atol=1e-16)
-                assert np.isclose(Sigmas.sigma_px[ixt], np.sqrt(Sigmas.Sigma22[ixt]), atol=1e-16)
-                assert np.isclose(Sigmas.sigma_py[ixt], np.sqrt(Sigmas.Sigma44[ixt]), atol=1e-16)
+                xo.assert_allclose(Sigmas.sigma_x[ixt], np.sqrt(Sigmas.Sigma11[ixt]), atol=1e-16)
+                xo.assert_allclose(Sigmas.sigma_y[ixt], np.sqrt(Sigmas.Sigma33[ixt]), atol=1e-16)
+                xo.assert_allclose(Sigmas.sigma_px[ixt], np.sqrt(Sigmas.Sigma22[ixt]), atol=1e-16)
+                xo.assert_allclose(Sigmas.sigma_py[ixt], np.sqrt(Sigmas.Sigma44[ixt]), atol=1e-16)
 
                 if not(is_part): # We don't have survey on a part of the machine
                     # Check survey
-                    assert np.isclose(survxt.X[ixt], survmad['X'][imad], atol=1e-6)
-                    assert np.isclose(survxt.Y[ixt], survmad['Y'][imad], atol=1e-6)
-                    assert np.isclose(survxt.Z[ixt], survmad['Z'][imad], atol=1e-6)
-                    assert np.isclose(survxt.s[ixt], survmad['s'][imad], atol=5e-6)
-                    assert np.isclose(survxt.phi[ixt], survmad['phi'][imad], atol=1e-10)
-                    assert np.isclose(survxt.theta[ixt], survmad['theta'][imad], atol=1e-10)
-                    assert np.isclose(survxt.psi[ixt], survmad['psi'][imad], atol=1e-10)
+                    xo.assert_allclose(survxt.X[ixt], survmad['X'][imad], atol=1e-6)
+                    xo.assert_allclose(survxt.Y[ixt], survmad['Y'][imad], rtol=2e-7, atol=1e-6)
+                    xo.assert_allclose(survxt.Z[ixt], survmad['Z'][imad], atol=1e-6)
+                    xo.assert_allclose(survxt.s[ixt], survmad['s'][imad], atol=5e-6)
+                    xo.assert_allclose(survxt.phi[ixt], survmad['phi'][imad], atol=1e-10)
+                    xo.assert_allclose(survxt.theta[ixt], survmad['theta'][imad], atol=1e-10)
+                    xo.assert_allclose(survxt.psi[ixt], survmad['psi'][imad], atol=1e-10)
 
                     # angle and tilt are associated to the element itself (ixt - 1)
                     # For now not checking the sign of the angles, convetion in mad-X to be calrified
-                    assert np.isclose(np.abs(survxt.angle[ixt-1]),
+                    xo.assert_allclose(np.abs(survxt.angle[ixt-1]),
                             np.abs(survmad['angle'][imad]), atol=1e-10)
-                    assert np.isclose(survxt.tilt[ixt-1], survmad['tilt'][imad], atol=1e-10)
+                    xo.assert_allclose(survxt.tilt[ixt-1], survmad['tilt'][imad], atol=1e-10)
 
         # Check to_pandas (not extensively for now)
         dftw = twtst.to_pandas()
@@ -367,14 +366,14 @@ def test_twiss_and_survey(
             s_test = [2e3, 1e3, 3e3, 10e3]
             twats = line.twiss(at_s = s_test)
             for ii, ss in enumerate(s_test):
-                assert np.isclose(twats['s'][ii], ss, rtol=0, atol=1e-14)
-                assert np.isclose(twats['alfx'][ii], np.interp(ss, twxt['s'], twxt['alfx']),
+                xo.assert_allclose(twats['s'][ii], ss, rtol=0, atol=1e-14)
+                xo.assert_allclose(twats['alfx'][ii], np.interp(ss, twxt['s'], twxt['alfx']),
                                 rtol=1e-5, atol=0)
-                assert np.isclose(twats['alfy'][ii], np.interp(ss, twxt['s'], twxt['alfy']),
+                xo.assert_allclose(twats['alfy'][ii], np.interp(ss, twxt['s'], twxt['alfy']),
                                 rtol=1e-5, atol=0)
-                assert np.isclose(twats['dpx'][ii], np.interp(ss, twxt['s'], twxt['dpx']),
+                xo.assert_allclose(twats['dpx'][ii], np.interp(ss, twxt['s'], twxt['dpx']),
                                 rtol=1e-5, atol=0)
-                assert np.isclose(twats['dpy'][ii], np.interp(ss, twxt['s'], twxt['dpy']),
+                xo.assert_allclose(twats['dpy'][ii], np.interp(ss, twxt['s'], twxt['dpy']),
                                 rtol=1e-5, atol=0)
 
 
@@ -443,20 +442,20 @@ def test_line_import_from_madx(test_context, mad_with_errors):
         if isinstance(ee_test, xt.Multipole):
             if ee_test._order != ee_six._order:
                 min_order = min(ee_test._order, ee_six._order)
-                assert np.allclose(
+                xo.assert_allclose(
                     ee_test.knl[:min_order+1],
                     ee_six.knl[:min_order+1],
                     atol=1e-16,
                 )
-                assert np.allclose(
+                xo.assert_allclose(
                     ee_test.ksl[:min_order+1],
                     ee_six.ksl[:min_order+1],
                     atol=1e-16,
                 )
-                assert np.allclose(ee_test.knl[min_order+1:], 0, atol=1e-16)
-                assert np.allclose(ee_test.ksl[min_order+1:], 0, atol=1e-16)
-                assert np.allclose(ee_six.knl[min_order+1:], 0, atol=1e-16)
-                assert np.allclose(ee_six.ksl[min_order+1:], 0, atol=1e-16)
+                xo.assert_allclose(ee_test.knl[min_order+1:], 0, atol=1e-16)
+                xo.assert_allclose(ee_test.ksl[min_order+1:], 0, atol=1e-16)
+                xo.assert_allclose(ee_six.knl[min_order+1:], 0, atol=1e-16)
+                xo.assert_allclose(ee_six.ksl[min_order+1:], 0, atol=1e-16)
 
                 skip_order = True
 
@@ -512,20 +511,20 @@ def test_line_import_from_madx(test_context, mad_with_errors):
     print('\nTest tracker and xsuite vars...\n')
     line = line_with_expressions.copy()
     line.build_tracker(_context=test_context)
-    assert np.isclose(line.twiss()['qx'], 62.31, rtol=0, atol=1e-4)
+    xo.assert_allclose(line.twiss()['qx'], 62.31, rtol=0, atol=1e-4)
     line.vars['kqtf.b1'] = -2e-4
-    assert np.isclose(line.twiss()['qx'], 62.2834, rtol=0, atol=1e-4)
+    xo.assert_allclose(line.twiss()['qx'], 62.2834, rtol=0, atol=1e-4)
 
-    assert np.isclose(line.element_dict['acsca.b5l4.b1'].voltage,
+    xo.assert_allclose(line.element_dict['acsca.b5l4.b1'].voltage,
                       2e6, rtol=0, atol=1e-14)
     line.vars['vrf400'] = 8
-    assert np.isclose(line.element_dict['acsca.b5l4.b1'].voltage,
+    xo.assert_allclose(line.element_dict['acsca.b5l4.b1'].voltage,
                       1e6, rtol=0, atol=1e-14)
 
-    assert np.isclose(line.element_dict['acsca.b5l4.b1'].lag, 180,
+    xo.assert_allclose(line.element_dict['acsca.b5l4.b1'].lag, 180,
                     rtol=0, atol=1e-14)
     line.vars['lagrf400.b1'] = 0.75
-    assert np.isclose(line.element_dict['acsca.b5l4.b1'].lag, 270,
+    xo.assert_allclose(line.element_dict['acsca.b5l4.b1'].lag, 270,
                     rtol=0, atol=1e-14)
 
     assert np.abs(
@@ -534,11 +533,11 @@ def test_line_import_from_madx(test_context, mad_with_errors):
     assert np.abs(
         line.element_dict['acfcav.bl5.b1'].to_dict()['ksl'][0]) == 0
 
-    assert np.isclose(
+    xo.assert_allclose(
         line.element_dict['acfcav.bl5.b1'].to_dict()['ps'][0], 90,
         rtol=0, atol=1e-14)
     line.vars['phi_crab_l5b1'] = 0.5
-    assert np.isclose(
+    xo.assert_allclose(
         line.element_dict['acfcav.bl5.b1'].to_dict()['ps'][0], 270,
                     rtol=0, atol=1e-14)
 
@@ -548,11 +547,11 @@ def test_line_import_from_madx(test_context, mad_with_errors):
     assert np.abs(
         line.element_dict['acfcah.bl1.b1'].to_dict()['knl'][0]) == 0
 
-    assert np.isclose(
+    xo.assert_allclose(
         line.element_dict['acfcah.bl1.b1'].to_dict()['pn'][0], 90,
         rtol=0, atol=1e-14)
     line.vars['phi_crab_l1b1'] = 0.5
-    assert np.isclose(
+    xo.assert_allclose(
         line.element_dict['acfcah.bl1.b1'].to_dict()['pn'][0], 270,
         rtol=0, atol=1e-14)
 
@@ -577,17 +576,17 @@ def test_orbit_knobs(test_context, mad_b12_no_errors):
     line.build_tracker(_context=test_context)
 
     line.vars['on_x1'] = 250
-    assert np.isclose(line.twiss(at_elements=['ip1'])['px'][0], 250e-6,
+    xo.assert_allclose(line.twiss(at_elements=['ip1'])['px'][0], 250e-6,
                 atol=1e-6, rtol=0)
     line.vars['on_x1'] = -300
-    assert np.isclose(line.twiss(at_elements=['ip1'])['px'][0], -300e-6,
+    xo.assert_allclose(line.twiss(at_elements=['ip1'])['px'][0], -300e-6,
                 atol=1e-6, rtol=0)
 
     line.vars['on_x5'] = 130
-    assert np.isclose(line.twiss(at_elements=['ip5'])['py'][0], 130e-6,
+    xo.assert_allclose(line.twiss(at_elements=['ip5'])['py'][0], 130e-6,
                 atol=1e-6, rtol=0)
     line.vars['on_x5'] = -270
-    assert np.isclose(line.twiss(at_elements=['ip5'])['py'][0], -270e-6,
+    xo.assert_allclose(line.twiss(at_elements=['ip5'])['py'][0], -270e-6,
                 atol=1e-6, rtol=0)
 
 
@@ -611,17 +610,17 @@ def test_low_beta_twiss(test_context):
 
     emitdf = mad.table.emitsumm.dframe()
 
-    assert np.isclose(mad.sequence.psb.beam.gamma, line.particle_ref.gamma0,
+    xo.assert_allclose(mad.sequence.psb.beam.gamma, line.particle_ref.gamma0,
                       rtol=0, atol=1e-6)
-    assert np.isclose(mad.sequence.psb.beam.beta, line.particle_ref.beta0,
+    xo.assert_allclose(mad.sequence.psb.beam.beta, line.particle_ref.beta0,
                     rtol=0, atol=1e-10)
 
     beta0 = line.particle_ref.beta0
 
-    assert np.isclose(mad.table.summ['q1'][0], tw['qx'], rtol=0, atol=1e-6)
-    assert np.isclose(mad.table.summ['q2'][0], tw['qy'], rtol=0, atol=1e-6)
-    assert np.isclose(mad.table.summ['dq1'][0]*beta0, tw['dqx'], rtol=0,
+    xo.assert_allclose(mad.table.summ['q1'][0], tw['qx'], rtol=0, atol=1e-6)
+    xo.assert_allclose(mad.table.summ['q2'][0], tw['qy'], rtol=0, atol=1e-6)
+    xo.assert_allclose(mad.table.summ['dq1'][0]*beta0, tw['dqx'], rtol=0,
                         atol=1e-6)
-    assert np.isclose(mad.table.summ['dq2'][0]*beta0, tw['dqy'], rtol=0,
+    xo.assert_allclose(mad.table.summ['dq2'][0]*beta0, tw['dqy'], rtol=0,
                         atol=1e-6)
-    assert np.isclose(tw.qs, emitdf.qs.iloc[0], rtol=0, atol=1e-8)
+    xo.assert_allclose(tw.qs, emitdf.qs.iloc[0], rtol=0, atol=1e-8)

--- a/tests/test_xmask_orbit_correction.py
+++ b/tests/test_xmask_orbit_correction.py
@@ -1,9 +1,10 @@
 import json
 import pathlib
 
-import numpy as np
-import xtrack as xt
 from cpymad.madx import Madx
+
+import xobjects as xo
+import xtrack as xt
 from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(
@@ -170,10 +171,10 @@ def test_orbit_correction(test_context):
     for nn in ['lhcb1', 'lhcb1_co_ref']:
         tw = collider[nn].twiss(method='4d', zeta0=0, delta0=0)
         for ip in ['ip1', 'ip2', 'ip5', 'ip8']:
-            assert np.isclose(tw['x', ip], 0, 1e-10)
-            assert np.isclose(tw['px', ip], 0, 1e-10)
-            assert np.isclose(tw['y', ip], 0, 1e-10)
-            assert np.isclose(tw['py', ip], 0, 1e-10)
+            xo.assert_allclose(tw['x', ip], 0, 1e-10)
+            xo.assert_allclose(tw['px', ip], 0, 1e-10)
+            xo.assert_allclose(tw['y', ip], 0, 1e-10)
+            xo.assert_allclose(tw['py', ip], 0, 1e-10)
 
     # Check that the tune knobs work only on line and not on line_co_ref
     tw0 = collider['lhcb1'].twiss(method='4d', zeta0=0, delta0=0)
@@ -228,21 +229,21 @@ def test_orbit_correction(test_context):
 
     tw = collider.lhcb1.twiss()
 
-    assert np.isclose(tw['px', 'ip1'], 250e-6, atol=1e-8)
-    assert np.isclose(tw['py', 'ip1'], 0, atol=1e-8)
+    xo.assert_allclose(tw['px', 'ip1'], 250e-6, rtol=5e-5, atol=1e-8)
+    xo.assert_allclose(tw['py', 'ip1'], 0, atol=1e-8)
 
-    assert np.isclose(tw['px', 'ip5'], 0, atol=1e-8)
-    assert np.isclose(tw['py', 'ip5'], 250e-6, atol=1e-8)
+    xo.assert_allclose(tw['px', 'ip5'], 0, atol=1e-8)
+    xo.assert_allclose(tw['py', 'ip5'], 250e-6, atol=1e-8)
 
     assert tw['px', 'ip2'] > 1e-7 # effect of the spectrometer tilt
     assert tw['py', 'ip2'] > 255e-6 # effect of the spectrometer
-    assert np.isclose(tw['px', 'bpmsw.1r2.b1'], 0, atol=1e-8)  # external angle
-    assert np.isclose(tw['py', 'bpmsw.1r2.b1'], 250e-6, atol=1e-8) # external angle
+    xo.assert_allclose(tw['px', 'bpmsw.1r2.b1'], 0, atol=1e-8)  # external angle
+    xo.assert_allclose(tw['py', 'bpmsw.1r2.b1'], 250e-6, atol=1e-8) # external angle
 
     assert tw['px', 'ip8'] > 255e-6 # effect of the spectrometer
     assert tw['py', 'ip8'] > 1e-6 # effect of the spectrometer tilt
-    assert np.isclose(tw['px', 'bpmsw.1r8.b1'], 250e-6, atol=1e-8) # external angle
-    assert np.isclose(tw['py', 'bpmsw.1r8.b1'], 0, atol=1e-8) # external angle
+    xo.assert_allclose(tw['px', 'bpmsw.1r8.b1'], 250e-6, atol=1e-8) # external angle
+    xo.assert_allclose(tw['py', 'bpmsw.1r8.b1'], 0, atol=1e-8) # external angle
 
 
     places_to_check = [
@@ -260,10 +261,10 @@ def test_orbit_correction(test_context):
     's.ds.r8.b1']
 
     for place in places_to_check:
-        assert np.isclose(tw['x', place], 0, atol=1e-6)
-        assert np.isclose(tw['px', place], 0, atol=1e-8)
-        assert np.isclose(tw['y', place], 0, atol=1e-6)
-        assert np.isclose(tw['py', place], 0, atol=1e-8)
+        xo.assert_allclose(tw['x', place], 0, atol=1e-6)
+        xo.assert_allclose(tw['px', place], 0, atol=1e-8)
+        xo.assert_allclose(tw['y', place], 0, atol=1e-6)
+        xo.assert_allclose(tw['py', place], 0, atol=1e-8)
 
     with xt._temp_knobs(collider, dict(on_corr_co=0, on_disp=0)):
         tw_ref = collider.lhcb1_co_ref.twiss()


### PR DESCRIPTION
## Description

Change the assertion is `test_twiss.py::test_twiss_range_start_end` to use an inexact comparison, as currently the tests are failing with very small differences.

Use `xo.assert_allclose` whenever possible in the tests: I had to relax two `rtols` to make tests pass compared to before:
- in `test_vs_madx.py::test_twiss_and_survey`
- in `test_xmask_orbit_correction.py::test_orbit_correction`

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- x ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
