### PR TITLE
Fix `RBend` radiation configuration issue in `Line.configure_radiation` method

### DIFF
--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -2992,7 +2992,7 @@ class Line:
             self._bhabha_model = None
 
         for kk, ee in self.element_dict.items():
-            if isinstance (ee, (xt.Quadrupole, xt.Bend)):
+            if isinstance (ee, (xt.Quadrupole, xt.Bend, xt.RBend)):
                 continue
             if hasattr(ee, 'radiation_flag'):
                 ee.radiation_flag = radiation_flag


### PR DESCRIPTION
## Description
This pull request fixes an issue in the `Line.configure_radiation` method where the `radiation_flag` attribute was being set on thick `RBend` elements, causing an `AttributeError`. The solution adds `RBend` to the list of element types that are skipped during the iteration over the `line.element_dict` when configuring radiation. This ensures that only thin elements (or allowed thick elements) have their `radiation_flag` set, preventing errors when using `RBend` elements with synchrotron radiation enabled.

## Checklist

Mandatory: 

- [] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
