### PR TITLE
Allow Drift(N) and validate Particles kwargs

### DIFF
--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -51,6 +51,7 @@ class Marker(BeamElement):
     allow_loss_refinement = True
     has_backtrack = True
     allow_rot_and_shift = False
+    _skip_in_repr = ['_dummy']
 
     _extra_c_sources = [
         "/*gpufun*/\n"
@@ -82,6 +83,11 @@ class Drift(BeamElement):
         _pkg_root.joinpath('beam_elements/elements_src/drift.h'),
         _pkg_root.joinpath('beam_elements/elements_src/drift_elem.h'),
         ]
+
+    def __init__(self, length=None, **kwargs):
+        if length:  # otherwise length cannot be set as a positional argument
+            kwargs['length'] = length
+        super().__init__(**kwargs)
 
     @property
     def _thin_slice_class(self):

--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -212,6 +212,14 @@ class Particles(xo.HybridClass):
             raise NameError('`psigma` is not supported anymore.'
                             'Please use `pzeta` instead.')
 
+        accepted_args = set(self._xofields.keys()) | {
+            'energy0', 'tau', 'pzeta', 'mass_ratio', 'mass', 'kinetic_energy0',
+            '_context', '_buffer', '_offset',
+        }
+        if set(kwargs.keys()) - accepted_args:
+            raise NameError(f'Invalid argument(s) provided: '
+                            f'{set(kwargs.keys()) - accepted_args}')
+
         per_part_input_vars = (
             self.per_particle_vars +
             ((xo.Float64, 'energy0'),

--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -214,7 +214,7 @@ class Particles(xo.HybridClass):
 
         accepted_args = set(self._xofields.keys()) | {
             'energy0', 'tau', 'pzeta', 'mass_ratio', 'mass', 'kinetic_energy0',
-            '_context', '_buffer', '_offset',
+            '_context', '_buffer', '_offset', 'p0',
         }
         if set(kwargs.keys()) - accepted_args:
             raise NameError(f'Invalid argument(s) provided: '


### PR DESCRIPTION
## Description

- Allow constructing `Drift(lenght=N)` with just `Drift(N)`
- Validate kwargs passed to `Particles(**kwargs)`
- repr markers as `Marker()` (remove the `_dummy` field)

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
