### PR TITLE
Add angle to bend

### DIFF
--- a/tests/test_attr_replicas_and_slices.py
+++ b/tests/test_attr_replicas_and_slices.py
@@ -7,7 +7,7 @@ assert_allclose = np.testing.assert_allclose
 
 def _make_line_no_expressions():
     bend = xt.Bend(
-        k0=0.4, h=0.3, length=1,
+        k0=0.4, angle=0.3, length=1,
         shift_x=1e-3, shift_y=2e-3, shift_s=2e-3, rot_s_rad=0.2,
         k1=0.1,
         knl=[0.7, 0.8, 0.9, 1.0], ksl=[0.1, 0.2, 0.3, 0.4])
@@ -37,7 +37,7 @@ def _make_line_with_expressions():
     line = xt.Line(elements=[bend, quad, sext, octu, mult, drift, xt.Replica(parent_name='e0')])
 
     line.vars['k0_bend'] = 999.
-    line.vars['h_bend'] = 999.
+    line.vars['angle_bend'] = 999.
     line.vars['length_bend'] = 999.
     line.vars['shift_x_bend'] = 999.
     line.vars['shift_y_bend'] = 999.
@@ -95,7 +95,7 @@ def _make_line_with_expressions():
     line.vars['length_drift'] = 999.
 
     line.element_refs['e0'].k0 = line.vars['k0_bend']
-    line.element_refs['e0'].h = line.vars['h_bend']
+    line.element_refs['e0'].angle = line.vars['angle_bend']
     line.element_refs['e0'].length = line.vars['length_bend']
     line.element_refs['e0'].shift_x = line.vars['shift_x_bend']
     line.element_refs['e0'].shift_y = line.vars['shift_y_bend']
@@ -156,7 +156,7 @@ def _make_line_with_expressions():
 
 def _set_vars(line):
     line.vars['k0_bend'] = 0.4
-    line.vars['h_bend'] = 0.3
+    line.vars['angle_bend'] = 0.3
     line.vars['length_bend'] = 1
     line.vars['shift_x_bend'] = 1e-3
     line.vars['shift_y_bend'] = 2e-3

--- a/tests/test_elements_thick.py
+++ b/tests/test_elements_thick.py
@@ -179,31 +179,29 @@ def test_combined_function_dipole_expanded(test_context):
 def test_thick_bend_survey():
     circumference = 10
     rho = circumference / (2 * np.pi)
-    h = 1 / rho
     k = 1 / rho
 
     p0 = xp.Particles(p0c=7e12, mass0=xp.PROTON_MASS_EV, x=0.7, px=-0.4, delta=0.0)
 
-    el = xt.Bend(k0=k, h=h, length=circumference)
+    el = xt.Bend(k0=k, angle=2 * np.pi, length=circumference)
     line = xt.Line(elements=[el])
     line.reset_s_at_end_turn = False
     line.build_tracker()
 
-    s_array = np.linspace(0, circumference, 1000)
+    theta_array = np.linspace(0, 2 * np.pi, 1000)
 
-    X0_array = np.zeros_like(s_array)
-    Z0_array = np.zeros_like(s_array)
+    X0_array = np.zeros_like(theta_array)
+    Z0_array = np.zeros_like(theta_array)
 
-    X_array = np.zeros_like(s_array)
-    Z_array = np.zeros_like(s_array)
+    X_array = np.zeros_like(theta_array)
+    Z_array = np.zeros_like(theta_array)
 
-    for ii, s in enumerate(s_array):
+    for ii, theta in enumerate(theta_array):
         p = p0.copy()
 
-        el.length = s
+        el.angle = theta
+        el.length = rho * theta
         line.track(p)
-
-        theta = s / rho
 
         X0 = -rho * (1 - np.cos(theta))
         Z0 = rho * np.sin(theta)
@@ -353,7 +351,7 @@ def test_bend_param_handling(kwargs, scenario):
         ({'length': 2, 'angle': 0.1, 'h': 0.1}, {'length': 2, 'angle': 0.2, 'h': 0.1}),  # order matters
         ({'length': 2, 'angle': 0.1}, {'length': 2, 'angle': 0.1, 'h': 0.05}),
         ({'length': 2, 'h': 0.05}, {'length': 2, 'angle': 0.1, 'h': 0.05}),
