### PR TITLE
Add multipolar components to solenoid

### DIFF
--- a/xtrack/beam_elements/slice_elements.py
+++ b/xtrack/beam_elements/slice_elements.py
@@ -26,9 +26,6 @@ def _slice_copy(self, **kwargs):
     return out
 
 
-_thin_slice_quad_xofields = {
-    '_parent': xo.Ref(Quadrupole)}
-_thin_slice_quad_xofields.update(_common_xofields)
 class ThinSliceQuadrupole(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = True
@@ -39,7 +36,7 @@ class ThinSliceQuadrupole(BeamElement):
     _force_moveable = True
     _inherit_strengths = True
 
-    _xofields = _thin_slice_quad_xofields
+    _xofields = {'_parent': xo.Ref(Quadrupole), **_common_xofields}
 
     _extra_c_sources = _common_c_sources + [
         _pkg_root.joinpath('beam_elements/elements_src/thin_slice_quadrupole.h')]
@@ -76,9 +73,7 @@ class ThinSliceQuadrupole(BeamElement):
                         _buffer=self._buffer)
         return out
 
-_thin_slice_sext_xofields = {
-    '_parent': xo.Ref(Sextupole)}
-_thin_slice_sext_xofields.update(_common_xofields)
+
 class ThinSliceSextupole(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = True
@@ -89,7 +84,7 @@ class ThinSliceSextupole(BeamElement):
     _force_moveable = True
     _inherit_strengths = True
 
-    _xofields = _thin_slice_sext_xofields
+    _xofields = {'_parent': xo.Ref(Sextupole), **_common_xofields}
 
     _extra_c_sources = _common_c_sources + [
         _pkg_root.joinpath('beam_elements/elements_src/thin_slice_sextupole.h')]
@@ -126,9 +121,7 @@ class ThinSliceSextupole(BeamElement):
                         _buffer=self._buffer)
         return out
 
-_thin_slice_oct_xofields = {
-    '_parent': xo.Ref(Octupole)}
-_thin_slice_oct_xofields.update(_common_xofields)
+
 class ThinSliceOctupole(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = True
@@ -139,7 +132,7 @@ class ThinSliceOctupole(BeamElement):
     _force_moveable = True
     _inherit_strengths = True
 
-    _xofields = _thin_slice_oct_xofields
+    _xofields = {'_parent': xo.Ref(Octupole), **_common_xofields}
 
     _extra_c_sources = _common_c_sources + [
         _pkg_root.joinpath('beam_elements/elements_src/thin_slice_octupole.h')]
@@ -176,9 +169,7 @@ class ThinSliceOctupole(BeamElement):
                         _buffer=self._buffer)
         return out
 
-_thin_slice_bend_xofields = {
-    '_parent': xo.Ref(Bend)}
-_thin_slice_bend_xofields.update(_common_xofields)
+
 class ThinSliceBend(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = True
@@ -189,7 +180,7 @@ class ThinSliceBend(BeamElement):
     _force_moveable = True
     _inherit_strengths = True
 
-    _xofields = _thin_slice_bend_xofields
+    _xofields = {'_parent': xo.Ref(Bend), **_common_xofields}
 
     _extra_c_sources = _common_c_sources + [
         _pkg_root.joinpath('beam_elements/elements_src/thin_slice_bend.h')]
@@ -225,9 +216,7 @@ class ThinSliceBend(BeamElement):
                         _buffer=self._buffer)
         return out
 
