### PR TITLE
Apply fixes and relax some tolerances after `scipy.constant` changes

### DIFF
--- a/tests/test_elements_thick.py
+++ b/tests/test_elements_thick.py
@@ -75,7 +75,7 @@ def test_combined_function_dipole_against_ptc(test_context, k0, k1, k2, length,
 
     for ii in range(len(p0.x)):
         mad.input(f"""
-        beam, particle=proton, pc={p0.p0c[ii] / 1e9}, sequence=ss, radiate=FALSE;
+        beam, particle=ion, pc={p0.p0c[ii] / 1e9}, mass={p0.mass0 / 1e9}, beta={p0.beta0[ii]}, sequence=ss, radiate=FALSE;
 
         ptc_create_universe;
         ptc_create_layout, time=true, model=1, exact=true, method=6, nst=10000;
@@ -94,16 +94,20 @@ def test_combined_function_dipole_against_ptc(test_context, k0, k1, k2, length,
         line_thick.track(part)
         part.move(_context=xo.context_default)
 
+        # Some of these discrepancies are caused by the fact that the definition
+        # of the mass of the proton is not the same in PTC and Xtrack, despite
+        # having manually overridden the mass value in the PTC input above.
+
         xt_tau = part.zeta/part.beta0
         xo.assert_allclose(part.x[ii], mad_results.x, rtol=0,
-                           atol=(1e-11 if k1 == 0 and k2 == 0 else 5e-9))
+                           atol=(3e-11 if k1 == 0 and k2 == 0 else 5e-9))
         xo.assert_allclose(part.px[ii], mad_results.px, rtol=0,
-                           atol=(1e-11 if k1 == 0 and k2 == 0 else 5e-9))
+                           atol=(4e-11 if k1 == 0 and k2 == 0 else 5e-9))
         xo.assert_allclose(part.y[ii], mad_results.y, rtol=0,
                            atol=(1e-11 if k1 == 0 and k2 == 0 else 5e-9))
         xo.assert_allclose(part.py[ii], mad_results.py, rtol=0,
                            atol=(1e-11 if k1 == 0 and k2 == 0 else 5e-9))
-        xo.assert_allclose(xt_tau[ii], mad_results.t, rtol=0,
+        xo.assert_allclose(xt_tau[ii], mad_results.t, rtol=4e-8,
                            atol=(1e-10 if k1 == 0 and k2 == 0 else 5e-9))
         xo.assert_allclose(part.ptau[ii], mad_results.pt, atol=1e-11, rtol=0)
 
@@ -997,7 +1001,7 @@ def test_solenoid_against_madx(test_context, ks, ksi, length):
 
     for ii in range(len(p0.x)):
         mad.input(f"""
-        beam, particle=proton, pc={p0.p0c[ii] / 1e9}, sequence=ss, radiate=FALSE;
+        beam, particle=ion, pc={p0.p0c[ii] / 1e9}, mass={p0.mass0 / 1e9}, sequence=ss, radiate=FALSE;
 
         track, onepass, onetable;
         start, x={p0.x[ii]}, px={p0.px[ii]}, y={p0.y[ii]}, py={p0.py[ii]}, \

--- a/tests/test_madloader.py
+++ b/tests/test_madloader.py
@@ -368,8 +368,8 @@ def test_mad_elements_import():
               )
 
     # Beam
-    mad.input("""
-    beam, particle=proton, gamma=1.05, sequence=testseq;
+    mad.input(f"""
+    beam, particle=ion, gamma=1.05, mass={xt.PROTON_MASS_EV / 1e9}, sequence=testseq;
     """)
 
     mad.use('testseq')

--- a/tests/test_periodic_symmetric_twiss_and_match.py
+++ b/tests/test_periodic_symmetric_twiss_and_match.py
@@ -1,4 +1,3 @@
-
 import xtrack as xt
 import xobjects as xo
 import numpy as np
@@ -138,7 +137,7 @@ def test_periodic_symmetric_twiss_and_match():
     xo.assert_allclose(tw_half_cell.dpx[:-1], # remove '_end_point'
                         tw_cell.rows[:'mid_cell'].dpx, atol=1e-8, rtol=0)
     xo.assert_allclose(tw_half_cell.ddx[:-1], # remove '_end_point'
-                   tw_cell.rows[:'mid_cell'].ddx, atol=1e-7, rtol=0)
+                   tw_cell.rows[:'mid_cell'].ddx, atol=1e-7, rtol=1e-8)
 
     xo.assert_allclose(tw_half_cell.ax_chrom[:-1], # remove '_end_point'
                         tw_cell.rows[:'mid_cell'].ax_chrom, atol=1e-5, rtol=0)
@@ -149,7 +148,7 @@ def test_periodic_symmetric_twiss_and_match():
     xo.assert_allclose(tw_half_cell.by_chrom[:-1], # remove '_end_point'
                         tw_cell.rows[:'mid_cell'].by_chrom, atol=1e-5, rtol=0)
     xo.assert_allclose(tw_half_cell.ddx[:-1], # remove '_end_point'
-                        tw_cell.rows[:'mid_cell'].ddx, atol=1e-7, rtol=0)
+                        tw_cell.rows[:'mid_cell'].ddx, atol=1e-7, rtol=1e-8)
 
     xo.assert_allclose(tw_half_cell.qx, tw_cell.qx / 2, atol=1e-9, rtol=0)
     xo.assert_allclose(tw_half_cell.qy, tw_cell.qy / 2, atol=1e-9, rtol=0)

--- a/xtrack/match.py
+++ b/xtrack/match.py
@@ -1,11 +1,7 @@
-from collections.abc import Iterable
-from functools import partial
-
 import numpy as np
-from scipy.optimize import fsolve, minimize
 
-from .twiss import TwissInit, VARS_FOR_TWISS_INIT_GENERATION, _complete_twiss_init
-from .general import _print, START, END, _LOC
+from .twiss import VARS_FOR_TWISS_INIT_GENERATION
+from .general import _print, _LOC
 import xtrack as xt
 import xdeps as xd
 

--- a/xtrack/particles/constants.py
+++ b/xtrack/particles/constants.py
@@ -5,8 +5,8 @@
 
 import scipy.constants as sc
 
-PROTON_MASS_EV = sc.m_p *sc.c**2 /sc.e
-ELECTRON_MASS_EV = sc.m_e * sc.c**2 /sc.e
-MUON_MASS_EV = sc.physical_constants['muon mass'][0] * sc.c**2 /sc.e
+PROTON_MASS_EV = sc.m_p * sc.c**2 / sc.e
+ELECTRON_MASS_EV = sc.m_e * sc.c**2 / sc.e
+MUON_MASS_EV = sc.physical_constants['muon mass'][0] * sc.c**2 / sc.e
 Pb208_MASS_EV = 193729024900.
 U_MASS_EV = 931494102.42


### PR DESCRIPTION
## Description

In scipy==1.15.0 definitions of constants were updated (notably $m_p$ and $\varepsilon_0$) which caused two kinds of failures in our test suite:

1. In some tests results from Xsuite are compared with the results of MAD-X, which can be incompatible if different constants are used – in those cases we can attempt to fix things by redefining the beam in MAD-X using the new constant.
2. In other tests the change causes some assertions that previously held to no longer do so – we fix those by relaxing tolerances.

This PR makes the tests pass again by applying the above-mentioned fixes.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
