### PR TITLE
Bugfix: badly parsed identifiers in new madloader (parse ^ correctly)

### DIFF
--- a/tests/test_new_madloader.py
+++ b/tests/test_new_madloader.py
@@ -19,6 +19,7 @@ def test_simple_parser():
     if (version>=50401){option,-rbarc;};  ! to be ignored
     
     third = 1 / 3;
+    power = 3^4;
     hello := third * twopi;
     mb.l = 1;
     qd.l = 0.5;
@@ -45,6 +46,7 @@ def test_simple_parser():
     expected: MadxOutputType = {
         'vars': {
             'third': {'deferred': False, 'expr': '(1.0 / 3.0)'},
+            'power': {'deferred': False, 'expr': '(3.0 ** 4.0)'},
             'hello': {'deferred': True, 'expr': '(third * twopi)'},
             'mb.l': {'deferred': False, 'expr': 1.0},
             'qd.l': {'deferred': False, 'expr': 0.5},

--- a/xtrack/mad_parser/loader.py
+++ b/xtrack/mad_parser/loader.py
@@ -298,14 +298,14 @@ class MadxLoader:
 
 
             if (isinstance(self.env[name], BeamElement) and not self.env[name].isthick
-                 and length and not isinstance(self.env[name], xt.Marker)):
+                    and length and not isinstance(self.env[name], xt.Marker)):
                 drift_name = f'drift_{name}'
                 self.env.new(drift_name, 'Drift', length=f'({length}) / 2')
                 name = builder.new_line([drift_name, name, drift_name])
             builder.place(name, **el_params)
         else:
             if (isinstance(self.env[parent], BeamElement) and not self.env[parent].isthick
-                and length and not isinstance(self.env[parent], xt.Marker)):
+                    and length and not isinstance(self.env[parent], xt.Marker)):
                 drift_name = f'{name}_drift'
                 self.env.new(drift_name, 'Drift', force=True, length=f'({length}) / 2')  # Not sure why `force` is needed
                 at, from_ = el_params.pop('at', None), el_params.pop('from_', None)

--- a/xtrack/mad_parser/madx.lark
+++ b/xtrack/mad_parser/madx.lark
@@ -96,7 +96,7 @@ _ENDSEQUENCE: "endsequence"i
 _SEQEDIT: "seqedit"i
 _ENDEDIT: "endedit"i
 _LINE: "line"i
-NAME: /[A-z_\\.][A-z0-9_\\.%]*/
+NAME: /[A-Za-z_\\.][A-Za-z0-9_\\.%]*/
 STRING: /"[^"]*"/
 _COMMENT: "!" /[^\n]*/
        | "//" /[^\n]*/


### PR DESCRIPTION
## Description

Fixes xsuite/xsuite#592.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
