### PR TITLE
Release/0.72.1

### DIFF
--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -1096,4 +1096,14 @@ def test_insert_repeated_names():
     line.insert_element("m2",xt.Marker(),at="d")
     assert line.element_names[0]=="m2"
 
+def test_line_table_unique_names():
+    line = xt.Line(
+        elements = {"obm": xt.Bend(length=0.5)},
+        element_names= ["obm","obm"]
+    )
+    table = line.get_table()
+    assert np.all(np.unique_counts(table.name).counts == 1), "Not all elements are unique"
+    for name, env_name in zip(table.name, table.env_name):
+        if name == '_end_point': continue
+        assert line[name] == line[env_name]
 

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -384,7 +384,7 @@ def test_check_aperture():
         element_names=['dr1', 'm1_ap', 'dum', 'm1', 'dr2', 'm2', 'dr3',
                        'th1_ap_front', 'dum', 'th1', 'dum', 'th1_ap_back',
                        'dr4', 'th2', 'th2_ap_back',
-                       'dr5', 'th3_ap_front', 'th3'])
+                       'dr5', 'th3_ap_front', 'th3', 'dr6'])
     df = line.check_aperture()
 
     expected_miss_upstream = [nn in ('m2', 'th2') for nn in df['name'].values]

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -357,7 +357,6 @@ def test_to_pandas():
 def test_check_aperture():
 
     class ThickElement:
-
         length = 2.
         isthick = True
 
@@ -380,11 +379,16 @@ def test_check_aperture():
             'th3_ap_front': xt.LimitEllipse(a=1e-2, b=1e-2),
             'th3': ThickElement(),
             'dr6': xt.Drift(length=1),
+            'th4_ap_entry': xt.LimitEllipse(a=1e-2, b=1e-2),
+            'th4': ThickElement(),
+            'th4_ap_exit': xt.LimitEllipse(a=1e-2, b=1e-2),
         },
         element_names=['dr1', 'm1_ap', 'dum', 'm1', 'dr2', 'm2', 'dr3',
                        'th1_ap_front', 'dum', 'th1', 'dum', 'th1_ap_back',
                        'dr4', 'th2', 'th2_ap_back',
-                       'dr5', 'th3_ap_front', 'th3', 'dr6'])
+                       'dr5', 'th3_ap_front', 'th3', 'dr6',
+                       'th4_ap_entry', 'th4', 'th4_ap_exit'])
+    
     df = line.check_aperture()
 
     expected_miss_upstream = [nn in ('m2', 'th2') for nn in df['name'].values]

--- a/tests/test_radiation_equilibrium_emittances.py
+++ b/tests/test_radiation_equilibrium_emittances.py
@@ -145,7 +145,7 @@ def test_eq_emitt(conf):
         xo.assert_allclose(ez, 3.5766e-6,  atol=0,     rtol=1e-4)
         checked = True
     elif tilt_machine_by_90_degrees and vertical_orbit_distortion and not wiggler_on:
-        xo.assert_allclose(ex, 2.5039e-12, atol=0,     rtol=4e-3)
+        xo.assert_allclose(ex, 2.5039e-12, atol=0,     rtol=5e-3)
         xo.assert_allclose(ey, 7.0576e-10, atol=0,     rtol=1e-4)
         xo.assert_allclose(ez, 3.5763e-6,  atol=0,     rtol=1e-4)
         checked = True

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -51,6 +51,7 @@ class Marker(BeamElement):
     allow_loss_refinement = True
     has_backtrack = True
     allow_rot_and_shift = False
+    _skip_in_repr = ['_dummy']
 
     _extra_c_sources = [
         "/*gpufun*/\n"
@@ -82,6 +83,11 @@ class Drift(BeamElement):
         _pkg_root.joinpath('beam_elements/elements_src/drift.h'),
         _pkg_root.joinpath('beam_elements/elements_src/drift_elem.h'),
         ]
+
+    def __init__(self, length=None, **kwargs):
+        if length:  # otherwise length cannot be set as a positional argument
+            kwargs['length'] = length
+        super().__init__(**kwargs)
 
     @property
     def _thin_slice_class(self):

--- a/xtrack/beam_elements/exciter.py
+++ b/xtrack/beam_elements/exciter.py
@@ -99,16 +99,24 @@ class Exciter(BeamElement):
     _extra_c_sources = [_pkg_root.joinpath('beam_elements/elements_src/exciter.h')]
 
 
