### PR TITLE
Fix flag loading in new madloader; more tests for env.new

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1594,6 +1594,12 @@ def test_env_new():
     assert isinstance(env['e1.ll4'], xt.Bend)
     assert isinstance(env['e2.ll4'], xt.Bend)
 
+    ret = env.new('aper', xt.LimitEllipse, a='2*a', b='a')
+    assert ret == 'aper'
+    assert env[ret].a == 6
+    assert env[ret].b == 3
+
+
 def test_builder_new():
 
     env = xt.Environment()
@@ -1686,6 +1692,7 @@ def test_builder_new():
     assert isinstance(bdr['e2.ll4'], xt.Bend)
     assert len(bdr.components) == 11
     assert bdr.components[-1] is ret
+
 
 def test_neg_line():
 
@@ -2015,6 +2022,23 @@ def test_import_line_from_other_env(overwrite_vars, x_value):
     assert env2['b/line'].k0 == 2 * x_value
     assert isinstance(env2['ip'], xt.Marker)
     assert env2['d'].length == 3 * 7
+
+
+def test_copy_element_from_other_env():
+    env1 = xt.Environment()
+    env1['var'] = 3
+    env1['var2'] = '2 * var'
+    env1.new('quad', xt.Quadrupole, length='var', knl=[0, 'var2'])
+
+    env2 = xt.Environment()
+    env2['var'] = 4
+    env2['var2'] = '2 * var'
+    env2.copy_element_from('quad', env1, 'quad/env2')
+
+    assert env2['quad/env2'].length == 4
+    assert env2['quad/env2'].knl[0] == 0
+    assert env2['quad/env2'].knl[1] == 8
+
 
 def test_insert_repeated_elements():
 

--- a/tests/test_new_madloader.py
+++ b/tests/test_new_madloader.py
@@ -146,7 +146,7 @@ def example_sequence(temp_context_default_mod):
     se: sextupole, L=1, K2=2, K2S=3, TILT=2;  ! ignore ktap
     oc: octupole, L=2, K3=3, K3S=2, TILT=2;
     ma: marker;
-    rf: rfcavity, L=2, VOLT=1, LAG=2, FREQ=3, HARMON=2;  ! ignore N_BESSEL, NO_CAVITY_TOTALPATH
+    rf: rfcavity, L=2, VOLT=1, LAG=2, FREQ=3, HARMON=2, NO_CAVITY_TOTALPATH;  ! ignore N_BESSEL
     mu: multipole, LRAD=1, TILT=2, KNL={3, 4, 5, 6}, KSL={1, 2, 3, 4};
     so: solenoid, l=2, ks=3;  ! ignore ksi
     

--- a/xtrack/environment.py
+++ b/xtrack/environment.py
@@ -457,6 +457,9 @@ class Environment:
             Suffix to be added to the names of the elements that are common to
             the imported line and the line in this environment. If None,
             '_{source_line_name}' is used.
+        rename_elements : dict, optional
+            Dictionary with the elements to be renamed. The keys are the names
+            of the elements in `line`, and the values are the new names.
         line_name : str, optional
             Name of the new line. If None, the name of the imported line is used.
         overwrite_vars : bool, optional
@@ -485,9 +488,9 @@ class Environment:
             elif (bool(re.match(r'^drift_\d+$', name))
                 and line.ref[name].length._expr is None):
                 new_name = self._get_a_drift_name()
-            elif (name in self.element_dict and not
-                (isinstance(line[name], xt.Marker)
-                and isinstance(self.element_dict.get(name), xt.Marker))):
+            elif (name in self.element_dict and
+                    not (isinstance(line[name], xt.Marker) and
+                        isinstance(self.element_dict.get(name), xt.Marker))):
                 new_name += suffix_for_common_elements
 
             self.copy_element_from(name, line, new_name=new_name)

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -3096,7 +3096,7 @@ class Line:
         # Unfreeze the line
         self.discard_tracker()
 
-        if verbose: _print("Replance slices with equivalent elements")
+        if verbose: _print("Replace slices with equivalent elements")
         self._replace_with_equivalent_elements()
 
         if keep_markers is True:
@@ -3873,7 +3873,7 @@ class Line:
         cls = type(source.element_dict[name])
 
         if cls not in _ALLOWED_ELEMENT_TYPES_IN_NEW + [xt.DipoleEdge]: # No issue in copying DipoleEdge
-                                                                       # while creating it requirese handling properties
+                                                                       # while creating it requires handling properties
                                                                        # which are strings.
             raise ValueError(
                 f'Only {_STR_ALLOWED_ELEMENT_TYPES_IN_NEW} elements are '

--- a/xtrack/mad_parser/parse.py
+++ b/xtrack/mad_parser/parse.py
@@ -131,10 +131,16 @@ class MadxTransformer(Transformer):
         return args
 
     def set_flag(self, name_token):
-        return name_token.value.lower(), True
+        return name_token.value.lower(), {
+            'expr': True,
+            'deferred': False,
+        }
 
     def reset_flag(self, name_token):
-        return name_token.value.lower(), False
+        return name_token.value.lower(), {
+            'expr': False,
+            'deferred': False,
+        }
 
     def sequence(self, name_token, arglist, *clones) -> Tuple[str, LineType]:
         return name_token.value.lower(), {


### PR DESCRIPTION
## Description

- Fix an issue of the native madloader, where some boolean flags of elements were not loaded properly, blocking the parsing of some existing MAD-X sequences.
- Add test for xsuite/xsuite#581.
- Add explicit test for `Line.copy_element_from`.
- Minor typos and style.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
