### PR TITLE
Specialise twiss

### DIFF
--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -4473,7 +4473,7 @@ class Line:
             return self
 
         elif not self.iscollective and not self.tracker._skip_noncollective_elements_in_twiss:
-            # Can use the regular tracker
+            # Can use the regular line
             return self
 
         else:
@@ -4481,7 +4481,7 @@ class Line:
                 log.warning(
                     "The tracker has non-collective elements marked by "
                     "'skip_in_twiss=True'.\nIn the twiss computation these "
-                    "elements are replaced by drifts")
+                    "elements are replaced by drifts.")
             if self.tracker._enable_collective_elements_in_twiss and _print:
                 log.warning(
                     "The tracker has collective elements.\n"
@@ -4527,7 +4527,10 @@ class Line:
                 particles_monitor_class = self.tracker.particles_monitor_class
                 extra_headers = self.tracker.extra_headers
                 local_particle_src = self.tracker.local_particle_src
-                out.discard_tracker()
+                # Discard the tracker; cannot do out.discard_tracker() as it points to
+                # the same object and would invalidate the existing tracker on the line
+                out._element_names = list(out._element_names)
+                out.tracker = None
                 out.build_tracker(_buffer=_buffer, io_buffer=io_buffer,
                     extra_headers=extra_headers, local_particle_src=local_particle_src,
                     use_prebuilt_kernels=use_prebuilt_kernels,

--- a/xtrack/loss_location_refinement/loss_location_refinement.py
+++ b/xtrack/loss_location_refinement/loss_location_refinement.py
@@ -65,12 +65,8 @@ class LossLocationRefinement:
         if backtrack_line is not None:
             raise ValueError('Backtracking line not supported anymore!')
 
-        if line.iscollective:
-            self._original_line = line
-            self.line = line._get_non_collective_line()
-        else:
-            self._original_line = line
-            self.line = line
+        self._original_line = line
+        self.line = line._get_non_collective_line()
 
         self._context = self.line._context
         assert isinstance(self._context, xo.ContextCpu), (

--- a/xtrack/multisetter/multisetter.py
+++ b/xtrack/multisetter/multisetter.py
@@ -138,8 +138,7 @@ class MultiSetter(xo.HybridClass):
         else:
             tracker = line.tracker
 
-        if tracker.iscollective:
-            tracker = tracker.line._get_non_collective_line().tracker
+        tracker = tracker.line._get_non_collective_line(_print=False).tracker
 
         context = tracker._context
 

--- a/xtrack/multisetter/multisetter.py
+++ b/xtrack/multisetter/multisetter.py
@@ -138,7 +138,7 @@ class MultiSetter(xo.HybridClass):
         else:
             tracker = line.tracker
 
-        tracker = tracker.line._get_non_collective_line(_print=False).tracker
+        tracker = tracker.line._get_non_collective_line().tracker
 
         context = tracker._context
 

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -103,21 +103,7 @@ class Tracker:
             ele_dict_non_collective = line.element_dict
 
         # Deal with special cases for twiss
-        self._skip_noncollective_elements_in_twiss = False
-        for ee in line.elements:
-            if not _is_collective(ee, line) and _skip_in_twiss(ee, line):
-                self._skip_noncollective_elements_in_twiss = True
-                break
-
-        self._enable_collective_elements_in_twiss = False
-        for ee in line.elements:
-            if _is_collective(ee, line) and not _skip_in_twiss(ee, line):
-                self._enable_collective_elements_in_twiss = True
-                break
-
-        ele_dict_for_twiss = self._make_ele_dict_for_twiss(ele_dict_non_collective)
-        self._element_dict_for_twiss = ele_dict_for_twiss
-        self._specialised_for_twiss = False
+        self._make_ele_dict_for_twiss(ele_dict_non_collective)
 
         if _prebuilding_kernels:
             element_s_locations = np.zeros(len(line.element_names))
@@ -252,7 +238,21 @@ class Tracker:
                 _part_element_index, noncollective_xelements)
 
     def _make_ele_dict_for_twiss(self, ele_dict_non_collective):
+        self._specialised_for_twiss = False
         line = self.line
+
+        self._skip_noncollective_elements_in_twiss = False
+        for ee in line.elements:
+            if not _is_collective(ee, line) and _skip_in_twiss(ee, line):
+                self._skip_noncollective_elements_in_twiss = True
+                break
+
+        self._enable_collective_elements_in_twiss = False
+        for ee in line.elements:
+            if _is_collective(ee, line) and not _skip_in_twiss(ee, line):
+                self._enable_collective_elements_in_twiss = True
+                break
+
         if self._skip_noncollective_elements_in_twiss \
         or self._enable_collective_elements_in_twiss:
             ele_dict_for_twiss = ele_dict_non_collective.copy() # need to keep the parents
@@ -267,9 +267,9 @@ class Tracker:
                     ele_dict_for_twiss[nn] = Drift(_buffer=ee_buffer, length=ldrift)
                 elif _is_collective(ee, line) and not _skip_in_twiss(ee, line):
                     ele_dict_for_twiss[nn] = ee
-            return ele_dict_for_twiss
+            self._element_dict_for_twiss = ele_dict_for_twiss
         else:
-            return ele_dict_non_collective
+            self._element_dict_for_twiss = ele_dict_non_collective
 
     @property
     def track_kernel(self):

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -589,12 +589,7 @@ def twiss_line(line, particle_ref=None, method=None,
         elif co_guess is None and hasattr(line, 'particle_ref'):
             particle_ref = line.particle_ref
 
-    if line.iscollective:
-        _print(
-            'The line has collective elements.\n'
-            'In the twiss computation collective elements are'
-            ' replaced by drifts')
-        line = line._get_non_collective_line()
+    line = line._get_non_collective_line()
 
     if particle_ref is None and co_guess is None:
         raise ValueError(


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

This PR makes it possible to fine-tune whether or not a certain element type in the line should be included in a twiss calculation or not, using the new `skip_in_twiss` flag that can be added to a class. Regular behaviour is not affected.

In this way, one can enforce collective elements to be included in the twiss calculation (useful for instance for elements with track methods in python which still might be single-particle, hence need to be included in twiss). Example:

```python
class MyDrift:

    isthick = True
    skip_in_twiss = False

    def __init__(self, *, length=0):
        self.length = length

    def track(self, particles):
        pass
```

Similarly, one can enforce non-collective elements to NOT be included in the twiss calculation (useful for destructive elements like collimators). Example:

```python
class MyExtremeAperture(xt.BeamElement):
    skip_in_twiss = True

    _extra_c_sources = ["""
/*gpufun*/
void MyExtremeAperture_track_local_particle(DriftData el, LocalParticle* part0){
    //start_per_particle_block (part0->part)
        double y = LocalParticle_get_y(part);
        if (y > - 0.1){
            LocalParticle_set_state(part, -666);  // Die, maggots!
        }
    //end_per_particle_block
}
"""
```

## Implementation
 - When a `Tracker` is built, it will check the line for elements with non-standard behaviour and set two flags: `_skip_noncollective_elements_in_twiss` (`True` if there are some non-collective elements with `skip_in_twiss=True`) and `_enable_collective_elements_in_twiss` (`True` if there are some collective elements with `skip_in_twiss=False`). Of course, by default collective elements act as skip_in_twiss=True` and non-collective elements as `skip_in_twiss=False`). If any of these tracker flags is `True`, the tracker makes an element dict `_element_dict_for_twiss` with `Drifts` where needed (when both these flags are `False`, this dict is just equal to the regular non-collective element dict in the tracker).
 - Whenever a function needs to twiss, it will call `_get_non_collective_line` on the `Line` under consideration. This function is updated to handle the different cases. If both above flags are `False`, it works the same as before and returns itself. If this tracker is already on a line specialised for its twiss (`_specialised_for_twiss=True`) it will also return itself. If `_skip_noncollective_elements_in_twiss` is `True`, it will just make a shallow copy of the tracker and adapt its dict, just as in the regular case. However, if `_enable_collective_elements_in_twiss` is `True` it needs to completely rebuild the tracker as now some collective elements are included and hence the structure is different.
 - Because rebuilding the tracker is rarely needed but time-consuming, the specialised line is cached. The cache is invalidated if the original tracker on the original line gets invalidated and rebuilt. This is inspected by storing the memory address of the tracker of the original line into the specialised line (in `_tracker_id`). Every time a specialised line is needed, the memory addresses are compared and if invalid it is rebuilt.
 - The functions that call `_get_non_collective_line` (twiss, closed orbit search, one turn matrix, multisetter, build particles, build longitudinal particles) are adapted. Instead of first checking if the line is collective, they now directly call `_get_non_collective_line` because otherwise the case of a non-collective line with skipped elements might be missed. In any case, if the line is collective and no classes behave differently, the function does the same as before. There is a parallel PR in `xpart` with these small changes. For ease of messaging, the logging info is moved into the specialised line generation (and hence only outputted once instead of multiple times).

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [X] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
