### PR TITLE
Add Environment.import_line

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1963,3 +1963,36 @@ def test_call(tmpdir):
 
     env['var1'] = 10
     assert env['drx'].length == 13
+
+
+@pytest.mark.parametrize(
+    'overwrite_vars,x_value',
+    [
+        (False, 6),
+        (True, 3),
+    ]
+)
+def test_import_line_from_other_env(overwrite_vars, x_value):
+    env = xt.Environment()
+    env['z'] = 5
+    env['x'] = 'z - 2'
+    env['y'] = 7
+
+    line = env.new_line(components=[
+        env.new('b', xt.Bend, k0='2 * x'),
+        env.new('d', xt.Drift, length='3 * y'),
+    ])
+
+    env2 = xt.Environment()
+    env2['z'] = 3
+    env2['x'] = '2 * z'
+    env2.new('b', xt.Bend, k0='x')
+
+    env2.import_line(line, line_name='line', overwrite_vars=overwrite_vars)
+
+    assert env2['x'] == x_value
+    assert env2['y'] == 7
+
+    assert env2['b'].k0 == x_value
+    assert env2['b_line'].k0 == 2 * x_value
+    assert env2['d'].length == 3 * 7

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1980,6 +1980,7 @@ def test_import_line_from_other_env(overwrite_vars, x_value):
 
     line = env.new_line(components=[
         env.new('b', xt.Bend, k0='2 * x'),
+        env.new('ip', xt.Marker),
         env.new('d', xt.Drift, length='3 * y'),
     ])
 
@@ -1987,12 +1988,15 @@ def test_import_line_from_other_env(overwrite_vars, x_value):
     env2['z'] = 3
     env2['x'] = '2 * z'
     env2.new('b', xt.Bend, k0='x')
+    env2.new('ip', xt.Marker)
 
     env2.import_line(line, line_name='line', overwrite_vars=overwrite_vars)
 
     assert env2['x'] == x_value
     assert env2['y'] == 7
 
+    assert env2.lines['line'].element_names == ['b_line', 'ip', 'd']
     assert env2['b'].k0 == x_value
     assert env2['b_line'].k0 == 2 * x_value
+    assert isinstance(env2['ip'], xt.Marker)
     assert env2['d'].length == 3 * 7

--- a/xtrack/environment.py
+++ b/xtrack/environment.py
@@ -85,7 +85,7 @@ class Environment:
         self._lines_weakrefs = WeakSet()
 
     def new(self, name, parent, mode=None, at=None, from_=None, extra=None,
-            mirror=False, **kwargs):
+            mirror=False, import_from=None, **kwargs):
 
         '''
         Create a new element or line.
@@ -101,6 +101,8 @@ class Environment:
                The parent element or line is copied, together with the associated
                expressions.
              - replica: replicate the parent elements or lines are made.
+             - import: clone from a different environment. `import_from` must be
+               provided.
         at : float or str, optional
             Position of the created object.
         from_: str, optional
@@ -109,6 +111,7 @@ class Environment:
         mirror : bool, optional
             Can only be used when cloning lines. If True, the order of the elements
             is reversed.
+        import_from : Environment, optional. Only to be used when mode is 'import'.
 
         Returns
         -------
@@ -173,6 +176,7 @@ class Environment:
                 # Clone an existing element
                 self.element_dict[name] = xt.Replica(parent_name=parent)
                 xt.Line.replace_replica(self, name)
+
                 parent_element = self.element_dict[name]
                 parent = type(parent_element)
                 needs_instantiation = False
@@ -336,6 +340,54 @@ class Environment:
             xtrack._passed_env = None
             raise ee
         xtrack._passed_env = None
+
+    def copy_element_from(self, name, source, new_name=None):
+        return xt.Line.copy_element_from(self, name, source, new_name)
+
+    def import_line(
+            self,
+            line,
+            suffix_for_common_elements=None,
+            line_name=None,
+            overwrite_vars=False,
+    ):
+        """Import a line into this environment.
+
+        Parameters
+        ----------
+        suffix_for_common_elements : str, optional
+            Suffix to be added to the names of the elements that are common to
+            the imported line and the line in this environment. If None,
+            '_{source_line_name}' is used.
+        line_name : str, optional
+            Name of the new line. If None, the name of the imported line is used.
+        overwrite_vars : bool, optional
+            If True, the variables in the imported line will overwrite the
+            variables with the same name in this environment. Default is False.
+        """
+        line_name = line_name or line.name
+        if suffix_for_common_elements is None:
+            suffix_for_common_elements = f'_{line_name}'
+
+        new_var_values = line.ref_manager.containers['vars']._owner
+        if not overwrite_vars:
+            new_var_values = new_var_values.copy()
+            new_var_values.update(self.ref_manager.containers['vars']._owner)
+        self.ref_manager.containers['vars']._owner.update(new_var_values)
+
+        self.ref_manager.copy_expr_from(line.ref_manager, 'vars', overwrite=overwrite_vars)
+        self.ref_manager.run_tasks()
+
+        components = []
+        for name in line.element_names:
+            new_name = name
+            if name in self.element_dict:
+                new_name += suffix_for_common_elements
+
+            self.copy_element_from(name, line, new_name=new_name)
+            components.append(new_name)
+
+        self.new_line(components=components, name=line_name)
 
     def _ensure_tracker_consistency(self, buffer):
         for ln in self._lines_weakrefs:

--- a/xtrack/environment.py
+++ b/xtrack/environment.py
@@ -384,8 +384,14 @@ class Environment:
             if name in self.element_dict:
                 new_name += suffix_for_common_elements
 
-            self.copy_element_from(name, line, new_name=new_name)
             components.append(new_name)
+
+            # Skip shared markers
+            if (isinstance(line[name], xt.Marker) and
+                    name in isinstance(self.element_dict.get(name), xt.Marker)):
+                continue
+
+            self.copy_element_from(name, line, new_name=new_name)
 
         self.new_line(components=components, name=line_name)
 


### PR DESCRIPTION
## Description

Introduce `Environment.import_line(line, suffix_for_common_elements=None, line_name=None, overwrite_vars=False)` to allow bringing in lines from other environments/lines into an environment in a way that copies variables and expressions.

Requires xsuite/xdeps#89.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
