### PR TITLE
Adjust rtol in test_twiss and test_radiation

### DIFF
--- a/tests/test_radiation.py
+++ b/tests/test_radiation.py
@@ -67,7 +67,7 @@ def test_radiation(test_context):
     dct_rng = particles_rnd.to_dict()
 
     xo.assert_allclose(dct_ave['delta'], np.mean(dct_rng['delta']),
-                    atol=0, rtol=5e-3)
+                    atol=1e-12, rtol=5e-3)
 
     rho_0 = L_bend/theta_bend
     mass0_kg = (dct_ave['mass0']*qe/clight**2)

--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -1734,4 +1734,4 @@ def test_twiss_range_start_end(test_context, line_name, reverse, section, collid
             assert np.all(tw_test._data[kk] == tw_ref._data[kk])
             continue
 
-        xo.assert_allclose(tw_test._data[kk], tw_ref._data[kk], rtol=0, atol=5e-13)
+        xo.assert_allclose(tw_test._data[kk], tw_ref._data[kk], rtol=1e-12, atol=5e-13)


### PR DESCRIPTION
## Description

Fix the tolerance issue appearing in https://github.com/xsuite/xsuite/actions/runs/9454155324/job/26041337219 in test_twiss and test_radiation.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