-        ({'length': 2}, {'length': 2, 'angle': 0.04, 'h': 0.02}),  # keeps h
+        ({'length': 2}, {'length': 2, 'angle': 0.2, 'h': 0.1}),  # keeps angle
         ({'h': 0.05, 'angle': 0.1}, {'length': 10, 'angle': 0.1, 'h': 0.01}),  # order matters
     ],
     ids=['none', 'all', 'h_after_angle', 'no_h', 'no_angle', 'only_length', 'angle_after_h'],

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -89,15 +89,15 @@ def test_vars_and_element_access_modes(container_type):
     })
 
     env.new('bb', xt.Bend, k0='2 * b', length=3+env.vars['a'] + env.vars['b'],
-            h=5.)
+            angle=5.)
     assert env['bb'].k0 == 2 * (2 * 4 + 5)
     assert env['bb'].length == 3 + 4 + 2 * 4 + 5
-    assert env['bb'].h == 5.
+    assert env['bb'].angle == 5.
 
     env.vars['a'] = 2.
     assert env['bb'].k0 == 2 * (2 * 2 + 5)
     assert env['bb'].length == 3 + 2 + 2 * 2 + 5
-    assert env['bb'].h == 5.
+    assert env['bb'].angle == 5.
 
     line = env.new_line([
         env.new('bb1', 'bb', length=3*env.vars['a'], at='2*a'),
@@ -120,11 +120,11 @@ def test_vars_and_element_access_modes(container_type):
     a = env.vv['a']
     assert line['bb1'].length == 3 * a
     assert line['bb1'].k0 == 2 * (2 * a + 5)
-    assert line['bb1'].h == 5.
+    assert line['bb1'].angle == 5.
 
     assert line['bb'].k0 == 2 * (2 * a + 5)
     assert line['bb'].length == 3 + a + 2 * a + 5
-    assert line['bb'].h == 5.
+    assert line['bb'].angle == 5.
 
     tt = line.get_table(attr=True)
     tt['s_center'] = tt['s'] + tt['length']/2
@@ -139,11 +139,11 @@ def test_vars_and_element_access_modes(container_type):
     a = line.vv['a']
     assert line['bb1'].length == 3 * a
     assert line['bb1'].k0 == 2 * (2 * a + 5)
-    assert line['bb1'].h == 5.
+    assert line['bb1'].angle == 5.
 
     assert line['bb'].k0 == 2 * (2 * a + 5)
     assert line['bb'].length == 3 + a + 2 * a + 5
-    assert line['bb'].h == 5.
+    assert line['bb'].angle == 5.
 
     tt_new = line.get_table(attr=True)
 

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -2,8 +2,7 @@
 # This file is part of the Xtrack Package.  #
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
-from re import error
-from typing import List, Optional
+from typing import List
 
 import numpy as np
 from numbers import Number
@@ -713,6 +712,7 @@ class _BendCommon:
         'k0': xo.Float64,
         'k1': xo.Float64,
         'h': xo.Float64,
+        'angle': xo.Float64,
         'length': xo.Float64,
         'model': xo.Int64,
         'edge_entry_active': xo.Field(xo.Int64, default=1),
@@ -742,6 +742,9 @@ class _BendCommon:
         'edge_exit_model': '_edge_exit_model',
         'k0': '_k0',
         'k0_from_h': '_k0_from_h',
+        'angle': '_angle',
+        'length': '_length',
+        'h': '_h',
     }
 
     _common_c_sources = [
@@ -970,7 +973,7 @@ class Bend(_BendCommon, BeamElement):
         _pkg_root.joinpath('beam_elements/elements_src/bend.h'),
     ]
 
-    def __init__(self, angle=None, order=None, knl: List[float]=None, ksl: List[float]=None, **kwargs):
+    def __init__(self, order=None, knl: List[float]=None, ksl: List[float]=None, **kwargs):
 
         if '_xobject' in kwargs.keys() and kwargs['_xobject'] is not None:
             self.xoinitialize(**kwargs)
@@ -982,12 +985,14 @@ class Bend(_BendCommon, BeamElement):
         multipolar_kwargs = _prepare_multipolar_params(knl, ksl, order)
         kwargs.update(multipolar_kwargs)
 
-        if angle is not None and (length := kwargs.get('length')):
-            if kwargs.get('h') is not None:
-                raise ValueError('Cannot specify both `angle` and `h`')
-            kwargs['h'] = angle / length
-
         self.xoinitialize(**kwargs)
+
+        # Calculate length and h in the event length_straight and/or angle given
+        self.set_bend_params(
+            kwargs.get('length'),
+            kwargs.get('h'),
+            kwargs.get('angle'),
+        )
 
         if self.k0_from_h:
             self.k0 = self.h
@@ -996,14 +1001,72 @@ class Bend(_BendCommon, BeamElement):
             self.model = model
 
     @property
+    def length(self):
+        return self._length
+
+    @length.setter
+    def length(self, value):
+        self.set_bend_params(length=value, h=self.h)
+
+    @property
+    def h(self):
+        return self._h
+
+    @h.setter
+    def h(self, value):
+        self.set_bend_params(length=self.length, h=value)
+
+    @property
     def angle(self):
-        return self.h * self.length
+        return self._angle
 
     @angle.setter
     def angle(self, value):
-        self.h = value / self.length
+        self.set_bend_params(length=self.length, angle=value)
+
+    def set_bend_params(self, length=None, h=None, angle=None):
+        length, h, angle = self.compute_bend_params(
+            length, h, angle,
+        )
+
+        # None becomes NaN in numpy buffers
+        if length is not None:
+            self._length = length
+        if h is not None:
+            self._h = h
+        if angle is not None:
+            self._angle = angle
+
         if self.k0_from_h:
-            self.k0 = self.h
+            self._k0 = self.h
+
+    @staticmethod
+    def compute_bend_params(length=None, h=None, angle=None):
+        if not length:
+            # If no length, then we cannot meaningfully calculate anything
+            return length, h, angle
+
+        if angle is not None:
+            computed_h = angle / length
+
+            if h is not None and not np.isclose(h, computed_h, rtol=0, atol=1e-13):
+                raise ValueError('Given `h` and `angle` are inconsistent!')
+
+            h = h or computed_h
+            return length, h, angle
+
+        if h is not None:
+            computed_angle = h * length
+
+            if angle is not None and not np.isclose(angle, computed_angle, rtol=0, atol=1e-13):
+                raise ValueError('Given `h` and `angle` are inconsistent!')
+
+            angle = angle or computed_angle
+            return length, h, angle
+
+        # Both `h` and `angle` are None
+        return length, h, angle
+
 
     @property
     def _thin_slice_class(self):
@@ -1104,15 +1167,11 @@ class RBend(_BendCommon, BeamElement):
 
     _xofields = {
         **_BendCommon._common_xofields,
-        'angle': xo.Float64,
         'length_straight': xo.Float64,
     }
 
     _rename = {
         **_BendCommon._common_rename,
-        'length': '_length',
-        'h': '_h',
-        'angle': '_angle',
         'length_straight': '_length_straight',
     }
 
@@ -1188,14 +1247,21 @@ class RBend(_BendCommon, BeamElement):
 
     def set_bend_params(self, length=None, length_straight=None, h=None, angle=None):
         (
-            self._length,
-            self._length_straight,
-            self._h,
-            self._angle,
+            length, length_straight, h, angle
         ) = self.compute_bend_params(length, length_straight, h, angle)
 
+        # None becomes NaN in numpy buffers
+        if length is not None:
+            self._length = length
+        if length_straight is not None:
+            self._length_straight = length_straight
+        if h is not None:
+            self._h = h
+        if angle is not None:
+            self._angle = angle
+
         if self.k0_from_h:
-            self.k0 = self.h
+            self._k0 = self.h
 
     @staticmethod
     def compute_bend_params(length=None, length_straight=None, h=None, angle=None):

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -1006,7 +1006,7 @@ class Bend(_BendCommon, BeamElement):
 
     @length.setter
     def length(self, value):
-        self.set_bend_params(length=value, h=self.h)
+        self.set_bend_params(length=value, angle=self.angle)
 
     @property
     def h(self):

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -732,7 +732,7 @@ class _BendCommon:
         'inv_factorial_order': xo.Float64,
         'knl': xo.Float64[:],
         'ksl': xo.Float64[:],
-        'k0_from_h': xo.UInt8,
+        'k0_from_h': xo.UInt64,
     }
 
     _common_rename = {

--- a/xtrack/mad_loader.py
+++ b/xtrack/mad_loader.py
@@ -799,18 +799,7 @@ class MadLoader:
             l_curv = mad_el.l
             bend_kwargs['length'] = l_curv
 
-
-        if mad_el.type == 'rbend':
-            # Xtrack RBend element will update h from the angle and l...
-            bend_kwargs['angle'] = mad_el.angle
-        else:
-            # ...however, for the Bend element things are a bit more complex.
-            # Since `angle` is a computed parameter, and `h` is the actual
-            # stored value, changing the length (e.g. through expressions)
-            # implicitly changes the angle (since `h` is constant). Therefore,
-            # we need to store the expression for `h` here, to indicate that
-            # the value of the angle is the authoritative one.
-            bend_kwargs['h'] = mad_el.angle / mad_el.l
+        bend_kwargs['angle'] = mad_el.angle
 
         # Edge angles
         e1 = mad_el.e1


### PR DESCRIPTION
## Description

Add `angle` as an xofield to the Bend. Make `angle` the invariant quantity: meaning that changes to angle change h, changes to length, change h, and changes to h change the angle.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
