### PR TITLE
Fix issue when using time dependent variables (or logger) with multitracker

### DIFF
--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -913,6 +913,7 @@ class Tracker:
         if log is not None and _reset_log:
             if self.line.enable_time_dependent_vars:
                 self.line.log_last_track = {}
+                self.line._log_last_track_at_turn = -1
             else:
                 raise NotImplementedError(
                     'log can be used only when time-dependent variables are '
@@ -1005,23 +1006,26 @@ class Tracker:
                         particles.update_p0c_and_energy_deviations(p0c)
 
                 if log is not None:
-                    for kk in log:
-                        if log[kk] == None:
-                            if kk not in self.line.log_last_track:
-                                self.line.log_last_track[kk] = []
-                            self.line.log_last_track[kk].append(self.line.vv[kk])
-                        else:
-                            ff = log[kk]
-                            val = ff(self.line, particles)
-                            if hasattr(ff, '_store'):
-                                for nn in ff._store:
-                                    if nn not in self.line.log_last_track:
-                                        self.line.log_last_track[nn] = []
-                                    self.line.log_last_track[nn].append(val[nn])
-                            else:
+                    if at_turn > self.line._log_last_track_at_turn:
+                        self.line._log_last_track_at_turn = at_turn
+                        for kk in log:
+                            if log[kk] == None:
                                 if kk not in self.line.log_last_track:
                                     self.line.log_last_track[kk] = []
-                                self.line.log_last_track[kk].append(val)
+                                self.line.log_last_track[kk].append(self.line.vv[kk])
+                            else:
+                                ff = log[kk]
+                                val = ff(self.line, particles)
+                                if hasattr(ff, '_store'):
+                                    for nn in ff._store:
+                                        if nn not in self.line.log_last_track:
+                                            self.line.log_last_track[nn] = []
+                                        if at_turn > len(self.line.log_last_track[nn]):
+                                            self.line.log_last_track[nn].append(val[nn])
+                                else:
+                                    if kk not in self.line.log_last_track:
+                                        self.line.log_last_track[kk] = []
+                                    self.line.log_last_track[kk].append(val)
 
             moveback_to_buffer = None
             moveback_to_offset = None

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -937,6 +937,7 @@ class Tracker:
             assert _session_to_resume['tracker'] is self, (
                 "This session was not created by this tracker")
 
+            particles = _session_to_resume['particles']
             ele_start = _session_to_resume['ele_start']
             ele_stop = _session_to_resume['ele_stop']
             num_turns = _session_to_resume['num_turns']
@@ -1026,8 +1027,6 @@ class Tracker:
                 if (ipp_resume is not None and ipp < ipp_resume):
                     continue
                 elif (ipp_resume is not None and ipp == ipp_resume):
-                    assert particles is None
-                    particles = _session_to_resume['particles']
                     pp = self._parts[ipp]
                     moveback_to_buffer = _session_to_resume['moveback_to_buffer']
                     moveback_to_offset = _session_to_resume['moveback_to_offset']

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -948,6 +948,7 @@ class Tracker:
                                     '_context_needs_clean_active_lost_state']
             tt_resume = _session_to_resume['tt']
             ipp_resume = _session_to_resume['ipp']
+            log = _session_to_resume['log']
             _session_to_resume['resumed'] = True
         else:
             (ele_start, ele_stop, num_turns, flag_monitor, monitor,
@@ -1078,6 +1079,7 @@ class Tracker:
                             'moveback_to_offset': moveback_to_offset,
                             'ipp': ipp,
                             'tt': tt,
+                            'log':log,
                             'resumed': False
                         }
                     return PipelineStatus(on_hold=True, data=session_on_hold)

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -928,6 +928,7 @@ class Tracker:
                                  "please call `particles.reorganize()` first.")
 
         if _session_to_resume is not None:
+            assert particles is None
             if isinstance(_session_to_resume, PipelineStatus):
                 _session_to_resume = _session_to_resume.data
 


### PR DESCRIPTION
## Description
There was a bug when using the multitracker with time dependent variables enables. When the tracking is resumed in the multitracker, the method track_with_collective is called with particles=None and instead a '_session_to_resume' which embeds the particles object. Yet the particles object is needed in the part that is enabled by the time dependent variables. To fix this the assignment of the particles object embeded in the _session_to_resume is assigned to the corresponding variable earlier in a dedicated block. 
Also, the 'log' was not propagated when the tracing was stopped and resumed by the pipeline. This is fixed here.

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
