### PR TITLE
Fix for solenoid radiation on OpenCL (memory label)

### DIFF
--- a/xtrack/beam_elements/elements_src/track_solenoid.h
+++ b/xtrack/beam_elements/elements_src/track_solenoid.h
@@ -84,7 +84,7 @@ void Solenoid_thick_track_single_particle(
 
 /*gpufun*/
 void Solenoid_apply_radiation_single_particle(
-    /*gpuglmem*/ LocalParticle* part,
+    LocalParticle* part,
     const double length,
     const int64_t radiation_flag,
     const double old_px, const double old_py,


### PR DESCRIPTION
## Description

Remove a memory label that is causing a build problem on OpenCL.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