-_thin_slice_bend_entry_xofields = {
-    '_parent': xo.Ref(Bend)}
-_thin_slice_bend_entry_xofields.update(_common_xofields)
+
 class ThinSliceBendEntry(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = True
@@ -236,7 +225,7 @@ class ThinSliceBendEntry(BeamElement):
     _force_moveable = True
     _inherit_strengths = False
 
-    _xofields = _thin_slice_bend_entry_xofields
+    _xofields = {'_parent': xo.Ref(Bend), **_common_xofields}
 
     _extra_c_sources = [
         _pkg_root.joinpath('headers/constants.h'),
@@ -268,9 +257,7 @@ class ThinSliceBendEntry(BeamElement):
             _buffer=self._buffer
         )
 
-_thin_slice_bend_exit_xofields = {
-    '_parent': xo.Ref(Bend)}
-_thin_slice_bend_exit_xofields.update(_common_xofields)
+
 class ThinSliceBendExit(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = True
@@ -279,7 +266,7 @@ class ThinSliceBendExit(BeamElement):
     _force_moveable = True
     _inherit_strengths = False
 
-    _xofields = _thin_slice_bend_exit_xofields
+    _xofields = {'_parent': xo.Ref(Bend), **_common_xofields}
 
     _extra_c_sources = [
         _pkg_root.joinpath('headers/constants.h'),

--- a/xtrack/beam_elements/slice_elements_thick.py
+++ b/xtrack/beam_elements/slice_elements_thick.py
@@ -12,9 +12,7 @@ _common_xofields = {
     'weight': xo.Float64,
 }
 
-_thick_slice_bend_xofields = {
-    '_parent': xo.Ref(Bend)}
-_thick_slice_bend_xofields.update(_common_xofields)
+
 class ThickSliceBend(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = True
@@ -24,7 +22,7 @@ class ThickSliceBend(BeamElement):
     isthick = True
     _inherit_strengths = True
 
-    _xofields = _thick_slice_bend_xofields
+    _xofields = {'_parent': xo.Ref(Bend), **_common_xofields}
 
     _extra_c_sources = [
         _pkg_root.joinpath('beam_elements/elements_src/drift.h'),
@@ -48,9 +46,6 @@ class ThickSliceBend(BeamElement):
         return obj
 
 
-_thick_slice_quadrupole_xofields = {
-    '_parent': xo.Ref(Quadrupole)}
-_thick_slice_quadrupole_xofields.update(_common_xofields)
 class ThickSliceQuadrupole(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = True
@@ -60,7 +55,7 @@ class ThickSliceQuadrupole(BeamElement):
     isthick = True
     _inherit_strengths = True
 
-    _xofields = _thick_slice_quadrupole_xofields
+    _xofields = {'_parent': xo.Ref(Quadrupole), **_common_xofields}
 
     _extra_c_sources = [
         _pkg_root.joinpath('beam_elements/elements_src/drift.h'),
@@ -83,9 +78,6 @@ class ThickSliceQuadrupole(BeamElement):
         return obj
 
 
-_thick_slice_sextupole_xofields = {
-    '_parent': xo.Ref(Sextupole)}
-_thick_slice_sextupole_xofields.update(_common_xofields)
 class ThickSliceSextupole(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = True
@@ -95,7 +87,7 @@ class ThickSliceSextupole(BeamElement):
     isthick = True
     _inherit_strengths = True
 
-    _xofields = _thick_slice_sextupole_xofields
+    _xofields = {'_parent': xo.Ref(Sextupole), **_common_xofields}
 
     _depends_on = [RandomUniform, RandomExponential]
     _internal_record_class = SynchrotronRadiationRecord
@@ -121,9 +113,6 @@ class ThickSliceSextupole(BeamElement):
         return obj
 
 
-_thick_slice_octupole_xofields = {
-    '_parent': xo.Ref(Octupole)}
-_thick_slice_octupole_xofields.update(_common_xofields)
 class ThickSliceOctupole(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = True
@@ -133,7 +122,7 @@ class ThickSliceOctupole(BeamElement):
     isthick = True
     _inherit_strengths = True
 
-    _xofields = _thick_slice_octupole_xofields
+    _xofields = {'_parent': xo.Ref(Octupole), **_common_xofields}
 
     _depends_on = [RandomUniform, RandomExponential]
     _internal_record_class = SynchrotronRadiationRecord
@@ -158,9 +147,7 @@ class ThickSliceOctupole(BeamElement):
         obj.parent_name = dct['parent_name']
         return obj
 
-_thick_slice_solenoid_xofields = {
-    '_parent': xo.Ref(Solenoid)}
-_thick_slice_solenoid_xofields.update(_common_xofields)
+
 class ThickSliceSolenoid(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = True
@@ -170,7 +157,7 @@ class ThickSliceSolenoid(BeamElement):
     isthick = True
     _inherit_strengths = True
 
-    _xofields = _thick_slice_solenoid_xofields
+    _xofields = {'_parent': xo.Ref(Solenoid), **_common_xofields}
 
     _depends_on = [RandomUniform, RandomExponential]
     _internal_record_class = SynchrotronRadiationRecord
@@ -195,10 +182,6 @@ class ThickSliceSolenoid(BeamElement):
         return obj
 
 
-
-_drift_slice_bend_xofields = {
-    '_parent': xo.Ref(Bend)}
-_drift_slice_bend_xofields.update(_common_xofields)
 class DriftSliceBend(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = False
@@ -209,7 +192,7 @@ class DriftSliceBend(BeamElement):
     isthick = True
     _inherit_strengths = False
 
-    _xofields = _drift_slice_bend_xofields
+    _xofields = {'_parent': xo.Ref(Bend), **_common_xofields}
 
     _extra_c_sources = [
         _pkg_root.joinpath('beam_elements/elements_src/drift.h'),
@@ -233,9 +216,7 @@ class DriftSliceBend(BeamElement):
                      _buffer=self._buffer)
         return out
 
-_drift_slice_quadrupole_xofields = {
-    '_parent': xo.Ref(Quadrupole)}
-_drift_slice_quadrupole_xofields.update(_common_xofields)
+
 class DriftSliceQuadrupole(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = False
@@ -246,7 +227,7 @@ class DriftSliceQuadrupole(BeamElement):
     isthick = True
     _inherit_strengths = False
 
-    _xofields = _drift_slice_quadrupole_xofields
+    _xofields = {'_parent': xo.Ref(Quadrupole), **_common_xofields}
 
     _extra_c_sources = [
         _pkg_root.joinpath('beam_elements/elements_src/drift.h'),
@@ -271,9 +252,6 @@ class DriftSliceQuadrupole(BeamElement):
         return out
 
 
-_drift_slice_sextupole_xofields = {
-    '_parent': xo.Ref(Sextupole)}
-_drift_slice_sextupole_xofields.update(_common_xofields)
 class DriftSliceSextupole(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = False
@@ -284,7 +262,7 @@ class DriftSliceSextupole(BeamElement):
     isthick = True
     _inherit_strengths = False
 
-    _xofields = _drift_slice_sextupole_xofields
+    _xofields = {'_parent': xo.Ref(Sextupole), **_common_xofields}
 
     _extra_c_sources = [
         _pkg_root.joinpath('beam_elements/elements_src/drift.h'),
@@ -309,9 +287,6 @@ class DriftSliceSextupole(BeamElement):
         return out
 
 
-_drift_slice_octupole_xofields = {
-    '_parent': xo.Ref(Octupole)}
-_drift_slice_octupole_xofields.update(_common_xofields)
 class DriftSliceOctupole(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = False
@@ -322,7 +297,7 @@ class DriftSliceOctupole(BeamElement):
     isthick = True
     _inherit_strengths = False
 
-    _xofields = _drift_slice_octupole_xofields
+    _xofields = {'_parent': xo.Ref(Octupole), **_common_xofields}
 
     _extra_c_sources = [
         _pkg_root.joinpath('beam_elements/elements_src/drift.h'),
@@ -346,9 +321,7 @@ class DriftSliceOctupole(BeamElement):
                      _buffer=self._buffer)
         return out
 
-_drift_slice_xofields = {
-    '_parent': xo.Ref(Drift)}
-_drift_slice_xofields.update(_common_xofields)
+
 class DriftSlice(BeamElement):
     allow_rot_and_shift = False
     rot_and_shift_from_parent = False
@@ -359,7 +332,7 @@ class DriftSlice(BeamElement):
     isthick = True
     _inherit_strengths = False
 
-    _xofields = _drift_slice_xofields
+    _xofields = {'_parent': xo.Ref(Drift), **_common_xofields}
 
     _extra_c_sources = [
         _pkg_root.joinpath('beam_elements/elements_src/drift.h'),


### PR DESCRIPTION
## Description

- Add `knl`, `ksl` and related fields to the solenoid element to implement multipolar components.
- Also a small amount of refactoring in `xtrack/beam_elements/slice_elements.py`.
- Also see a comment below.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