-    def __init__(self, *, samples=None, nsamples=None, sampling_frequency=0, frev=0, knl=[], ksl=[], start_turn=0, duration=None, _xobject=None, **kwargs):
+    def __init__(self, *, samples=None, nsamples=None, sampling_frequency=0, frev=0, knl=None, ksl=None, start_turn=0, duration=None, _xobject=None, **kwargs):
 
         if _xobject is not None:
             super().__init__(_xobject=_xobject)
 
         else:
+            # The default is needed, as we wish to be able to instantiate
+            # elements without properties (empty elements can be templates).
+            if knl is None and ksl is None:
+                knl = [0]
+                ksl = []
+            elif knl is None:
+                knl = []
+            elif ksl is None:
+                ksl = []
 
             # sanitize knl and ksl array length
             n = max(len(knl), len(ksl))
-            assert n > 0, 'Cannot initialise Exciter without componenents'
             nknl = np.zeros(n, dtype=np.float64)
             nksl = np.zeros(n, dtype=np.float64)
             if knl is not None:

--- a/xtrack/beam_elements/exciter.py
+++ b/xtrack/beam_elements/exciter.py
@@ -99,7 +99,7 @@ class Exciter(BeamElement):
     _extra_c_sources = [_pkg_root.joinpath('beam_elements/elements_src/exciter.h')]
 
 
-    def __init__(self, *, samples=None, nsamples=None, sampling_frequency=0, frev=0, knl=[1], ksl=[], start_turn=0, duration=None, _xobject=None, **kwargs):
+    def __init__(self, *, samples=None, nsamples=None, sampling_frequency=0, frev=0, knl=[], ksl=[], start_turn=0, duration=None, _xobject=None, **kwargs):
 
         if _xobject is not None:
             super().__init__(_xobject=_xobject)
@@ -108,6 +108,7 @@ class Exciter(BeamElement):
 
             # sanitize knl and ksl array length
             n = max(len(knl), len(ksl))
+            assert n > 0, 'Cannot initialise Exciter without componenents'
             nknl = np.zeros(n, dtype=np.float64)
             nksl = np.zeros(n, dtype=np.float64)
             if knl is not None:

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -4060,6 +4060,8 @@ class Line:
             return self.vv[key]
         elif hasattr(self, 'lines') and key in self.lines: # Want to reuse the method for the env
             return self.lines[key]
+        elif "::" in key and (env_name := key.split("::")[0]) in self.element_dict:
+            return self[env_name]
         else:
             raise KeyError(f'Name {key} not found')
 

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -3213,11 +3213,11 @@ class Line:
         i_next_aperture = 0
 
         for iee in progress(range(i_prev_aperture, num_elements), desc='Checking aperture'):
-            if dont_need_aperture[elements_df.loc[iee, 'name']]:
-                continue
-
             if elements_df.loc[iee, 'is_aperture']:
                 i_prev_aperture = iee
+                continue
+
+            if dont_need_aperture[elements_df.loc[iee, 'name']]:
                 continue
 
             if i_next_aperture < iee:

--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -212,6 +212,14 @@ class Particles(xo.HybridClass):
             raise NameError('`psigma` is not supported anymore.'
                             'Please use `pzeta` instead.')
 
+        accepted_args = set(self._xofields.keys()) | {
+            'energy0', 'tau', 'pzeta', 'mass_ratio', 'mass', 'kinetic_energy0',
+            '_context', '_buffer', '_offset',
+        }
+        if set(kwargs.keys()) - accepted_args:
+            raise NameError(f'Invalid argument(s) provided: '
+                            f'{set(kwargs.keys()) - accepted_args}')
+
         per_part_input_vars = (
             self.per_particle_vars +
             ((xo.Float64, 'energy0'),

--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -214,7 +214,7 @@ class Particles(xo.HybridClass):
 
         accepted_args = set(self._xofields.keys()) | {
             'energy0', 'tau', 'pzeta', 'mass_ratio', 'mass', 'kinetic_energy0',
-            '_context', '_buffer', '_offset',
+            '_context', '_buffer', '_offset', 'p0',
         }
         if set(kwargs.keys()) - accepted_args:
             raise NameError(f'Invalid argument(s) provided: '


### PR DESCRIPTION
**Changes:**

- Catch `start == end` condition in the creation of 2nd order Taylor map #565 
- Allow getting the element from `Line.get_table()` using the generated unique names #561 
- Fix the `aperture_check` method of the Line #534 
- Allow constructing a drift with `Drift(n)` and validate Particles kwargs #522 
- Change the default value in the exciter #521 (default changed to zero)