### PR TITLE
Fix/non linear chroma

### DIFF
--- a/xtrack/beam_elements/elements_src/linesegmentmap.h
+++ b/xtrack/beam_elements/elements_src/linesegmentmap.h
@@ -112,18 +112,17 @@ void transverse_motion(LocalParticle *part0, LineSegmentMapData el){
     double sin_y = 0;
     double cos_y = 0;
 
-    int64_t any_chroma_x = 0;
-    int64_t any_chroma_y = 0;
+    int64_t any_chroma = 0;
 
     for (int i_dqx=0; i_dqx<ndqx; i_dqx++){
-        any_chroma_x = LineSegmentMapData_get_coeffs_dqx(el, 0) != 0;
+        any_chroma += LineSegmentMapData_get_coeffs_dqx(el, 0) != 0;
     }
 
     for (int i_dqy=0; i_dqy<ndqy; i_dqy++){
-        any_chroma_y = LineSegmentMapData_get_coeffs_dqy(el, 0) != 0;
+        any_chroma += LineSegmentMapData_get_coeffs_dqy(el, 0) != 0;
     }
 
-    if (any_chroma_x || any_chroma_y ||
+    if (any_chroma ||
         det_xx != 0.0 || det_xy != 0.0 || det_yx != 0.0 || det_yy != 0.0){
         detuning = 1;
     }

--- a/xtrack/beam_elements/elements_src/linesegmentmap.h
+++ b/xtrack/beam_elements/elements_src/linesegmentmap.h
@@ -112,17 +112,18 @@ void transverse_motion(LocalParticle *part0, LineSegmentMapData el){
     double sin_y = 0;
     double cos_y = 0;
 
-    int64_t any_chroma = 0;
+    int64_t any_chroma_x = 0;
+    int64_t any_chroma_y = 0;
 
     for (int i_dqx=0; i_dqx<ndqx; i_dqx++){
-        any_chroma = LineSegmentMapData_get_coeffs_dqx(el, 0) != 0;
+        any_chroma_x = LineSegmentMapData_get_coeffs_dqx(el, 0) != 0;
     }
 
     for (int i_dqy=0; i_dqy<ndqy; i_dqy++){
-        any_chroma = LineSegmentMapData_get_coeffs_dqy(el, 0) != 0;
+        any_chroma_y = LineSegmentMapData_get_coeffs_dqy(el, 0) != 0;
     }
 
-    if (any_chroma ||
+    if (any_chroma_x || any_chroma_y ||
         det_xx != 0.0 || det_xy != 0.0 || det_yx != 0.0 || det_yy != 0.0){
         detuning = 1;
     }


### PR DESCRIPTION
Bugfix for the non-linear chromaticity. `any_chroma` should be added rather than overwritten.

## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
