### PR TITLE
Fix Syntaxwarning

### DIFF
--- a/xtrack/madng_interface.py
+++ b/xtrack/madng_interface.py
@@ -231,7 +231,7 @@ def line_to_madng(line, sequence_name='seq', temp_fname=None, keep_files=False):
                     f'{nn_ng}.dx = 0\n'
                     f'{nn_ng}.dy = 0\n'
                     f'{nn_ng}.misalign'
-                    ' =\ {'
+                    r' =\ {'
                     # f'dx={line[nn].shift_x},'
                     # f'dy={line[nn].shift_y}'
                     + (f'dx={dx},' if not isinstance(dx, str) else f'dx={dx},')


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

At the moment simply running `import xtrack` emits a syntax warning to the user. This is a fix for that.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
