### PR TITLE
catch start==end in creation of second-order taylor map

### DIFF
--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -2441,6 +2441,10 @@ class SecondOrderTaylorMap(BeamElement):
             A `SecondOrderTaylorMap` object.
 
         '''
+        if start == end:
+            # start == end will lead to compute_one_turn_matrix_finite_differences() computing a
+            # full one-turn response matrix (but here we would rather expect identity)
+            raise NotImplementedError('end element must be after start element')
 
         if twiss_table is None:
             tw = line.twiss(reverse=False)


### PR DESCRIPTION
`SecondOrderTaylorMap.from_line()` uses `compute_one_turn_matrix_finite_differences()` which for `start==end` returns a full one-turn response matrix. This is a "surprising" behavior in the context of creating a one-turn map, where one might rather expect an identity map (K=0, R=eye, T=0) in this case.