### PR TITLE
Bugfix: `Particles.filter` does not copy the value of `start_tracking_at_element`

### DIFF
--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -762,6 +762,8 @@ class Particles(xo.HybridClass):
         capacity = len(test_x)
         new_part_cpu = self.__class__(_capacity=capacity)
 
+        new_part_cpu.start_tracking_at_element = self.start_tracking_at_element
+
         # Copy scalar vars from first particle
         for tt, nn in self.scalar_vars:
             setattr(new_part_cpu, nn, getattr(self_cpu, nn))
@@ -777,7 +779,7 @@ class Particles(xo.HybridClass):
         # Copy to original context
         target_ctx = self._buffer.context
         if isinstance(target_ctx, xo.ContextCpu):
-            new_part_cpu._buffer.context = target_ctx
+            new_part_cpu.move(_context=target_ctx)
             return new_part_cpu
         else:
             return new_part_cpu.copy(_context=target_ctx)


### PR DESCRIPTION
## Description

Currently when calling `particles.filter(...)` the value of `start_tracking_at_element` in the new particles object is always zero, which is a bug.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
