### PR TITLE
Allow to get elements by (unique made) names from line.get_table()

### DIFF
--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -1092,4 +1092,14 @@ def test_insert_repeated_names():
     line.insert_element("m2",xt.Marker(),at="d")
     assert line.element_names[0]=="m2"
 
+def test_line_table_unique_names():
+    line = xt.Line(
+        elements = {"obm": xt.Bend(length=0.5)},
+        element_names= ["obm","obm"]
+    )
+    table = line.get_table()
+    assert np.all(np.unique_counts(table.name).counts == 1), "Not all elements are unique"
+    for name, env_name in zip(table.name, table.env_name):
+        if name == '_end_point': continue
+        assert line[name] == line[env_name]
 

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -4057,6 +4057,8 @@ class Line:
             return self.vv[key]
         elif hasattr(self, 'lines') and key in self.lines: # Want to reuse the method for the env
             return self.lines[key]
+        elif "::" in key and (env_name := key.split("::")[0]) in self.element_dict:
+            return self[env_name]
         else:
             raise KeyError(f'Name {key} not found')
 


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Unique names from `line.get_table()` (and survey and ...) cause an error if trying to get the corresponding element via `line[name]`.

While for `line.get_table()` there is `env_names` to help out, for survey there is nothing. Also, this is quite unintuitive behaviour.

```python
line = xt.Line(
        elements = {"obm": xt.Bend(length=0.5)},
        element_names= ["obm","obm"]
    )
print(line.get_table())
line["obm::0"]
```
```
Table: 3 rows, 8 cols
name                   s element_type isthick isreplica parent_name iscollective env_name  
obm::0                 0 Bend            True     False None               False obm       
obm::1               0.5 Bend            True     False None               False obm       
_end_point             1                False     False None               False _end_point
```
```
KeyError: 'Name obm::0 not found'
```

The PR fixes this. See https://github.com/xsuite/xplt/issues/31#issuecomment-2512812190

Closes https://github.com/xsuite/xplt/issues/31

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
