### PR TITLE
Remove confusing default value in exciter

### DIFF
--- a/xtrack/beam_elements/exciter.py
+++ b/xtrack/beam_elements/exciter.py
@@ -99,7 +99,7 @@ class Exciter(BeamElement):
     _extra_c_sources = [_pkg_root.joinpath('beam_elements/elements_src/exciter.h')]
 
 
-    def __init__(self, *, samples=None, nsamples=None, sampling_frequency=0, frev=0, knl=[1], ksl=[], start_turn=0, duration=None, _xobject=None, **kwargs):
+    def __init__(self, *, samples=None, nsamples=None, sampling_frequency=0, frev=0, knl=[], ksl=[], start_turn=0, duration=None, _xobject=None, **kwargs):
 
         if _xobject is not None:
             super().__init__(_xobject=_xobject)
@@ -108,6 +108,7 @@ class Exciter(BeamElement):
 
             # sanitize knl and ksl array length
             n = max(len(knl), len(ksl))
+            assert n > 0, 'Cannot initialise Exciter without componenents'
             nknl = np.zeros(n, dtype=np.float64)
             nksl = np.zeros(n, dtype=np.float64)
             if knl is not None:


### PR DESCRIPTION
## Description

Exciter class used to excite the horizontal dipole component by default and was not overridden when initialising only ksl components. Now there are no default values and a check was added to make sure that at least one component is provided.

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
