### PR TITLE
Add Reference Frame Transforms to Survey

### DIFF
--- a/examples/survey/001_bend.py
+++ b/examples/survey/001_bend.py
@@ -1,0 +1,327 @@
+"""
+Test the survey on Bends
+"""
+################################################################################
+# Packages
+################################################################################
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+
+from _helpers import madpoint_twiss_survey, add_to_plot
+import xtrack as xt
+
+################################################################################
+# User variables
+################################################################################
+TOLERANCE           = 1E-12
+
+# Small angle needed for paraxial approximation tests
+BEND_ANGLE          = 1E-3
+BEND_LENGTH         = 0.5
+
+################################################################################
+# Plot setup
+################################################################################
+fig_h   = plt.figure(figsize = (16, 8))
+gs_h    = fig_h.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_h   = gs_h.subplots(sharex = 'row', sharey = True)
+
+fig_v   = plt.figure(figsize = (16, 8))
+gs_v    = fig_v.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_v   = gs_v.subplots(sharex = 'row', sharey = True)
+
+################################################################################
+# Create line
+################################################################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(
+    name        = 'line',
+    components  = [
+        env.new('bend', xt.Bend, k0 = 0, h = 0, length = BEND_LENGTH, at = 1),
+        env.new('end', xt.Marker, at = 2)])
+
+########################################
+# Configure Bend Model
+########################################
+line.configure_bend_model(edge = 'suppressed')
+
+################################################################################
+# Horizontal Bend
+################################################################################
+
+########################################
+# h = k0 = 0
+########################################
+line['bend'].k0         = 0
+line['bend'].h          = 0
+line['bend'].rot_s_rad  = 0
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_h, sv, tw, 0)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# h = 0, k0 != 0
+########################################
+line['bend'].k0         = BEND_ANGLE / BEND_LENGTH
+line['bend'].h          = 0
+line['bend'].rot_s_rad  = 0
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_h, sv, tw, 1)
+
+####################
+# Tests
+####################
+# No bending with h = 0, so the survey must be zero
+assert np.allclose(sv.X[-1], 0, atol = TOLERANCE)
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.X[-1] + tw.x[-1], sv.xx[-1], rtol = TOLERANCE)
+# All y related quantities are zero
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol = TOLERANCE)
+
+########################################
+# h != 0, k0 = 0
+########################################
+line['bend'].k0         = 0
+line['bend'].h          = BEND_ANGLE / BEND_LENGTH
+line['bend'].rot_s_rad  = 0
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_h, sv, tw, 2)
+
+####################
+# Tests
+####################
+# With h!=0, k0=0, the survey must be the negative of the Twiss
+assert np.allclose(sv.X[-1], -tw.x[-1], rtol = TOLERANCE)
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.X[-1] + tw.x[-1], sv.xx[-1], rtol = TOLERANCE)
+# All y related quantities are zero
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol = TOLERANCE)
+
+########################################
+# h != k0 !=0
+########################################
+line['bend'].k0         = BEND_ANGLE / BEND_LENGTH * 2
+line['bend'].h          = BEND_ANGLE / BEND_LENGTH
+line['bend'].rot_s_rad  = 0
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_h, sv, tw, 3)
+
+####################
+# Tests
+####################
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.X[-1] + tw.x[-1], sv.xx[-1], rtol = TOLERANCE)
+# All y related quantities are zero
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol = TOLERANCE)
+
+########################################
+# h = k0 != 0
+########################################
+line['bend'].k0         = BEND_ANGLE / BEND_LENGTH
+line['bend'].h          = BEND_ANGLE / BEND_LENGTH
+line['bend'].rot_s_rad  = 0
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_h, sv, tw, 4)
+
+####################
+# Tests
+####################
+# With h=k0, there should be no residual orbit on the twiss
+assert np.allclose(tw.x[-1], 0, atol = TOLERANCE)
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.X[-1] + tw.x[-1], sv.xx[-1], rtol = TOLERANCE)
+# All y related quantities are zero
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol = TOLERANCE)
+
+################################################################################
+# Vertical Bend
+################################################################################
+
+########################################
+# h = k0 = 0
+########################################
+line['bend'].k0         = 0
+line['bend'].h          = 0
+line['bend'].rot_s_rad  = np.pi / 2
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_v, sv, tw, 0)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# h = 0, k0 != 0
+########################################
+line['bend'].k0         = BEND_ANGLE / BEND_LENGTH
+line['bend'].h          = 0
+line['bend'].rot_s_rad  = np.pi / 2
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_v, sv, tw, 1)
+
+####################
+# Tests
+####################
+# No bending with h = 0, so the survey must be zero
+assert np.allclose(sv.Y[-1], 0, atol = TOLERANCE)
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.Y[-1] + tw.y[-1], sv.yy[-1], rtol = TOLERANCE)
+# All x related quantities are zero
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol = TOLERANCE)
+
+########################################
+# h != 0, k0 = 0
+########################################
+line['bend'].k0         = 0
+line['bend'].h          = BEND_ANGLE / BEND_LENGTH
+line['bend'].rot_s_rad  = np.pi / 2
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_v, sv, tw, 2)
+
+####################
+# Tests
+####################
+# With h!=0, k0=0, the survey must be the negative of the Twiss
+assert np.allclose(sv.Y[-1], -tw.y[-1], rtol = TOLERANCE)
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.Y[-1] + tw.y[-1], sv.yy[-1], rtol = TOLERANCE)
+# All x related quantities are zero
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol = TOLERANCE)
+
+########################################
+# h != k0 !=0 
+########################################
+line['bend'].k0         = BEND_ANGLE / BEND_LENGTH * 2
+line['bend'].h          = BEND_ANGLE / BEND_LENGTH
+line['bend'].rot_s_rad  = np.pi / 2
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_v, sv, tw, 3)
+
+####################
+# Tests
+####################
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.Y[-1] + tw.y[-1], sv.yy[-1], rtol = TOLERANCE)
+# All x related quantities are zero
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol = TOLERANCE)
+
+########################################
+# h = k0 != 0
+########################################
+line['bend'].k0         = BEND_ANGLE / BEND_LENGTH
+line['bend'].h          = BEND_ANGLE / BEND_LENGTH
+line['bend'].rot_s_rad  = np.pi / 2
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_v, sv, tw, 4)
+
+####################
+# Tests
+####################
+# With h=k0, there should be no residual orbit on the twiss
+assert np.allclose(tw.y[-1], 0, atol = TOLERANCE)
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.Y[-1] + tw.y[-1], sv.yy[-1], rtol = TOLERANCE)
+# All x related quantities are zero
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol = TOLERANCE)
+
+################################################################################
+# Show Plots
+################################################################################
+
+########################################
+# Horizontal Bends
+########################################
+# y labels
+axs_h[0, 0].set_ylabel('Survey x,y [m]')
+axs_h[1, 0].set_ylabel('Twiss x,y [m]')
+axs_h[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_h[0, 2].set_xlabel('Z [m]')
+axs_h[1, 2].set_xlabel('s [m]')
+axs_h[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_h[0, 0].set_title('h = 0, k0 = 0')
+axs_h[0, 1].set_title('h = 0, k0 != 0')
+axs_h[0, 2].set_title('h != 0, k0 = 0')
+axs_h[0, 3].set_title('h = k0 / 2 != 0')
+axs_h[0, 4].set_title('h = k0 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_h.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_h.suptitle('Horizontal Bend')
+
+########################################
+# Vertical Bends
+########################################
+# y labels
+axs_v[0, 0].set_ylabel('Survey x,y [m]')
+axs_v[1, 0].set_ylabel('Twiss x,y [m]')
+axs_v[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_v[0, 2].set_xlabel('Z [m]')
+axs_v[1, 2].set_xlabel('s [m]')
+axs_v[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_v[0, 0].set_title('h = 0, k0 = 0')
+axs_v[0, 1].set_title('h = 0, k0 != 0')
+axs_v[0, 2].set_title('h != 0, k0 = 0')
+axs_v[0, 3].set_title('h = k0 / 2 != 0')
+axs_v[0, 4].set_title('h = k0 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_v.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_v.suptitle('Vertical Bend')
+
+########################################
+# Show
+########################################
+plt.tight_layout()
+plt.show()

--- a/examples/survey/002_multipole.py
+++ b/examples/survey/002_multipole.py
@@ -1,0 +1,317 @@
+"""
+Test the survey on Bends
+"""
+################################################################################
+# Packages
+################################################################################
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+
+from _helpers import madpoint_twiss_survey, add_to_plot
+import xtrack as xt
+
+################################################################################
+# User variables
+################################################################################
+TOLERANCE           = 1E-12
+HXL                 = 1E-3
+
+################################################################################
+# Plot setup
+################################################################################
+fig_h   = plt.figure(figsize = (16, 8))
+gs_h    = fig_h.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_h   = gs_h.subplots(sharex = 'row', sharey = True)
+
+fig_v   = plt.figure(figsize = (16, 8))
+gs_v    = fig_v.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_v   = gs_v.subplots(sharex = 'row', sharey = True)
+
+################################################################################
+# Create line
+################################################################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('mult', xt.Multipole, hxl = 0, length = 0.5, at = 1),
+    env.new('end', xt.Marker, at = 2)])
+
+################################################################################
+# Horizontal Bend
+################################################################################
+
+########################################
+# h = k0 = 0
+########################################
+line['mult'].knl[0]     = 0
+line['mult'].hxl        = 0
+line['mult'].rot_s_rad  = 0
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_h, sv, tw, 0)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# h = 0, k0 != 0
+########################################
+line['mult'].knl[0]     = HXL
+line['mult'].hxl        = 0
+line['mult'].rot_s_rad  = 0
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_h, sv, tw, 1)
+
+####################
+# Tests
+####################
+# No bending with h = 0, so the survey must be zero
+assert np.allclose(sv.X[-1], 0, atol = TOLERANCE)
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.X[-1] + tw.x[-1], sv.xx[-1], rtol = TOLERANCE)
+# All y related quantities are zero
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol = TOLERANCE)
+
+########################################
+# h != 0, k0 = 0
+########################################
+line['mult'].knl[0]     = 0
+line['mult'].hxl        = HXL
+line['mult'].rot_s_rad  = 0
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_h, sv, tw, 2)
+
+####################
+# Tests
+####################
+# With h!=0, k0=0, the survey must be the negative of the Twiss
+assert np.allclose(sv.X[-1], -tw.x[-1], rtol = TOLERANCE)
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.X[-1] + tw.x[-1], sv.xx[-1], rtol = TOLERANCE)
+# All y related quantities are zero
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol = TOLERANCE)
+
+########################################
+# h != k0 !=0
+########################################
+line['mult'].knl[0]     = HXL * 2
+line['mult'].hxl        = HXL
+line['mult'].rot_s_rad  = 0
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_h, sv, tw, 3)
+
+####################
+# Tests
+####################
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.X[-1] + tw.x[-1], sv.xx[-1], rtol = TOLERANCE)
+# All y related quantities are zero
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol = TOLERANCE)
+
+########################################
+# h = k0 != 0
+########################################
+line['mult'].knl[0]     = HXL
+line['mult'].hxl        = HXL
+line['mult'].rot_s_rad  = 0
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_h, sv, tw, 4)
+
+####################
+# Tests
+####################
+# With h=k0, there should be no residual orbit on the twiss
+assert np.allclose(tw.x[-1], 0, atol = TOLERANCE)
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.X[-1] + tw.x[-1], sv.xx[-1], rtol = TOLERANCE)
+# All y related quantities are zero
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol = TOLERANCE)
+
+################################################################################
+# Vertical Bend
+################################################################################
+
+########################################
+# h = k0 = 0
+########################################
+line['mult'].knl[0]     = 0
+line['mult'].hxl        = 0
+line['mult'].rot_s_rad  = np.pi / 2
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_v, sv, tw, 0)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# h = 0, k0 != 0
+########################################
+line['mult'].knl[0]     = HXL
+line['mult'].hxl        = 0
+line['mult'].rot_s_rad  = np.pi / 2
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_v, sv, tw, 1)
+
+####################
+# Tests
+####################
+# No bending with h = 0, so the survey must be zero
+assert np.allclose(sv.Y[-1], 0, atol = TOLERANCE)
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.Y[-1] + tw.y[-1], sv.yy[-1], rtol = TOLERANCE)
+# All x related quantities are zero
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol = TOLERANCE)
+
+########################################
+# h != 0, k0 = 0
+########################################
+line['mult'].knl[0]     = 0
+line['mult'].hxl        = HXL
+line['mult'].rot_s_rad  = np.pi / 2
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_v, sv, tw, 2)
+
+####################
+# Tests
+####################
+# With h!=0, k0=0, the survey must be the negative of the Twiss
+assert np.allclose(sv.Y[-1], -tw.y[-1], rtol = TOLERANCE)
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.Y[-1] + tw.y[-1], sv.yy[-1], rtol = TOLERANCE)
+# All x related quantities are zero
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol = TOLERANCE)
+
+########################################
+# h != k0 !=0 
+########################################
+line['mult'].knl[0]     = HXL * 2
+line['mult'].hxl        = HXL
+line['mult'].rot_s_rad  = np.pi / 2
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_v, sv, tw, 3)
+
+####################
+# Tests
+####################
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.Y[-1] + tw.y[-1], sv.yy[-1], rtol = TOLERANCE)
+# All x related quantities are zero
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol = TOLERANCE)
+
+########################################
+# h = k0 != 0
+########################################
+line['mult'].knl[0]     = HXL
+line['mult'].hxl        = HXL
+line['mult'].rot_s_rad  = np.pi / 2
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_v, sv, tw, 4)
+
+####################
+# Tests
+####################
+# With h=k0, there should be no residual orbit on the twiss
+assert np.allclose(tw.y[-1], 0, atol = TOLERANCE)
+# MadPoint sum of twiss and survey (paraxial approximation)
+assert np.allclose(sv.Y[-1] + tw.y[-1], sv.yy[-1], rtol = TOLERANCE)
+# All x related quantities are zero
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol = TOLERANCE)
+
+################################################################################
+# Show Plots
+################################################################################
+
+########################################
+# Horizontal Bends
+########################################
+# y labels
+axs_h[0, 0].set_ylabel('Survey x,y [m]')
+axs_h[1, 0].set_ylabel('Twiss x,y [m]')
+axs_h[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_h[0, 2].set_xlabel('Z [m]')
+axs_h[1, 2].set_xlabel('s [m]')
+axs_h[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_h[0, 0].set_title('hxl = 0, k0l = 0')
+axs_h[0, 1].set_title('hxl = 0, k0l != 0')
+axs_h[0, 2].set_title('hxl != 0, k0l = 0')
+axs_h[0, 3].set_title('hxl = k0l / 2 != 0')
+axs_h[0, 4].set_title('hxl = k0l != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_h.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_h.suptitle('Horizontal Multipole')
+
+########################################
+# Vertical Bends
+########################################
+# y labels
+axs_v[0, 0].set_ylabel('Survey x,y [m]')
+axs_v[1, 0].set_ylabel('Twiss x,y [m]')
+axs_v[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_v[0, 2].set_xlabel('Z [m]')
+axs_v[1, 2].set_xlabel('s [m]')
+axs_v[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_v[0, 0].set_title('hyl = 0, k0sl = 0')
+axs_v[0, 1].set_title('hyl = 0, k0sl != 0')
+axs_v[0, 2].set_title('hyl != 0, k0sl = 0')
+axs_v[0, 3].set_title('hyl = k0sl / 2 != 0')
+axs_v[0, 4].set_title('hyl = k0sl != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_v.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_v.suptitle('Vertical Bend')
+
+########################################
+# Show
+########################################
+plt.tight_layout()
+plt.show()

--- a/examples/survey/003_xyshift.py
+++ b/examples/survey/003_xyshift.py
@@ -1,0 +1,152 @@
+"""
+Test the survey on XY Shifts
+"""
+################################################################################
+# Packages
+################################################################################
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+
+from _helpers import madpoint_twiss_survey, add_to_plot
+import xtrack as xt
+
+################################################################################
+# User variables
+################################################################################
+TOLERANCE           = 1E-12
+
+################################################################################
+# Plot setup
+################################################################################
+fig     = plt.figure(figsize = (16, 8))
+gs      = fig.add_gridspec(3, 4, hspace = 0.3, wspace = 0)
+axs     = gs.subplots(sharex = 'row', sharey = True)
+
+################################################################################
+# Create line
+################################################################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('xyshift', xt.XYShift, dx = 0, dy = 0, at = 1),
+    env.new('end', xt.Marker, at = 2)])
+
+################################################################################
+# No Shift
+################################################################################
+line['xyshift'].dx      = 0
+line['xyshift'].dy      = 0
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs, sv, tw, 0, ylims = (-0.15, 0.15))
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+################################################################################
+# X Shift
+################################################################################
+line['xyshift'].dx      = 0.1
+line['xyshift'].dy      = 0
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs, sv, tw, 1, ylims = (-0.15, 0.15))
+
+####################
+# Tests
+####################
+# No bending of particles, so must remain zero
+assert np.allclose( sv.xx[-1], 0, atol=TOLERANCE)
+# Survey negative of Twiss for h != 0, k0 = 0
+assert np.allclose(sv.X[-1], -tw.x[-1], rtol=TOLERANCE)
+# MadPoint sum of twiss and survey
+assert np.allclose(sv.X[-1] + tw.x[-1], sv.xx[-1], rtol=TOLERANCE)
+# All y related quantities are zero
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+################################################################################
+# Y Shift
+################################################################################
+line['xyshift'].dx      = 0
+line['xyshift'].dy      = 0.1
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs, sv, tw, 2, ylims = (-0.15, 0.15))
+
+####################
+# Tests
+####################
+# No bending of particles, so must remain zero
+assert np.allclose(sv.yy[-1], 0, atol=TOLERANCE)
+# Survey negative of Twiss for h != 0, k0 = 0
+assert np.allclose(sv.Y[-1], -tw.y[-1], rtol=TOLERANCE)
+# MadPoint sum of twiss and survey
+assert np.allclose(sv.Y[-1] + tw.y[-1], sv.yy[-1], rtol=TOLERANCE)
+# All x related quantities are zero
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+
+################################################################################
+# X and Y Shift
+################################################################################
+line['xyshift'].dx      = 0.1
+line['xyshift'].dy      = 0.1
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs, sv, tw, 3, ylims = (-0.15, 0.15))
+
+####################
+# Tests
+####################
+# No bending of particles, so must remain zero
+assert np.allclose( sv.xx[-1], 0, atol=TOLERANCE)
+assert np.allclose(sv.yy[-1], 0, atol=TOLERANCE)
+# Survey negative of Twiss for h != 0, k0 = 0
+assert np.allclose(sv.X[-1], -tw.x[-1], rtol=TOLERANCE)
+assert np.allclose(sv.Y[-1], -tw.y[-1], rtol=TOLERANCE)
+# MadPoint sum of twiss and survey
+assert np.allclose(sv.X[-1] + tw.x[-1], sv.xx[-1], rtol=TOLERANCE)
+assert np.allclose(sv.Y[-1] + tw.y[-1], sv.yy[-1], rtol=TOLERANCE)
+
+################################################################################
+# Show Plots
+################################################################################
+# y labels
+axs[0, 0].set_ylabel('Survey x,y [m]')
+axs[1, 0].set_ylabel('Twiss x,y [m]')
+axs[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs[0, 2].set_xlabel('Z [m]')
+axs[1, 2].set_xlabel('s [m]')
+axs[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs[0, 0].set_title('DX = 0, DY = 0')
+axs[0, 1].set_title('DX != 0, DY = 0')
+axs[0, 2].set_title('DX = 0, DY != 0')
+axs[0, 3].set_title('DX != 0, DY != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig.suptitle('XYShift')
+
+########################################
+# Show
+########################################
+plt.tight_layout()
+plt.show()

--- a/examples/survey/004_xrotation.py
+++ b/examples/survey/004_xrotation.py
@@ -1,0 +1,575 @@
+"""
+Test the survey on XRotation
+"""
+################################################################################
+# Packages
+################################################################################
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+
+from _helpers import madpoint_twiss_survey, add_to_plot
+import xtrack as xt
+
+################################################################################
+# User variables
+################################################################################
+TOLERANCE           = 1E-12
+ROT_DEG             = 30
+HXL                 = 0.1
+DX                  = 0.2
+PLOT_X_LIMS         = (-0.1, 4.1)
+PLOT_Y_LIMS         = (-1, 1)
+
+################################################################################
+# Plot setup
+################################################################################
+fig_mult_h  = plt.figure(figsize = (16, 8))
+gs_mult_h   = fig_mult_h.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_mult_h  = gs_mult_h.subplots(sharex = 'row', sharey = True)
+
+fig_mult_v  = plt.figure(figsize = (16, 8))
+gs_mult_v   = fig_mult_v.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_mult_v  = gs_mult_v.subplots(sharex = 'row', sharey = True)
+
+fig_shift_h = plt.figure(figsize = (16, 8))
+gs_shift_h  = fig_shift_h.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_shift_h = gs_shift_h.subplots(sharex = 'row', sharey = True)
+
+fig_shift_v = plt.figure(figsize = (16, 8))
+gs_shift_v  = fig_shift_v.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_shift_v = gs_shift_v.subplots(sharex = 'row', sharey = True)
+
+################################################################################
+# Horizontal Multipole Bends
+################################################################################
+
+########################################
+# Create line
+########################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('mult1', xt.Multipole, hxl = 0, length = 0.5, at = 1),
+    env.new('xrotation', xt.XRotation, angle = 0, at = 2),
+    env.new('mult2', xt.Multipole, hxl = 0, length = 0.5, at = 3),
+    env.new('end', xt.Marker, at = 4)])
+
+########################################
+# Off
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = 0
+line['xrotation'].angle = np.rad2deg(0)
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 0, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# Rotation Only
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = 0
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 1, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot
+########################################
+line['mult1'].hxl       = HXL
+line['mult2'].hxl       = 0
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 2, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Rot then mult
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = HXL
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 3, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot then mult
+########################################
+line['mult1'].hxl       = HXL
+line['mult2'].hxl       = HXL
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 4, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+################################################################################
+# Vertical Multipole Bends
+################################################################################
+
+########################################
+# Create line
+########################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('mult1', xt.Multipole, hxl = 0, length = 0.5, at = 1, rot_s_rad = np.pi / 2),
+    env.new('xrotation', xt.XRotation, angle = 0, at = 2),
+    env.new('mult2', xt.Multipole, hxl = 0, length = 0.5, at = 3, rot_s_rad = np.pi / 2),
+    env.new('end', xt.Marker, at = 4)])
+
+########################################
+# Off
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = 0
+line['xrotation'].angle = np.rad2deg(0)
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 0, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# Rotation Only
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = 0
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 1, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot
+########################################
+line['mult1'].hxl       = HXL
+line['mult2'].hxl       = 0
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 2, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Rot then mult
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = HXL
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 3, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot then mult
+########################################
+line['mult1'].hxl       = HXL
+line['mult2'].hxl       = HXL
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 4, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+################################################################################
+# Horizontal Shift
+################################################################################
+
+########################################
+# Create line
+########################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('shift1', xt.XYShift, dx = 0, dy = 0, at = 1),
+    env.new('xrotation', xt.XRotation, angle = 0, at = 2),
+    env.new('shift2', xt.XYShift, dx = 0, dy = 0, at = 3),
+    env.new('end', xt.Marker, at = 4)])
+
+########################################
+# Off
+########################################
+line['shift1'].dx       = 0
+line['shift2'].dx       = 0
+line['xrotation'].angle = np.rad2deg(0)
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 0, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# Rotation Only
+########################################
+line['shift1'].dx       = 0
+line['shift2'].dx       = 0
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 1, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot
+########################################
+line['shift1'].dx       = DX
+line['shift2'].dx       = 0
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 2, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Rot then mult
+########################################
+line['shift1'].dx       = 0
+line['shift2'].dx       = DX
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 3, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot then mult
+########################################
+line['shift1'].dx       = DX
+line['shift2'].dx       = DX
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 4, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+################################################################################
+# Vertical Shift
+################################################################################
+
+########################################
+# Create line
+########################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('shift1', xt.XYShift, dx = 0, dy = 0, at = 1),
+    env.new('xrotation', xt.XRotation, angle = 0, at = 2),
+    env.new('shift2', xt.XYShift, dx = 0, dy = 0, at = 3),
+    env.new('end', xt.Marker, at = 4)])
+
+########################################
+# Off
+########################################
+line['shift1'].dy       = 0
+line['shift2'].dy       = 0
+line['xrotation'].angle = np.rad2deg(0)
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 0, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# Rotation Only
+########################################
+line['shift1'].dy       = 0
+line['shift2'].dy       = 0
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 1, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot
+########################################
+line['shift1'].dy       = DX
+line['shift2'].dy       = 0
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 2, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Rot then mult
+########################################
+line['shift1'].dy       = 0
+line['shift2'].dy       = DX
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 3, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot then mult
+########################################
+line['shift1'].dy       = DX
+line['shift2'].dy       = DX
+line['xrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 4, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+################################################################################
+# Show Plots
+################################################################################
+
+########################################
+# Horizontal Mult
+########################################
+# y labels
+axs_mult_h[0, 0].set_ylabel('Survey x,y [m]')
+axs_mult_h[1, 0].set_ylabel('Twiss x,y [m]')
+axs_mult_h[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_mult_h[0, 2].set_xlabel('Z [m]')
+axs_mult_h[1, 2].set_xlabel('s [m]')
+axs_mult_h[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_mult_h[0, 0].set_title('Rot  = 0,\n HXL1 = 0, HXL2 = 0')
+axs_mult_h[0, 1].set_title('Rot != 0,\n HXL1 = 0, HXL2 = 0')
+axs_mult_h[0, 2].set_title('Rot != 0,\n HXL1 != 0, HXL2 = 0')
+axs_mult_h[0, 3].set_title('Rot != 0,\n HXL1 = 0, HXL2 != 0')
+axs_mult_h[0, 4].set_title('Rot != 0,\n HXL1 != 0, HXL2 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_mult_h.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_mult_h.suptitle('Horizontal Multipole and XRotation')
+
+########################################
+# Vertical Mult
+########################################
+# y labels
+axs_mult_v[0, 0].set_ylabel('Survey x,y [m]')
+axs_mult_v[1, 0].set_ylabel('Twiss x,y [m]')
+axs_mult_v[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_mult_v[0, 2].set_xlabel('Z [m]')
+axs_mult_v[1, 2].set_xlabel('s [m]')
+axs_mult_v[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_mult_v[0, 0].set_title('Rot  = 0,\n HYL1 = 0, HYL2 = 0')
+axs_mult_v[0, 1].set_title('Rot != 0,\n HYL1 = 0, HYL2 = 0')
+axs_mult_v[0, 2].set_title('Rot != 0,\n HYL1 != 0, HYL2 = 0')
+axs_mult_v[0, 3].set_title('Rot != 0,\n HYL1 = 0, HYL2 != 0')
+axs_mult_v[0, 4].set_title('Rot != 0,\n HYL1 != 0, HYL2 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_mult_v.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_mult_v.suptitle('Vertical Multipole and XRotation')
+
+########################################
+# Horizontal XYShift
+########################################
+# y labels
+axs_shift_h[0, 0].set_ylabel('Survey x,y [m]')
+axs_shift_h[1, 0].set_ylabel('Twiss x,y [m]')
+axs_shift_h[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_shift_h[0, 2].set_xlabel('Z [m]')
+axs_shift_h[1, 2].set_xlabel('s [m]')
+axs_shift_h[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_shift_h[0, 0].set_title('Rot  = 0,\n DX1 = 0, DX2 = 0')
+axs_shift_h[0, 1].set_title('Rot != 0,\n DX1 = 0, DX2 = 0')
+axs_shift_h[0, 2].set_title('Rot != 0,\n DX1 != 0, DX2 = 0')
+axs_shift_h[0, 3].set_title('Rot != 0,\n DX1 = 0, DX2 != 0')
+axs_shift_h[0, 4].set_title('Rot != 0,\n DX1 != 0, DX2 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_shift_h.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_shift_h.suptitle('Horizontal XYShift and XRotation')
+
+########################################
+# Vertical XYShift
+########################################
+# y labels
+axs_shift_v[0, 0].set_ylabel('Survey x,y [m]')
+axs_shift_v[1, 0].set_ylabel('Twiss x,y [m]')
+axs_shift_v[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_shift_v[0, 2].set_xlabel('Z [m]')
+axs_shift_v[1, 2].set_xlabel('s [m]')
+axs_shift_v[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_shift_v[0, 0].set_title('Rot  = 0,\n DY1 = 0, DY2 = 0')
+axs_shift_v[0, 1].set_title('Rot != 0,\n DY1 = 0, DY2 = 0')
+axs_shift_v[0, 2].set_title('Rot != 0,\n DY1 != 0, DY2 = 0')
+axs_shift_v[0, 3].set_title('Rot != 0,\n DY1 = 0, DY2 != 0')
+axs_shift_v[0, 4].set_title('Rot != 0,\n DY1 != 0, DY2 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_shift_v.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_shift_v.suptitle('Vertical XYShift and XRotation')
+
+########################################
+# Show
+########################################
+plt.tight_layout()
+plt.show()

--- a/examples/survey/005_yrotation.py
+++ b/examples/survey/005_yrotation.py
@@ -1,0 +1,575 @@
+"""
+Test the survey on YRotation
+"""
+################################################################################
+# Packages
+################################################################################
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+
+from _helpers import madpoint_twiss_survey, add_to_plot
+import xtrack as xt
+
+################################################################################
+# User variables
+################################################################################
+TOLERANCE           = 1E-12
+ROT_DEG             = 30
+HXL                 = 0.1
+DX                  = 0.2
+PLOT_X_LIMS         = (-0.1, 4.1)
+PLOT_Y_LIMS         = (-1, 1)
+
+################################################################################
+# Plot setup
+################################################################################
+fig_mult_h  = plt.figure(figsize = (16, 8))
+gs_mult_h   = fig_mult_h.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_mult_h  = gs_mult_h.subplots(sharex = 'row', sharey = True)
+
+fig_mult_v  = plt.figure(figsize = (16, 8))
+gs_mult_v   = fig_mult_v.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_mult_v  = gs_mult_v.subplots(sharex = 'row', sharey = True)
+
+fig_shift_h = plt.figure(figsize = (16, 8))
+gs_shift_h  = fig_shift_h.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_shift_h = gs_shift_h.subplots(sharex = 'row', sharey = True)
+
+fig_shift_v = plt.figure(figsize = (16, 8))
+gs_shift_v  = fig_shift_v.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_shift_v = gs_shift_v.subplots(sharex = 'row', sharey = True)
+
+################################################################################
+# Horizontal Multipole Bends
+################################################################################
+
+########################################
+# Create line
+########################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('mult1', xt.Multipole, hxl = 0, length = 0.5, at = 1),
+    env.new('yrotation', xt.YRotation, angle = 0, at = 2),
+    env.new('mult2', xt.Multipole, hxl = 0, length = 0.5, at = 3),
+    env.new('end', xt.Marker, at = 4)])
+
+########################################
+# Off
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = 0
+line['yrotation'].angle = np.rad2deg(0)
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 0, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# Rotation Only
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = 0
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 1, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot
+########################################
+line['mult1'].hxl       = HXL
+line['mult2'].hxl       = 0
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 2, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Rot then mult
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = HXL
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 3, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot then mult
+########################################
+line['mult1'].hxl       = HXL
+line['mult2'].hxl       = HXL
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 4, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+################################################################################
+# Vertical Multipole Bends
+################################################################################
+
+########################################
+# Create line
+########################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('mult1', xt.Multipole, hxl = 0, length = 0.5, at = 1, rot_s_rad = np.pi / 2),
+    env.new('yrotation', xt.YRotation, angle = 0, at = 2),
+    env.new('mult2', xt.Multipole, hxl = 0, length = 0.5, at = 3, rot_s_rad = np.pi / 2),
+    env.new('end', xt.Marker, at = 4)])
+
+########################################
+# Off
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = 0
+line['yrotation'].angle = np.rad2deg(0)
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 0, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# Rotation Only
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = 0
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 1, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot
+########################################
+line['mult1'].hxl       = HXL
+line['mult2'].hxl       = 0
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 2, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Rot then mult
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = HXL
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 3, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot then mult
+########################################
+line['mult1'].hxl       = HXL
+line['mult2'].hxl       = HXL
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 4, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+################################################################################
+# Horizontal Shift
+################################################################################
+
+########################################
+# Create line
+########################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('shift1', xt.XYShift, dx = 0, dy = 0, at = 1),
+    env.new('yrotation', xt.YRotation, angle = 0, at = 2),
+    env.new('shift2', xt.XYShift, dx = 0, dy = 0, at = 3),
+    env.new('end', xt.Marker, at = 4)])
+
+########################################
+# Off
+########################################
+line['shift1'].dx       = 0
+line['shift2'].dx       = 0
+line['yrotation'].angle = np.rad2deg(0)
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 0, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# Rotation Only
+########################################
+line['shift1'].dx       = 0
+line['shift2'].dx       = 0
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 1, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot
+########################################
+line['shift1'].dx       = DX
+line['shift2'].dx       = 0
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 2, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Rot then mult
+########################################
+line['shift1'].dx       = 0
+line['shift2'].dx       = DX
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 3, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot then mult
+########################################
+line['shift1'].dx       = DX
+line['shift2'].dx       = DX
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 4, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+################################################################################
+# Vertical Shift
+################################################################################
+
+########################################
+# Create line
+########################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('shift1', xt.XYShift, dx = 0, dy = 0, at = 1),
+    env.new('yrotation', xt.YRotation, angle = 0, at = 2),
+    env.new('shift2', xt.XYShift, dx = 0, dy = 0, at = 3),
+    env.new('end', xt.Marker, at = 4)])
+
+########################################
+# Off
+########################################
+line['shift1'].dy       = 0
+line['shift2'].dy       = 0
+line['yrotation'].angle = np.rad2deg(0)
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 0, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# Rotation Only
+########################################
+line['shift1'].dy       = 0
+line['shift2'].dy       = 0
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 1, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot
+########################################
+line['shift1'].dy       = DX
+line['shift2'].dy       = 0
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 2, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Rot then mult
+########################################
+line['shift1'].dy       = 0
+line['shift2'].dy       = DX
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 3, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot then mult
+########################################
+line['shift1'].dy       = DX
+line['shift2'].dy       = DX
+line['yrotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 4, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+################################################################################
+# Show Plots
+################################################################################
+
+########################################
+# Horizontal Mult
+########################################
+# y labels
+axs_mult_h[0, 0].set_ylabel('Survey x,y [m]')
+axs_mult_h[1, 0].set_ylabel('Twiss x,y [m]')
+axs_mult_h[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_mult_h[0, 2].set_xlabel('Z [m]')
+axs_mult_h[1, 2].set_xlabel('s [m]')
+axs_mult_h[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_mult_h[0, 0].set_title('Rot  = 0,\n HXL1 = 0, HXL2 = 0')
+axs_mult_h[0, 1].set_title('Rot != 0,\n HXL1 = 0, HXL2 = 0')
+axs_mult_h[0, 2].set_title('Rot != 0,\n HXL1 != 0, HXL2 = 0')
+axs_mult_h[0, 3].set_title('Rot != 0,\n HXL1 = 0, HXL2 != 0')
+axs_mult_h[0, 4].set_title('Rot != 0,\n HXL1 != 0, HXL2 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_mult_h.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_mult_h.suptitle('Horizontal Multipole and YRotation')
+
+########################################
+# Vertical Mult
+########################################
+# y labels
+axs_mult_v[0, 0].set_ylabel('Survey x,y [m]')
+axs_mult_v[1, 0].set_ylabel('Twiss x,y [m]')
+axs_mult_v[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_mult_v[0, 2].set_xlabel('Z [m]')
+axs_mult_v[1, 2].set_xlabel('s [m]')
+axs_mult_v[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_mult_v[0, 0].set_title('Rot  = 0,\n HYL1 = 0, HYL2 = 0')
+axs_mult_v[0, 1].set_title('Rot != 0,\n HYL1 = 0, HYL2 = 0')
+axs_mult_v[0, 2].set_title('Rot != 0,\n HYL1 != 0, HYL2 = 0')
+axs_mult_v[0, 3].set_title('Rot != 0,\n HYL1 = 0, HYL2 != 0')
+axs_mult_v[0, 4].set_title('Rot != 0,\n HYL1 != 0, HYL2 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_mult_v.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_mult_v.suptitle('Vertical Multipole and YRotation')
+
+########################################
+# Horizontal XYShift
+########################################
+# y labels
+axs_shift_h[0, 0].set_ylabel('Survey x,y [m]')
+axs_shift_h[1, 0].set_ylabel('Twiss x,y [m]')
+axs_shift_h[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_shift_h[0, 2].set_xlabel('Z [m]')
+axs_shift_h[1, 2].set_xlabel('s [m]')
+axs_shift_h[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_shift_h[0, 0].set_title('Rot  = 0,\n DX1 = 0, DX2 = 0')
+axs_shift_h[0, 1].set_title('Rot != 0,\n DX1 = 0, DX2 = 0')
+axs_shift_h[0, 2].set_title('Rot != 0,\n DX1 != 0, DX2 = 0')
+axs_shift_h[0, 3].set_title('Rot != 0,\n DX1 = 0, DX2 != 0')
+axs_shift_h[0, 4].set_title('Rot != 0,\n DX1 != 0, DX2 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_shift_h.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_shift_h.suptitle('Horizontal XYShift and YRotation')
+
+########################################
+# Vertical XYShift
+########################################
+# y labels
+axs_shift_v[0, 0].set_ylabel('Survey x,y [m]')
+axs_shift_v[1, 0].set_ylabel('Twiss x,y [m]')
+axs_shift_v[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_shift_v[0, 2].set_xlabel('Z [m]')
+axs_shift_v[1, 2].set_xlabel('s [m]')
+axs_shift_v[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_shift_v[0, 0].set_title('Rot  = 0,\n DY1 = 0, DY2 = 0')
+axs_shift_v[0, 1].set_title('Rot != 0,\n DY1 = 0, DY2 = 0')
+axs_shift_v[0, 2].set_title('Rot != 0,\n DY1 != 0, DY2 = 0')
+axs_shift_v[0, 3].set_title('Rot != 0,\n DY1 = 0, DY2 != 0')
+axs_shift_v[0, 4].set_title('Rot != 0,\n DY1 != 0, DY2 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_shift_v.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_shift_v.suptitle('Vertical XYShift and YRotation')
+
+########################################
+# Show
+########################################
+plt.tight_layout()
+plt.show()

--- a/examples/survey/006_srotation.py
+++ b/examples/survey/006_srotation.py
@@ -1,0 +1,575 @@
+"""
+Test the survey on SRotation
+"""
+################################################################################
+# Packages
+################################################################################
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+
+from _helpers import madpoint_twiss_survey, add_to_plot
+import xtrack as xt
+
+################################################################################
+# User variables
+################################################################################
+TOLERANCE           = 1E-12
+ROT_DEG             = 30
+HXL                 = 0.1
+DX                  = 0.2
+PLOT_X_LIMS         = (-0.1, 4.1)
+PLOT_Y_LIMS         = (-1, 1)
+
+################################################################################
+# Plot setup
+################################################################################
+fig_mult_h  = plt.figure(figsize = (16, 8))
+gs_mult_h   = fig_mult_h.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_mult_h  = gs_mult_h.subplots(sharex = 'row', sharey = True)
+
+fig_mult_v  = plt.figure(figsize = (16, 8))
+gs_mult_v   = fig_mult_v.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_mult_v  = gs_mult_v.subplots(sharex = 'row', sharey = True)
+
+fig_shift_h = plt.figure(figsize = (16, 8))
+gs_shift_h  = fig_shift_h.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_shift_h = gs_shift_h.subplots(sharex = 'row', sharey = True)
+
+fig_shift_v = plt.figure(figsize = (16, 8))
+gs_shift_v  = fig_shift_v.add_gridspec(3, 5, hspace = 0.3, wspace = 0)
+axs_shift_v = gs_shift_v.subplots(sharex = 'row', sharey = True)
+
+################################################################################
+# Horizontal Multipole Bends
+################################################################################
+
+########################################
+# Create line
+########################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('mult1', xt.Multipole, hxl = 0, length = 0.5, at = 1),
+    env.new('srotation', xt.SRotation, angle = 0, at = 2),
+    env.new('mult2', xt.Multipole, hxl = 0, length = 0.5, at = 3),
+    env.new('end', xt.Marker, at = 4)])
+
+########################################
+# Off
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = 0
+line['srotation'].angle = np.rad2deg(0)
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 0, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# Rotation Only
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = 0
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 1, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot
+########################################
+line['mult1'].hxl       = HXL
+line['mult2'].hxl       = 0
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 2, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Rot then mult
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = HXL
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 3, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot then mult
+########################################
+line['mult1'].hxl       = HXL
+line['mult2'].hxl       = HXL
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_h, sv, tw, 4, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+################################################################################
+# Vertical Multipole Bends
+################################################################################
+
+########################################
+# Create line
+########################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('mult1', xt.Multipole, hxl = 0, length = 0.5, at = 1, rot_s_rad = np.pi / 2),
+    env.new('srotation', xt.SRotation, angle = 0, at = 2),
+    env.new('mult2', xt.Multipole, hxl = 0, length = 0.5, at = 3, rot_s_rad = np.pi / 2),
+    env.new('end', xt.Marker, at = 4)])
+
+########################################
+# Off
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = 0
+line['srotation'].angle = np.rad2deg(0)
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 0, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# Rotation Only
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = 0
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 1, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot
+########################################
+line['mult1'].hxl       = HXL
+line['mult2'].hxl       = 0
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 2, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Rot then mult
+########################################
+line['mult1'].hxl       = 0
+line['mult2'].hxl       = HXL
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 3, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot then mult
+########################################
+line['mult1'].hxl       = HXL
+line['mult2'].hxl       = HXL
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_mult_v, sv, tw, 4, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+################################################################################
+# Horizontal Shift
+################################################################################
+
+########################################
+# Create line
+########################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('shift1', xt.XYShift, dx = 0, dy = 0, at = 1),
+    env.new('srotation', xt.SRotation, angle = 0, at = 2),
+    env.new('shift2', xt.XYShift, dx = 0, dy = 0, at = 3),
+    env.new('end', xt.Marker, at = 4)])
+
+########################################
+# Off
+########################################
+line['shift1'].dx       = 0
+line['shift2'].dx       = 0
+line['srotation'].angle = np.rad2deg(0)
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 0, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# Rotation Only
+########################################
+line['shift1'].dx       = 0
+line['shift2'].dx       = 0
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 1, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot
+########################################
+line['shift1'].dx       = DX
+line['shift2'].dx       = 0
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 2, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Rot then mult
+########################################
+line['shift1'].dx       = 0
+line['shift2'].dx       = DX
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 3, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot then mult
+########################################
+line['shift1'].dx       = DX
+line['shift2'].dx       = DX
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_h, sv, tw, 4, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+################################################################################
+# Vertical Shift
+################################################################################
+
+########################################
+# Create line
+########################################
+env     = xt.Environment(particle_ref = xt.Particles(p0c = 1E9))
+line    = env.new_line(name = 'line', components=[
+    env.new('shift1', xt.XYShift, dx = 0, dy = 0, at = 1),
+    env.new('srotation', xt.SRotation, angle = 0, at = 2),
+    env.new('shift2', xt.XYShift, dx = 0, dy = 0, at = 3),
+    env.new('end', xt.Marker, at = 4)])
+
+########################################
+# Off
+########################################
+line['shift1'].dy       = 0
+line['shift2'].dy       = 0
+line['srotation'].angle = np.rad2deg(0)
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 0, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Element off must have no effect
+assert np.allclose(np.array([sv.X[-1], sv.xx[-1], tw.x[-1]]), 0, atol=TOLERANCE)
+assert np.allclose(np.array([sv.Y[-1], sv.yy[-1], tw.y[-1]]), 0, atol=TOLERANCE)
+
+########################################
+# Rotation Only
+########################################
+line['shift1'].dy       = 0
+line['shift2'].dy       = 0
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 1, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot
+########################################
+line['shift1'].dy       = DX
+line['shift2'].dy       = 0
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 2, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Rot then mult
+########################################
+line['shift1'].dy       = 0
+line['shift2'].dy       = DX
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 3, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+########################################
+# Mult then rot then mult
+########################################
+line['shift1'].dy       = DX
+line['shift2'].dy       = DX
+line['srotation'].angle = ROT_DEG
+
+sv, tw = madpoint_twiss_survey(line)
+
+add_to_plot(axs_shift_v, sv, tw, 4, xlims = PLOT_X_LIMS, ylims = PLOT_Y_LIMS)
+
+####################
+# Tests
+####################
+# Only rotation must have no effect
+# TODO
+
+################################################################################
+# Show Plots
+################################################################################
+
+########################################
+# Horizontal Mult
+########################################
+# y labels
+axs_mult_h[0, 0].set_ylabel('Survey x,y [m]')
+axs_mult_h[1, 0].set_ylabel('Twiss x,y [m]')
+axs_mult_h[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_mult_h[0, 2].set_xlabel('Z [m]')
+axs_mult_h[1, 2].set_xlabel('s [m]')
+axs_mult_h[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_mult_h[0, 0].set_title('Rot  = 0,\n HXL1 = 0, HXL2 = 0')
+axs_mult_h[0, 1].set_title('Rot != 0,\n HXL1 = 0, HXL2 = 0')
+axs_mult_h[0, 2].set_title('Rot != 0,\n HXL1 != 0, HXL2 = 0')
+axs_mult_h[0, 3].set_title('Rot != 0,\n HXL1 = 0, HXL2 != 0')
+axs_mult_h[0, 4].set_title('Rot != 0,\n HXL1 != 0, HXL2 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_mult_h.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_mult_h.suptitle('Horizontal Multipole and SRotation')
+
+########################################
+# Vertical Mult
+########################################
+# y labels
+axs_mult_v[0, 0].set_ylabel('Survey x,y [m]')
+axs_mult_v[1, 0].set_ylabel('Twiss x,y [m]')
+axs_mult_v[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_mult_v[0, 2].set_xlabel('Z [m]')
+axs_mult_v[1, 2].set_xlabel('s [m]')
+axs_mult_v[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_mult_v[0, 0].set_title('Rot  = 0,\n HYL1 = 0, HYL2 = 0')
+axs_mult_v[0, 1].set_title('Rot != 0,\n HYL1 = 0, HYL2 = 0')
+axs_mult_v[0, 2].set_title('Rot != 0,\n HYL1 != 0, HYL2 = 0')
+axs_mult_v[0, 3].set_title('Rot != 0,\n HYL1 = 0, HYL2 != 0')
+axs_mult_v[0, 4].set_title('Rot != 0,\n HYL1 != 0, HYL2 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_mult_v.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_mult_v.suptitle('Vertical Multipole and SRotation')
+
+########################################
+# Horizontal XYShift
+########################################
+# y labels
+axs_shift_h[0, 0].set_ylabel('Survey x,y [m]')
+axs_shift_h[1, 0].set_ylabel('Twiss x,y [m]')
+axs_shift_h[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_shift_h[0, 2].set_xlabel('Z [m]')
+axs_shift_h[1, 2].set_xlabel('s [m]')
+axs_shift_h[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_shift_h[0, 0].set_title('Rot  = 0,\n DX1 = 0, DX2 = 0')
+axs_shift_h[0, 1].set_title('Rot != 0,\n DX1 = 0, DX2 = 0')
+axs_shift_h[0, 2].set_title('Rot != 0,\n DX1 != 0, DX2 = 0')
+axs_shift_h[0, 3].set_title('Rot != 0,\n DX1 = 0, DX2 != 0')
+axs_shift_h[0, 4].set_title('Rot != 0,\n DX1 != 0, DX2 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_shift_h.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_shift_h.suptitle('Horizontal XYShift and SRotation')
+
+########################################
+# Vertical XYShift
+########################################
+# y labels
+axs_shift_v[0, 0].set_ylabel('Survey x,y [m]')
+axs_shift_v[1, 0].set_ylabel('Twiss x,y [m]')
+axs_shift_v[2, 0].set_ylabel('MadPoint xx,yy [m]')
+
+# x labels
+axs_shift_v[0, 2].set_xlabel('Z [m]')
+axs_shift_v[1, 2].set_xlabel('s [m]')
+axs_shift_v[2, 2].set_xlabel('s [m]')
+
+# Titles
+axs_shift_v[0, 0].set_title('Rot  = 0,\n DY1 = 0, DY2 = 0')
+axs_shift_v[0, 1].set_title('Rot != 0,\n DY1 = 0, DY2 = 0')
+axs_shift_v[0, 2].set_title('Rot != 0,\n DY1 != 0, DY2 = 0')
+axs_shift_v[0, 3].set_title('Rot != 0,\n DY1 = 0, DY2 != 0')
+axs_shift_v[0, 4].set_title('Rot != 0,\n DY1 != 0, DY2 != 0')
+
+legend_elements = [
+    Line2D([0], [0], color = 'black', lw = 2, label = 'x'),
+    Line2D([0], [0], color = 'red',   lw = 2, label = 'y')]
+fig_shift_v.legend(
+    handles         = legend_elements,
+    loc             = 'lower center',
+    ncol            = 2,
+    frameon         = False,
+    bbox_to_anchor  = (0.5, -0.05))
+fig_shift_v.suptitle('Vertical XYShift and SRotation')
+
+########################################
+# Show
+########################################
+plt.tight_layout()
+plt.show()

--- a/examples/survey/_helpers.py
+++ b/examples/survey/_helpers.py
@@ -1,0 +1,73 @@
+"""
+Helpers for testing the MadPoint class
+"""
+import numpy as np
+from _madpoint import MadPoint
+
+def zero_small_values(arr, tol):
+    """
+    Set values within a tolerance of 0, to 0
+    """
+    return np.where(np.abs(arr) < tol, 0, arr)
+
+def madpoint_twiss_survey(line):
+    """
+    Produce twiss and survey for a line, including MadPoint
+    """
+    survey  = line.survey()
+    twiss   = line.twiss4d(_continue_if_lost = True, betx = 1, bety = 1)
+
+    madpoints = []
+    xx = []
+    yy = []
+    zz = []
+    for nn in twiss.name:
+        madpoints.append(
+            MadPoint(name = nn, xsuite_twiss = twiss, xsuite_survey = survey))
+        xx.append(madpoints[-1].p[0])
+        yy.append(madpoints[-1].p[1])
+        zz.append(madpoints[-1].p[2])
+
+    survey['xx'] = np.array(xx)
+    survey['yy'] = np.array(yy)
+    survey['zz'] = np.array(zz)
+
+    return survey, twiss
+
+def add_to_plot(axes, survey, twiss, index, tol = 1E-12, xlims = (-0.1, 2.1), ylims = (-2E-3, 2E-3)):
+    """
+    Add a line to the overall plot to show a specific case
+    """
+    axes[0, index].plot(
+        zero_small_values(survey.Z, tol),
+        zero_small_values(survey.X, tol),
+        c = 'k')
+    axes[0, index].plot(
+        zero_small_values(survey.Z, tol),
+        zero_small_values(survey.Y, tol),
+        c = 'r')
+
+    axes[1, index].plot(
+        zero_small_values(twiss.s, tol),
+        zero_small_values(twiss.x, tol),
+        c = 'k')
+    axes[1, index].plot(
+        zero_small_values(twiss.s, tol),
+        zero_small_values(twiss.y, tol),
+        c = 'r')
+
+    axes[2, index].plot(
+        zero_small_values(survey.s, tol),
+        zero_small_values(survey.xx, tol),
+        c = 'k')
+    axes[2, index].plot(
+        zero_small_values(survey.s, tol),
+        zero_small_values(survey.yy, tol),
+        c = 'r')
+
+    axes[0, index].set_xlim(xlims)
+    axes[0, index].set_ylim(ylims)
+    axes[1, index].set_xlim(xlims)
+    axes[1, index].set_ylim(ylims)
+    axes[2, index].set_xlim(xlims)
+    axes[2, index].set_ylim(ylims)

--- a/examples/survey/_madpoint.py
+++ b/examples/survey/_madpoint.py
@@ -1,0 +1,137 @@
+import numpy as np
+
+class MadPoint(object):
+    @classmethod
+    def from_survey(cls, name, mad=None, xsuite_survey=None):
+        return cls(name, mad=mad, use_twiss=False, use_survey=True,
+                   xsuite_survey=xsuite_survey)
+
+    @classmethod
+    def from_twiss(cls, name, mad):
+        return cls(name, mad, use_twiss=True, use_survey=False)
+
+    def __init__(self, name, mad=None, use_twiss=True, use_survey=True,
+                 xsuite_twiss=None, xsuite_survey=None):
+
+        self.use_twiss = use_twiss
+        self.use_survey = use_survey
+
+        if not (use_survey) and not (use_twiss):
+            raise ValueError(
+                "use_survey and use_twiss cannot be False at the same time"
+            )
+
+        self.tx = None
+        self.ty = None
+        self.tpx = None
+        self.tpy = None
+
+        self.sx = None
+        self.sy = None
+        self.sz = None
+        self.sp = None
+        theta = 0.0
+        phi = 0.0
+        psi = 0.0
+
+        if mad is not None:
+
+            self.name = name
+            if use_twiss:
+                assert xsuite_survey is None
+                twiss = mad.table.twiss
+                names = twiss.name
+            if use_survey:
+                assert xsuite_twiss is None
+                survey = mad.table.survey
+                names = survey.name
+                # patch for this issue https://github.com/hibtc/cpymad/issues/91 
+                for ii, nn in enumerate(names):
+                    if not nn.endswith(':1'):
+                        names[ii] = nn+':1'
+
+            idx = np.where(names == name)[0][0]
+
+            if use_twiss:
+                self.tx = twiss.x[idx]
+                self.ty = twiss.y[idx]
+                self.tpx = twiss.px[idx]
+                self.tpy = twiss.py[idx]
+
+            if use_survey:
+                self.sx = survey.x[idx]
+                self.sy = survey.y[idx]
+                self.sz = survey.z[idx]
+                self.sp = np.array([self.sx, self.sy, self.sz])
+                theta = survey.theta[idx]
+                phi = survey.phi[idx]
+                psi = survey.psi[idx]
+        else:
+
+
+            if use_twiss:
+                assert xsuite_twiss is not None
+                idx = np.where(np.array(xsuite_twiss['name']) == name)[0][0]
+                self.tx = xsuite_twiss.x[idx]
+                self.ty = xsuite_twiss.y[idx]
+                self.tpx = xsuite_twiss.px[idx]
+                self.tpy = xsuite_twiss.py[idx]
+
+            if use_survey:
+                assert xsuite_survey is not None
+                idx = np.where(np.array(xsuite_survey['name']) == name)[0][0]
+                self.sx = xsuite_survey.X[idx]
+                self.sy = xsuite_survey.Y[idx]
+                self.sz = xsuite_survey.Z[idx]
+                self.sp = np.array([self.sx, self.sy, self.sz])
+                theta = xsuite_survey.theta[idx]
+                phi = xsuite_survey.phi[idx]
+                psi = xsuite_survey.psi[idx]
+
+        thetam = np.array(
+            [
+                [np.cos(theta), 0, np.sin(theta)],
+                [0, 1, 0],
+                [-np.sin(theta), 0, np.cos(theta)],
+            ]
+        )
+        phim = np.array(
+            [
+                [1, 0, 0],
+                [0, np.cos(phi), np.sin(phi)],
+                [0, -np.sin(phi), np.cos(phi)],
+            ]
+        )
+        psim = np.array(
+            [
+                [np.cos(psi), -np.sin(psi), 0],
+                [np.sin(psi), np.cos(psi), 0],
+                [0, 0, 1],
+            ]
+        )
+        wm = np.dot(thetam, np.dot(phim, psim))
+        self.ex = np.dot(wm, np.array([1, 0, 0]))
+        self.ey = np.dot(wm, np.array([0, 1, 0]))
+        self.ez = np.dot(wm, np.array([0, 0, 1]))
+
+        self.p = np.array([0.0, 0.0, 0.0])
+
+        if use_twiss:
+            self.p += self.ex * self.tx + self.ey * self.ty
+
+        if use_survey:
+            self.p += self.sp
+
+    def shift_survey(self, delta):
+        self.sx -= delta[0]
+        self.sy -= delta[1]
+        self.sz -= delta[2]
+        self.sp -= delta
+        self.p -= delta
+
+    def dist(self, other):
+        return np.sqrt(np.sum((self.p - other.p) ** 2))
+
+    def distxy(self, other):
+        dd = self.p - other.p
+        return np.dot(dd, self.ex), np.dot(dd, self.ey)

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -4631,15 +4631,15 @@ class Line:
                 '_own_k4sl': ('ksl', 4),
                 '_own_k5sl': ('ksl', 5),
 
-                '_own_dx': 'dx',
-                '_own_dy': 'dy',
-
-                '_own_sin_angle': 'sin_angle',
-                '_own_cos_angle': 'cos_angle',
-
-                # TODO: This should be corrected at the element level
-                '_own_sin_z': 'sin_z',
-                '_own_cos_z': 'cos_z',
+                # Handling of reference frame transformations
+                # (XYShift, XRotation, YRotation, SRotation)
+                '_own_ref_shift_x':         'ref_shift_x',
+                '_own_ref_shift_y':         'ref_shift_y',
+                '_own_ref_rot_sin_angle':   'ref_rot_sin_angle',
+                '_own_ref_rot_cos_angle':   'ref_rot_cos_angle',
+                # TODO: This is labelled differently at the element level
+                '_own_ref_rot_sin_z':       'ref_rot_sin_z',
+                '_own_ref_rot_cos_z':       'ref_rot_cos_z',
 
                 '_parent_length': (('_parent', 'length'), None),
                 '_parent_sin_rot_s': (('_parent', '_sin_rot_s'), None),
@@ -4679,15 +4679,15 @@ class Line:
                 '_parent_k4sl': (('_parent', 'ksl'), 4),
                 '_parent_k5sl': (('_parent', 'ksl'), 5),
 
-                '_parent_dx': (('_parent', 'dx'), None),
-                '_parent_dy': (('_parent', 'dy'), None),
-
-                '_parent_sin_angle': (('_parent', 'sin_angle'), None),
-                '_parent_cos_angle': (('_parent', 'cos_angle'), None),
-
-                # TODO: This should be corrected at the element level
-                '_parent_sin_z': (('_parent', 'sin_z'), None),
-                '_parent_cos_z': (('_parent', 'cos_z'), None),
+                # Handling of reference frame transformations
+                # (XYShift, XRotation, YRotation, SRotation)
+                '_parent_ref_shift_x': (('_parent', 'ref_shift_x'), None),
+                '_parent_ref_shift_y': (('_parent', 'ref_shift_y'), None),
+                '_parent_ref_rot_sin_angle': (('_parent', 'ref_rot_sin_angle'), None),
+                '_parent_ref_rot_cos_angle': (('_parent', 'ref_rot_cos_angle'), None),
+                # TODO: This is labelled differently at the element level
+                '_parent_ref_rot_sin_z': (('_parent', 'ref_rot_sin_z'), None),
+                '_parent_ref_rot_cos_z': (('_parent', 'ref_rot_cos_z'), None),
 
             },
             derived_fields={
@@ -4766,13 +4766,13 @@ class Line:
                     + attr['_parent_k5s'] * attr['_parent_length'] * attr['weight'] * attr._inherit_strengths),
                 'hkick': lambda attr: attr["angle_rad"] - attr["k0l"],
                 'vkick': lambda attr: attr["k0sl"],
-                'dx': lambda attr: attr['_own_dx'] + attr['_parent_dx'],
-                'dy': lambda attr: attr['_own_dy'] + attr['_parent_dy'],
-                'transform_angle_rad': lambda attr: np.arctan2(
-                    attr['_own_sin_angle'] + attr['_parent_sin_angle'] +\
-                    attr['_own_sin_z'] + attr['_parent_sin_z'],
-                    attr['_own_cos_angle'] + attr['_parent_cos_angle'] +\
-                    attr['_own_cos_z'] + attr['_parent_cos_z']),
+                'ref_shift_x': lambda attr: attr['_own_ref_shift_x'] + attr['_parent_ref_shift_x'],
+                'ref_shift_y': lambda attr: attr['_own_ref_shift_y'] + attr['_parent_ref_shift_y'],
+                'ref_rot_angle_rad': lambda attr: np.arctan2(
+                    attr['_own_ref_rot_sin_angle'] + attr['_parent_ref_rot_sin_angle'] +\
+                    attr['_own_ref_rot_sin_z'] + attr['_parent_ref_rot_sin_z'],
+                    attr['_own_ref_rot_cos_angle'] + attr['_parent_ref_rot_cos_angle'] +\
+                    attr['_own_ref_rot_cos_z'] + attr['_parent_ref_rot_cos_z']),
             }
         )
         return cache

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -4633,13 +4633,13 @@ class Line:
 
                 # Handling of reference frame transformations
                 # (XYShift, XRotation, YRotation, SRotation)
-                '_own_ref_shift_x':         'ref_shift_x',
-                '_own_ref_shift_y':         'ref_shift_y',
-                '_own_ref_rot_sin_angle':   'ref_rot_sin_angle',
-                '_own_ref_rot_cos_angle':   'ref_rot_cos_angle',
-                # TODO: This is labelled differently at the element level
-                '_own_ref_rot_sin_z':       'ref_rot_sin_z',
-                '_own_ref_rot_cos_z':       'ref_rot_cos_z',
+                # TODO: The dx, dy, etc labels come from the element level and should possibly be changed
+                '_own_ref_shift_x':         'dx',
+                '_own_ref_shift_y':         'dy',
+                '_own_ref_rot_sin_angle':   'sin_angle',
+                '_own_ref_rot_cos_angle':   'cos_angle',
+                '_own_ref_rot_sin_z':       'sin_z',
+                '_own_ref_rot_cos_z':       'cos_z',
 
                 '_parent_length': (('_parent', 'length'), None),
                 '_parent_sin_rot_s': (('_parent', '_sin_rot_s'), None),
@@ -4681,13 +4681,13 @@ class Line:
 
                 # Handling of reference frame transformations
                 # (XYShift, XRotation, YRotation, SRotation)
-                '_parent_ref_shift_x': (('_parent', 'ref_shift_x'), None),
-                '_parent_ref_shift_y': (('_parent', 'ref_shift_y'), None),
-                '_parent_ref_rot_sin_angle': (('_parent', 'ref_rot_sin_angle'), None),
-                '_parent_ref_rot_cos_angle': (('_parent', 'ref_rot_cos_angle'), None),
-                # TODO: This is labelled differently at the element level
-                '_parent_ref_rot_sin_z': (('_parent', 'ref_rot_sin_z'), None),
-                '_parent_ref_rot_cos_z': (('_parent', 'ref_rot_cos_z'), None),
+                # TODO: The dx, dy, etc labels come from the element level and should possibly be changed
+                '_parent_ref_shift_x': (('_parent', 'dx'), None),
+                '_parent_ref_shift_y': (('_parent', 'dy'), None),
+                '_parent_ref_rot_sin_angle': (('_parent', 'sin_angle'), None),
+                '_parent_ref_rot_cos_angle': (('_parent', 'cos_angle'), None),
+                '_parent_ref_rot_sin_z': (('_parent', 'sin_z'), None),
+                '_parent_ref_rot_cos_z': (('_parent', 'cos_z'), None),
 
             },
             derived_fields={

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -4631,6 +4631,16 @@ class Line:
                 '_own_k4sl': ('ksl', 4),
                 '_own_k5sl': ('ksl', 5),
 
+                '_own_dx': 'dx',
+                '_own_dy': 'dy',
+
+                '_own_sin_angle': 'sin_angle',
+                '_own_cos_angle': 'cos_angle',
+
+                # TODO: This should be corrected at the element level
+                '_own_sin_z': 'sin_z',
+                '_own_cos_z': 'cos_z',
+
                 '_parent_length': (('_parent', 'length'), None),
                 '_parent_sin_rot_s': (('_parent', '_sin_rot_s'), None),
                 '_parent_cos_rot_s': (('_parent', '_cos_rot_s'), None),
@@ -4668,6 +4678,16 @@ class Line:
                 '_parent_k3sl': (('_parent', 'ksl'), 3),
                 '_parent_k4sl': (('_parent', 'ksl'), 4),
                 '_parent_k5sl': (('_parent', 'ksl'), 5),
+
+                '_parent_dx': (('_parent', 'dx'), None),
+                '_parent_dy': (('_parent', 'dy'), None),
+
+                '_parent_sin_angle': (('_parent', 'sin_angle'), None),
+                '_parent_cos_angle': (('_parent', 'cos_angle'), None),
+
+                # TODO: This should be corrected at the element level
+                '_parent_sin_z': (('_parent', 'sin_z'), None),
+                '_parent_cos_z': (('_parent', 'cos_z'), None),
 
             },
             derived_fields={
@@ -4746,6 +4766,13 @@ class Line:
                     + attr['_parent_k5s'] * attr['_parent_length'] * attr['weight'] * attr._inherit_strengths),
                 'hkick': lambda attr: attr["angle_rad"] - attr["k0l"],
                 'vkick': lambda attr: attr["k0sl"],
+                'dx': lambda attr: attr['_own_dx'] + attr['_parent_dx'],
+                'dy': lambda attr: attr['_own_dy'] + attr['_parent_dy'],
+                'transform_angle_rad': lambda attr: np.arctan2(
+                    attr['_own_sin_angle'] + attr['_parent_sin_angle'] +\
+                    attr['_own_sin_z'] + attr['_parent_sin_z'],
+                    attr['_own_cos_angle'] + attr['_parent_cos_angle'] +\
+                    attr['_own_cos_z'] + attr['_parent_cos_z']),
             }
         )
         return cache

--- a/xtrack/survey.py
+++ b/xtrack/survey.py
@@ -80,54 +80,54 @@ def advance_drift(v, w, R):
 
 def advance_element(
         v, w, length = 0, angle = 0, tilt = 0,
-        dx = 0, dy = 0, transf_x_rad = 0, transf_y_rad = 0, transf_s_rad = 0):
+        ref_shift_x = 0, ref_shift_y = 0, ref_rot_x_rad = 0, ref_rot_y_rad = 0, ref_rot_s_rad = 0):
     """Computing the advance element-by-element.
     See MAD-X manual for generation of R and S"""
     # XYShift Handling
-    if dx != 0 or dy != 0:
-        assert angle == 0,  "dx and dy are only supported for angle = 0"
-        assert tilt == 0,   "dx and dy are only supported for tilt = 0"
-        assert length == 0, "dx and dy are only supported for length = 0"
+    if ref_shift_x != 0 or ref_shift_y != 0:
+        assert angle == 0,  "ref_shift_x and ref_shift_y are only supported for angle = 0"
+        assert tilt == 0,   "ref_shift_x and ref_shift_y are only supported for tilt = 0"
+        assert length == 0, "ref_shift_x and ref_shift_y are only supported for length = 0"
 
-        R = np.array([dx, dy, 0])
+        R = np.array([ref_shift_x, ref_shift_y, 0])
         # XYShift tarnsforms as a drift
         return advance_drift(v, w, R)
 
     # XRotation Handling
-    if transf_x_rad != 0:
+    if ref_rot_x_rad != 0:
         assert angle == 0,  "rot_x_rad is only supported for angle = 0"
         assert tilt == 0,   "rot_x_rad is only supported for tilt = 0"
         assert length == 0, "rot_x_rad is only supported for length = 0"
 
         # Rotation sine/cosine
-        cr = np.cos(-transf_x_rad)
-        sr = np.sin(-transf_x_rad)
+        cr = np.cos(-ref_rot_x_rad)
+        sr = np.sin(-ref_rot_x_rad)
         # ------
         S = np.array([[1, 0, 0], [0, cr, sr], [0, -sr, cr]]) # x rotation matrix
         return advance_rotation(v, w, S)
 
     # YRotation Handling
-    if transf_y_rad != 0:
+    if ref_rot_y_rad != 0:
         assert angle == 0,  "rot_y_rad is only supported for angle = 0"
         assert tilt == 0,   "rot_y_rad is only supported for tilt = 0"
         assert length == 0, "rot_y_rad is only supported for length = 0"
 
         # Rotation sine/cosine
-        cr = np.cos(transf_y_rad)
-        sr = np.sin(transf_y_rad)
+        cr = np.cos(ref_rot_y_rad)
+        sr = np.sin(ref_rot_y_rad)
         # ------
         S = np.array([[cr, 0, -sr], [0, 1, 0], [sr, 0, cr]]) # y rotation matrix
         return advance_rotation(v, w, S)
 
     # SRotation Handling
-    if transf_s_rad != 0:
+    if ref_rot_s_rad != 0:
         assert angle == 0,  "rot_s_rad is only supported for angle = 0"
         assert tilt == 0,   "rot_s_rad is only supported for tilt = 0"
         assert length == 0, "rot_s_rad is only supported for length = 0"
 
         # Rotation sine/cosine
-        cr = np.cos(transf_s_rad)
-        sr = np.sin(transf_s_rad)
+        cr = np.cos(ref_rot_s_rad)
+        sr = np.sin(ref_rot_s_rad)
         # ------
         S = np.array([[cr, sr, 0], [-sr, cr, 0], [0, 0, 1]]) # z rotation matrix
         return advance_rotation(v, w, S)
@@ -194,22 +194,22 @@ class SurveyTable(Table):
             "X0, Y0, Z0, theta0, phi0, psi0 must be all None or all not None")
 
         if X0 is None:
-            X0 = self.X[self.element0]
-            Y0 = self.Y[self.element0]
-            Z0 = self.Z[self.element0]
-            theta0 = self.theta[self.element0]
-            phi0 = self.phi[self.element0]
-            psi0 = self.psi[self.element0]
+            X0      = self.X[self.element0]
+            Y0      = self.Y[self.element0]
+            Z0      = self.Z[self.element0]
+            theta0  = self.theta[self.element0]
+            phi0    = self.phi[self.element0]
+            psi0    = self.psi[self.element0]
 
         # We cut away the last marker (added by survey) and reverse the order
         out_drift_length    = list(self.drift_length[:-1][::-1])
         out_angle           = list(-self.angle[:-1][::-1])
         out_tilt            = list(-self.tilt[:-1][::-1])
-        out_dx              = list(-self.dx[:-1][::-1])
-        out_dy              = list(-self.dy[:-1][::-1])
-        out_transf_x_rad    = list(-self.transf_x_rad[:-1][::-1])
-        out_transf_y_rad    = list(-self.transf_y_rad[:-1][::-1])
-        out_transf_s_rad    = list(-self.transf_s_rad[:-1][::-1])
+        out_ref_shift_x     = list(-self.ref_shift_x[:-1][::-1])
+        out_ref_shift_y     = list(-self.ref_shift_y[:-1][::-1])
+        out_ref_rot_x_rad   = list(-self.ref_rot_x_rad[:-1][::-1])
+        out_ref_rot_y_rad   = list(-self.ref_rot_y_rad[:-1][::-1])
+        out_ref_rot_s_rad   = list(-self.ref_rot_s_rad[:-1][::-1])
         out_name            = list(self.name[:-1][::-1])
 
         if isinstance(element0, str):
@@ -225,11 +225,11 @@ class SurveyTable(Table):
             drift_length    = out_drift_length,
             angle           = out_angle,
             tilt            = out_tilt,
-            dx              = out_dx,
-            dy              = out_dy,
-            transf_x_rad    = out_transf_x_rad,
-            transf_y_rad    = out_transf_y_rad,
-            transf_s_rad    = out_transf_s_rad,
+            ref_shift_x     = out_ref_shift_x,
+            ref_shift_y     = out_ref_shift_y,
+            ref_rot_x_rad   = out_ref_rot_x_rad,
+            ref_rot_y_rad   = out_ref_rot_y_rad,
+            ref_rot_s_rad   = out_ref_rot_s_rad,
             element0        = element0,
             reverse_xs      = False)
 
@@ -238,28 +238,28 @@ class SurveyTable(Table):
         out_scalars = {}
 
         # Fill survey data
-        out_columns["X"]            = np.array(X)
-        out_columns["Y"]            = np.array(Y)
-        out_columns["Z"]            = np.array(Z)
-        out_columns["theta"]        = np.unwrap(theta)
-        out_columns["phi"]          = np.unwrap(phi)
-        out_columns["psi"]          = np.unwrap(psi)
-        out_columns["name"]         = np.array(list(out_name) + ["_end_point"])
-        out_columns["s"]            = self.s[-1] - self.s[::-1]
-        out_columns['drift_length'] = np.array(out_drift_length + [0.])
-        out_columns['angle']        = np.array(out_angle + [0.])
-        out_columns['tilt']         = np.array(out_tilt + [0.])
-        out_columns["dx"]           = np.array(out_dx + [0.])
-        out_columns["dy"]           = np.array(out_dy + [0.])
-        out_columns["transf_x_rad"] = np.array(out_transf_x_rad + [0.])
-        out_columns["transf_y_rad"] = np.array(out_transf_y_rad + [0.])
-        out_columns["transf_s_rad"] = np.array(out_transf_s_rad + [0.])
+        out_columns["X"]                = np.array(X)
+        out_columns["Y"]                = np.array(Y)
+        out_columns["Z"]                = np.array(Z)
+        out_columns["theta"]            = np.unwrap(theta)
+        out_columns["phi"]              = np.unwrap(phi)
+        out_columns["psi"]              = np.unwrap(psi)
+        out_columns["name"]             = np.array(list(out_name) + ["_end_point"])
+        out_columns["s"]                = self.s[-1] - self.s[::-1]
+        out_columns['drift_length']     = np.array(out_drift_length + [0.])
+        out_columns['angle']            = np.array(out_angle + [0.])
+        out_columns['tilt']             = np.array(out_tilt + [0.])
+        out_columns["ref_shift_x"]      = np.array(out_ref_shift_x + [0.])
+        out_columns["ref_shift_y"]      = np.array(out_ref_shift_y + [0.])
+        out_columns["ref_rot_x_rad"]    = np.array(out_ref_rot_x_rad + [0.])
+        out_columns["ref_rot_y_rad"]    = np.array(out_ref_rot_y_rad + [0.])
+        out_columns["ref_rot_s_rad"]    = np.array(out_ref_rot_s_rad + [0.])
 
         out_scalars["element0"] = element0
 
         out = SurveyTable(
-            data=(out_columns | out_scalars),
-            col_names=out_columns.keys())
+            data        = (out_columns | out_scalars),
+            col_names   = out_columns.keys())
 
         return out
 
@@ -305,7 +305,7 @@ def survey_from_line(
         line,
         X0 = 0, Y0 = 0, Z0 = 0, theta0 = 0, phi0 = 0, psi0 = 0,
         element0 = 0, values_at_element_exit = False, reverse = True):
-    """Execute SURVEY command. Based on MADX equivalent.
+    """Execute SURVEY command. Based on MAref_shift_x equivalent.
     Attributes, must be given in this order in the dictionary:
     X0        (float)    Initial X position in meters.
     Y0        (float)    Initial Y position in meters.
@@ -332,14 +332,14 @@ def survey_from_line(
     drift_length[~tt.isthick] = 0
 
     # Extract xy shifts from elements
-    dx = tt.dx
-    dy = tt.dy
+    ref_shift_x = tt.ref_shift_x
+    ref_shift_y = tt.ref_shift_y
 
-    # Handling of XYSRotation elements
-    transf_angle_rad    = tt.transform_angle_rad
-    transf_x_rad    = transf_angle_rad * np.array(tt.element_type == 'XRotation')
-    transf_y_rad    = transf_angle_rad * np.array(tt.element_type == 'YRotation')
-    transf_s_rad    = transf_angle_rad * np.array(tt.element_type == 'SRotation')
+    # Handling of XRotation, YRotation and SRotation elements
+    ref_rot_angle_rad   = tt.ref_rot_angle_rad
+    ref_rot_x_rad    = ref_rot_angle_rad * np.array(tt.element_type == 'XRotation')
+    ref_rot_y_rad    = ref_rot_angle_rad * np.array(tt.element_type == 'YRotation')
+    ref_rot_s_rad    = ref_rot_angle_rad * np.array(tt.element_type == 'SRotation')
 
     if isinstance(element0, str):
         element0 = line.element_names.index(element0)
@@ -354,11 +354,11 @@ def survey_from_line(
         drift_length    = drift_length[:-1],
         angle           = angle[:-1],
         tilt            = tilt[:-1],
-        dx              = dx[:-1],
-        dy              = dy[:-1],
-        transf_x_rad    = transf_x_rad[:-1],
-        transf_y_rad    = transf_y_rad[:-1],
-        transf_s_rad    = transf_s_rad[:-1],
+        ref_shift_x     = ref_shift_x[:-1],
+        ref_shift_y     = ref_shift_y[:-1],
+        ref_rot_x_rad   = ref_rot_x_rad[:-1],
+        ref_rot_y_rad   = ref_rot_y_rad[:-1],
+        ref_rot_s_rad   = ref_rot_s_rad[:-1],
         element0        = element0,
         reverse_xs      = False)
 
@@ -367,22 +367,22 @@ def survey_from_line(
     out_scalars = {}
 
     # Fill survey data
-    out_columns["X"]            = np.array(X)
-    out_columns["Y"]            = np.array(Y)
-    out_columns["Z"]            = np.array(Z)
-    out_columns["theta"]        = np.unwrap(theta)
-    out_columns["phi"]          = np.unwrap(phi)
-    out_columns["psi"]          = np.unwrap(psi)
-    out_columns["name"]         = tt.name
-    out_columns["s"]            = tt.s
-    out_columns['drift_length'] = drift_length
-    out_columns['angle']        = angle
-    out_columns['tilt']         = tilt
-    out_columns['dx']           = dx
-    out_columns['dy']           = dy
-    out_columns['transf_x_rad'] = transf_x_rad
-    out_columns['transf_y_rad'] = transf_y_rad
-    out_columns['transf_s_rad'] = transf_s_rad
+    out_columns["X"]                = np.array(X)
+    out_columns["Y"]                = np.array(Y)
+    out_columns["Z"]                = np.array(Z)
+    out_columns["theta"]            = np.unwrap(theta)
+    out_columns["phi"]              = np.unwrap(phi)
+    out_columns["psi"]              = np.unwrap(psi)
+    out_columns["name"]             = tt.name
+    out_columns["s"]                = tt.s
+    out_columns['drift_length']     = drift_length
+    out_columns['angle']            = angle
+    out_columns['tilt']             = tilt
+    out_columns['ref_shift_x']      = ref_shift_x
+    out_columns['ref_shift_y']      = ref_shift_y
+    out_columns['ref_rot_x_rad']    = ref_rot_x_rad
+    out_columns['ref_rot_y_rad']    = ref_rot_y_rad
+    out_columns['ref_rot_s_rad']    = ref_rot_s_rad
 
     out_scalars['element0']     = element0
 
@@ -397,7 +397,7 @@ def survey_from_line(
 def compute_survey(
         X0, Y0, Z0, theta0, phi0, psi0,
         drift_length, angle, tilt,
-        dx, dy, transf_x_rad, transf_y_rad, transf_s_rad,
+        ref_shift_x, ref_shift_y, ref_rot_x_rad, ref_rot_y_rad, ref_rot_s_rad,
         element0 = 0, reverse_xs = False):
     """
     Compute survey from initial position and orientation.
@@ -412,11 +412,11 @@ def compute_survey(
         drift_forward           = drift_length[element0:]
         angle_forward           = angle[element0:]
         tilt_forward            = tilt[element0:]
-        dx_forward              = dx[element0:]
-        dy_forward              = dy[element0:]
-        transf_x_rad_forward    = transf_x_rad[element0:]
-        transf_y_rad_forward    = transf_y_rad[element0:]
-        transf_s_rad_forward    = transf_s_rad[element0:]
+        ref_shift_x_forward     = ref_shift_x[element0:]
+        ref_shift_y_forward     = ref_shift_y[element0:]
+        ref_rot_x_rad_forward   = ref_rot_x_rad[element0:]
+        ref_rot_y_rad_forward   = ref_rot_y_rad[element0:]
+        ref_rot_s_rad_forward   = ref_rot_s_rad[element0:]
 
         # Evaluate forward survey
         (X_forward, Y_forward, Z_forward, theta_forward, phi_forward,
@@ -430,11 +430,11 @@ def compute_survey(
             drift_length    = drift_forward,
             angle           = angle_forward,
             tilt            = tilt_forward,
-            dx              = dx_forward,
-            dy              = dy_forward,
-            transf_x_rad    = transf_x_rad_forward,
-            transf_y_rad    = transf_y_rad_forward,
-            transf_s_rad    = transf_s_rad_forward,
+            ref_shift_x     = ref_shift_x_forward,
+            ref_shift_y     = ref_shift_y_forward,
+            ref_rot_x_rad   = ref_rot_x_rad_forward,
+            ref_rot_y_rad   = ref_rot_y_rad_forward,
+            ref_rot_s_rad   = ref_rot_s_rad_forward,
             element0        = 0,
             reverse_xs      = False)
 
@@ -442,11 +442,11 @@ def compute_survey(
         drift_backward          = drift_length[:element0][::-1]
         angle_backward          = -np.array(angle[:element0][::-1])
         tilt_backward           = -np.array(tilt[:element0][::-1])
-        dx_backward             = -np.array(dx[:element0][::-1])
-        dy_backward             = -np.array(dy[:element0][::-1])
-        transf_x_rad_backward   = -np.array(transf_x_rad[:element0][::-1])
-        transf_y_rad_backward   = -np.array(transf_y_rad[:element0][::-1])
-        transf_s_rad_backward   = -np.array(transf_s_rad[:element0][::-1])
+        ref_shift_x_backward    = -np.array(ref_shift_x[:element0][::-1])
+        ref_shift_y_backward    = -np.array(ref_shift_y[:element0][::-1])
+        ref_rot_x_rad_backward  = -np.array(ref_rot_x_rad[:element0][::-1])
+        ref_rot_y_rad_backward  = -np.array(ref_rot_y_rad[:element0][::-1])
+        ref_rot_s_rad_backward  = -np.array(ref_rot_s_rad[:element0][::-1])
 
         # Evaluate backward survey
         (X_backward, Y_backward, Z_backward, theta_backward, phi_backward,
@@ -460,11 +460,11 @@ def compute_survey(
             drift_length    = drift_backward,
             angle           = angle_backward,
             tilt            = tilt_backward,
-            dx              = dx_backward,
-            dy              = dy_backward,
-            transf_x_rad    = transf_x_rad_backward,
-            transf_y_rad    = transf_y_rad_backward,
-            transf_s_rad    = transf_s_rad_backward,
+            ref_shift_x     = ref_shift_x_backward,
+            ref_shift_y     = ref_shift_y_backward,
+            ref_rot_x_rad   = ref_rot_x_rad_backward,
+            ref_rot_y_rad   = ref_rot_y_rad_backward,
+            ref_rot_s_rad   = ref_rot_s_rad_backward,
             element0        = 0,
             reverse_xs      = True)
 
@@ -494,8 +494,10 @@ def compute_survey(
         reverse_xs  = reverse_xs)
 
     # Advancing element by element
-    for ll, aa, tt, xx, yy, tx, ty, ts, in zip(
-        drift_length, angle, tilt, dx, dy, transf_x_rad, transf_y_rad, transf_s_rad):
+    for ll, aa, tt, xx, yy, rx, ry, rs, in zip(
+        drift_length, angle, tilt,
+        ref_shift_x, ref_shift_y,
+        ref_rot_x_rad, ref_rot_y_rad, ref_rot_s_rad):
 
         # Get angles from w matrix after previous element
         th, ph, ps = get_angles_from_w(w, reverse_xs = reverse_xs)
@@ -515,11 +517,11 @@ def compute_survey(
             length          = ll,
             angle           = aa,
             tilt            = tt,
-            dx              = xx,
-            dy              = yy,
-            transf_x_rad    = tx,
-            transf_y_rad    = ty,
-            transf_s_rad    = ts)
+            ref_shift_x     = xx,
+            ref_shift_y     = yy,
+            ref_rot_x_rad   = rx,
+            ref_rot_y_rad   = ry,
+            ref_rot_s_rad   = rs)
 
     # Last marker
     th, ph, ps = get_angles_from_w(w, reverse_xs = reverse_xs)

--- a/xtrack/survey.py
+++ b/xtrack/survey.py
@@ -14,7 +14,7 @@ import xtrack as xt
 
 # Required functions
 # ==================================================
-def get_w_from_angles(theta, phi, psi, reverse_xs=False):
+def get_w_from_angles(theta, phi, psi, reverse_xs = False):
     """W matrix, see MAD-X manual"""
     costhe = np.cos(theta)
     cosphi = np.cos(phi)
@@ -40,7 +40,7 @@ def get_w_from_angles(theta, phi, psi, reverse_xs=False):
     return w
 
 
-def get_angles_from_w(w, reverse_xs=False):
+def get_angles_from_w(w, reverse_xs = False):
     """Inverse function of get_w_from_angles()"""
     # w[0, 2]/w[2, 2] = (sinthe * cosphi)/(costhe * cosphi)
     # w[1, 0]/w[1, 1] = (cosphi * sinpsi)/(cosphi * cospsi)
@@ -55,7 +55,8 @@ def get_angles_from_w(w, reverse_xs=False):
     psi = np.arctan2(w[1, 0], w[1, 1])
     phi = np.arctan2(w[1, 2], w[1, 1] / np.cos(psi))
 
-    # TODO: arctan2 returns angle between [-pi,pi]. Hence theta ends up not at 2pi after a full survey
+    # TODO: arctan2 returns angle between [-pi,pi].
+    # Hence theta ends up not at 2pi after a full survey
     return theta, phi, psi
 
 
@@ -65,19 +66,80 @@ def advance_bend(v, w, R, S):
     return np.dot(w, R) + v, np.dot(w, S)
 
 
+def advance_rotation(v, w, S):
+    """Advancing through rotation element:
+    Rotate w matrix according to transformation matrix S"""
+    return v, np.dot(w, S)
+
+
 def advance_drift(v, w, R):
     """Advancing through drift element, see MAD-X manual:
     v2 = w1*R + v1  | w2 = w1*S -> S is unity"""
     return np.dot(w, R) + v, w
 
 
-def advance_element(v, w, length=0, angle=0, tilt=0):
-    """Computing the advance element-by-element. See MAD-X manual for generation of R and S"""
+def advance_element(
+        v, w, length = 0, angle = 0, tilt = 0,
+        dx = 0, dy = 0, transf_x_rad = 0, transf_y_rad = 0, transf_s_rad = 0):
+    """Computing the advance element-by-element.
+    See MAD-X manual for generation of R and S"""
+    # XYShift Handling
+    if dx != 0 or dy != 0:
+        assert angle == 0,  "dx and dy are only supported for angle = 0"
+        assert tilt == 0,   "dx and dy are only supported for tilt = 0"
+        assert length == 0, "dx and dy are only supported for length = 0"
+
+        R = np.array([dx, dy, 0])
+        # XYShift tarnsforms as a drift
+        return advance_drift(v, w, R)
+
+    # XRotation Handling
+    if transf_x_rad != 0:
+        assert angle == 0,  "rot_x_rad is only supported for angle = 0"
+        assert tilt == 0,   "rot_x_rad is only supported for tilt = 0"
+        assert length == 0, "rot_x_rad is only supported for length = 0"
+
+        # Rotation sine/cosine
+        cr = np.cos(-transf_x_rad)
+        sr = np.sin(-transf_x_rad)
+        # ------
+        S = np.array([[1, 0, 0], [0, cr, sr], [0, -sr, cr]]) # x rotation matrix
+        return advance_rotation(v, w, S)
+
+    # YRotation Handling
+    if transf_y_rad != 0:
+        assert angle == 0,  "rot_y_rad is only supported for angle = 0"
+        assert tilt == 0,   "rot_y_rad is only supported for tilt = 0"
+        assert length == 0, "rot_y_rad is only supported for length = 0"
+
+        # Rotation sine/cosine
+        cr = np.cos(transf_y_rad)
+        sr = np.sin(transf_y_rad)
+        # ------
+        S = np.array([[cr, 0, -sr], [0, 1, 0], [sr, 0, cr]]) # y rotation matrix
+        return advance_rotation(v, w, S)
+
+    # SRotation Handling
+    if transf_s_rad != 0:
+        assert angle == 0,  "rot_s_rad is only supported for angle = 0"
+        assert tilt == 0,   "rot_s_rad is only supported for tilt = 0"
+        assert length == 0, "rot_s_rad is only supported for length = 0"
+
+        # Rotation sine/cosine
+        cr = np.cos(transf_s_rad)
+        sr = np.sin(transf_s_rad)
+        # ------
+        S = np.array([[cr, sr, 0], [-sr, cr, 0], [0, 0, 1]]) # z rotation matrix
+        return advance_rotation(v, w, S)
+
+    # Non bending elements
     if angle == 0:
         R = np.array([0, 0, length])
         return advance_drift(v, w, R)
+
+    # Horizontal bending elements
     elif tilt == 0:
-        # Relevant sine/cosine
+        # Angle sine/cosine
         ca = np.cos(angle)
         sa = np.sin(angle)
         # ------
@@ -86,10 +148,12 @@ def advance_element(v, w, length=0, angle=0, tilt=0):
         S = np.array([[ca, 0, -sa], [0, 1, 0], [sa, 0, ca]])
         return advance_bend(v, w, R, S)
 
+    # Tilted bending elements
     else:
-        # Relevant sine/cosine
+        # Angle sine/cosine
         ca = np.cos(angle)
         sa = np.sin(angle)
+        # Tilt sine/cosine
         ct = np.cos(tilt)
         st = np.sin(tilt)
         # ------
@@ -98,18 +162,26 @@ def advance_element(v, w, length=0, angle=0, tilt=0):
         S = np.array([[ca, 0, -sa], [0, 1, 0], [sa, 0, ca]])
 
         # Orthogonal rotation matrix for tilt
-        T = np.array([[ct, -st, 0], [st, ct, 0], [0, 0, 1]])
-        Tinv = np.array([[ct, st, 0], [-st, ct, 0], [0, 0, 1]])
+        T       = np.array([[ct, -st, 0], [st, ct, 0], [0, 0, 1]])
+        Tinv    = np.array([[ct, st, 0], [-st, ct, 0], [0, 0, 1]])
 
         return advance_bend(v, w, np.dot(T, R), np.dot(T, np.dot(S, Tinv)))
 
 
 class SurveyTable(Table):
+    """
+    Table for survey data.
+    """
 
     _error_on_row_not_found = True
 
-    def reverse(self, X0=None, Y0=None, Z0=None, theta0=None,
-                phi0=None, psi0=None, element0=None):
+    def reverse(
+            self,
+            X0 = None, Y0 = None, Z0 = None,
+            theta0 = None, phi0 = None, psi0 = None, element0 = None):
+        """
+        Reverse the survey.
+        """
 
         if element0 is None:
             element0 = len(self.name) - self.element0 - 1
@@ -130,50 +202,75 @@ class SurveyTable(Table):
             psi0 = self.psi[self.element0]
 
         # We cut away the last marker (added by survey) and reverse the order
-        out_drift_length = list(self.drift_length[:-1][::-1])
-        out_angle = list(-self.angle[:-1][::-1])
-        out_tilt = list(-self.tilt[:-1][::-1])
-        out_name = list(self.name[:-1][::-1])
-        out_element_type = list(self.element_type[:-1][::-1])
-        out_isthick = list(self.isthick[:-1][::-1])
-        out_length = list(self.length[:-1][::-1])
+        out_drift_length    = list(self.drift_length[:-1][::-1])
+        out_angle           = list(-self.angle[:-1][::-1])
+        out_tilt            = list(-self.tilt[:-1][::-1])
+        out_dx              = list(-self.dx[:-1][::-1])
+        out_dy              = list(-self.dy[:-1][::-1])
+        out_transf_x_rad    = list(-self.transf_x_rad[:-1][::-1])
+        out_transf_y_rad    = list(-self.transf_y_rad[:-1][::-1])
+        out_transf_s_rad    = list(-self.transf_s_rad[:-1][::-1])
+        out_name            = list(self.name[:-1][::-1])
 
-        if type(element0) is str:
+        if isinstance(element0, str):
             element0 = out_name.index(element0)
 
         X, Y, Z, theta, phi, psi = compute_survey(
-                                        X0, Y0, Z0, theta0, phi0, psi0,
-                                        out_drift_length, out_angle, out_tilt,
-                                        element0=element0)
+            X0              = X0,
+            Y0              = Y0,
+            Z0              = Z0,
+            theta0          = theta0,
+            phi0            = phi0,
+            psi0            = psi0,
+            drift_length    = out_drift_length,
+            angle           = out_angle,
+            tilt            = out_tilt,
+            dx              = out_dx,
+            dy              = out_dy,
+            transf_x_rad    = out_transf_x_rad,
+            transf_y_rad    = out_transf_y_rad,
+            transf_s_rad    = out_transf_s_rad,
+            element0        = element0,
+            reverse_xs      = False)
 
         # Initializing dictionary
         out_columns = {}
-        out_columns["X"] = np.array(X)
-        out_columns["Y"] = np.array(Y)
-        out_columns["Z"] = np.array(Z)
-        out_columns["theta"] = np.unwrap(theta)
-        out_columns["phi"] = np.unwrap(phi)
-        out_columns["psi"] = np.unwrap(psi)
-
-        out_columns["name"] = np.array(list(out_name) + ["_end_point"])
-        out_columns["s"] = self.s[-1] - self.s[::-1]
-
-        out_columns['drift_length'] = np.array(out_drift_length + [0.])
-        out_columns['angle'] = np.array(out_angle + [0.])
-        out_columns['tilt'] = np.array(out_tilt + [0.])
-        out_columns['element_type'] = np.array(out_element_type + [""])
-        out_columns['isthick'] = np.array(out_isthick + [False])
-        out_columns['length'] = np.array(out_length + [0.])
-
         out_scalars = {}
+
+        # Fill survey data
+        out_columns["X"]            = np.array(X)
+        out_columns["Y"]            = np.array(Y)
+        out_columns["Z"]            = np.array(Z)
+        out_columns["theta"]        = np.unwrap(theta)
+        out_columns["phi"]          = np.unwrap(phi)
+        out_columns["psi"]          = np.unwrap(psi)
+        out_columns["name"]         = np.array(list(out_name) + ["_end_point"])
+        out_columns["s"]            = self.s[-1] - self.s[::-1]
+        out_columns['drift_length'] = np.array(out_drift_length + [0.])
+        out_columns['angle']        = np.array(out_angle + [0.])
+        out_columns['tilt']         = np.array(out_tilt + [0.])
+        out_columns["dx"]           = np.array(out_dx + [0.])
+        out_columns["dy"]           = np.array(out_dy + [0.])
+        out_columns["transf_x_rad"] = np.array(out_transf_x_rad + [0.])
+        out_columns["transf_y_rad"] = np.array(out_transf_y_rad + [0.])
+        out_columns["transf_s_rad"] = np.array(out_transf_s_rad + [0.])
+
         out_scalars["element0"] = element0
 
-        out = SurveyTable(data=(out_columns | out_scalars),
-                          col_names=out_columns.keys())
+        out = SurveyTable(
+            data=(out_columns | out_scalars),
+            col_names=out_columns.keys())
 
         return out
 
-    def plot(self, element_width=None, legend=True, **kwargs):
+    def plot(self, element_width = None, legend = True, **kwargs):
+        """
+        Plot the survey using xplt.FloorPlot
+        """
+        # Import the xplt module here
+        # (Not at the top as not default installation with xsuite)
+        import xplt
+
         # Shallow copy of self
         out_sv_table = SurveyTable.__new__(SurveyTable)
         out_sv_table.__dict__.update(self.__dict__)
@@ -182,25 +279,32 @@ class SurveyTable(Table):
         # Removing the count for repeated elements
         out_sv_table.name = np.array([nn.split('::')[0] for nn in out_sv_table.name])
 
+        # Setting element width for plotting
         if element_width is None:
             x_range = max(self.X) - min(self.X)
             y_range = max(self.Y) - min(self.Y)
             z_range = max(self.Z) - min(self.Z)
-            element_width = max([x_range, y_range, z_range]) * 0.03
-        import xplt
-        xplt.FloorPlot(out_sv_table, element_width=element_width, **kwargs)
+            element_width   = max([x_range, y_range, z_range]) * 0.03
+
+        xplt.FloorPlot(
+            survey          = out_sv_table,
+            line            = self.line,
+            element_width   = element_width,
+            **kwargs)
+
         if legend:
             import matplotlib.pyplot as plt
             plt.legend()
 
 
 # ==================================================
+
 # Main function
 # ==================================================
-def survey_from_line(line, X0=0, Y0=0, Z0=0, theta0=0, phi0=0, psi0=0,
-                        element0=0,
-                        values_at_element_exit=False,
-                        reverse=True):
+def survey_from_line(
+        line,
+        X0 = 0, Y0 = 0, Z0 = 0, theta0 = 0, phi0 = 0, psi0 = 0,
+        element0 = 0, values_at_element_exit = False, reverse = True):
     """Execute SURVEY command. Based on MADX equivalent.
     Attributes, must be given in this order in the dictionary:
     X0        (float)    Initial X position in meters.
@@ -216,90 +320,187 @@ def survey_from_line(line, X0=0, Y0=0, Z0=0, theta0=0, phi0=0, psi0=0,
 
     assert not values_at_element_exit, "Not implemented yet"
 
+    # Get line table to extract attributes
+    tt      = line.get_table(attr = True)
+
     # Extract angle and tilt from elements
-    tt = line.get_table(attr = True)
-    angle = tt.angle_rad
-    tilt = tt.rot_s_rad
-    drift_length = tt.length.copy()
+    angle   = tt.angle_rad
+    tilt    = tt.rot_s_rad
+
+    # Extract drift lengths
+    drift_length = tt.length
     drift_length[~tt.isthick] = 0
 
-    if type(element0) == str:
+    # Extract xy shifts from elements
+    dx = tt.dx
+    dy = tt.dy
+
+    # Handling of XYSRotation elements
+    transf_angle_rad    = tt.transform_angle_rad
+    transf_x_rad    = transf_angle_rad * np.array(tt.element_type == 'XRotation')
+    transf_y_rad    = transf_angle_rad * np.array(tt.element_type == 'YRotation')
+    transf_s_rad    = transf_angle_rad * np.array(tt.element_type == 'SRotation')
+
+    if isinstance(element0, str):
         element0 = line.element_names.index(element0)
 
     X, Y, Z, theta, phi, psi = compute_survey(
-        X0, Y0, Z0, theta0, phi0, psi0, drift_length[:-1], angle[:-1], tilt[:-1],
-        element0=element0)
+        X0              = X0,
+        Y0              = Y0,
+        Z0              = Z0,
+        theta0          = theta0,
+        phi0            = phi0,
+        psi0            = psi0,
+        drift_length    = drift_length[:-1],
+        angle           = angle[:-1],
+        tilt            = tilt[:-1],
+        dx              = dx[:-1],
+        dy              = dy[:-1],
+        transf_x_rad    = transf_x_rad[:-1],
+        transf_y_rad    = transf_y_rad[:-1],
+        transf_s_rad    = transf_s_rad[:-1],
+        element0        = element0,
+        reverse_xs      = False)
 
     # Initializing dictionary
     out_columns = {}
     out_scalars = {}
-    out_columns["X"] = np.array(X)
-    out_columns["Y"] = np.array(Y)
-    out_columns["Z"] = np.array(Z)
-    out_columns["theta"] = np.unwrap(theta)
-    out_columns["phi"] = np.unwrap(phi)
-    out_columns["psi"] = np.unwrap(psi)
 
-    out_columns["name"] = tt.name
-    out_columns["s"] = tt.s
-    out_columns["length"] = tt.length
-    out_columns["isthick"] = tt.isthick
+    # Fill survey data
+    out_columns["X"]            = np.array(X)
+    out_columns["Y"]            = np.array(Y)
+    out_columns["Z"]            = np.array(Z)
+    out_columns["theta"]        = np.unwrap(theta)
+    out_columns["phi"]          = np.unwrap(phi)
+    out_columns["psi"]          = np.unwrap(psi)
+    out_columns["name"]         = tt.name
+    out_columns["s"]            = tt.s
     out_columns['drift_length'] = drift_length
-    out_columns['angle'] = angle
-    out_columns['tilt'] = tilt
-    out_columns['element_type'] = tt.element_type
+    out_columns['angle']        = angle
+    out_columns['tilt']         = tilt
+    out_columns['dx']           = dx
+    out_columns['dy']           = dy
+    out_columns['transf_x_rad'] = transf_x_rad
+    out_columns['transf_y_rad'] = transf_y_rad
+    out_columns['transf_s_rad'] = transf_s_rad
 
-    out_scalars['element0'] = element0
+    out_scalars['element0']     = element0
 
-    out = SurveyTable(data={**out_columns, **out_scalars},  # this is a merge
-                      col_names=out_columns.keys())
+    out = SurveyTable(
+        data        = {**out_columns, **out_scalars},  # this is a merge
+        col_names   = out_columns.keys())
     out._data['line'] = line
 
     return out
 
 
-def compute_survey(X0, Y0, Z0, theta0, phi0, psi0, drift_length, angle, tilt,
-                   element0=0, reverse_xs=False):
+def compute_survey(
+        X0, Y0, Z0, theta0, phi0, psi0,
+        drift_length, angle, tilt,
+        dx, dy, transf_x_rad, transf_y_rad, transf_s_rad,
+        element0 = 0, reverse_xs = False):
+    """
+    Compute survey from initial position and orientation.
+    """
 
+    # If element0 is not the first element, split the survey
     if element0 != 0:
+        # Assert that reverse_xs is not implemented yet
         assert not(reverse_xs), "Not implemented yet"
-        drift_forward = drift_length[element0:]
-        angle_forward = angle[element0:]
-        tilt_forward = tilt[element0:]
+
+        # Forward section of survey
+        drift_forward           = drift_length[element0:]
+        angle_forward           = angle[element0:]
+        tilt_forward            = tilt[element0:]
+        dx_forward              = dx[element0:]
+        dy_forward              = dy[element0:]
+        transf_x_rad_forward    = transf_x_rad[element0:]
+        transf_y_rad_forward    = transf_y_rad[element0:]
+        transf_s_rad_forward    = transf_s_rad[element0:]
+
+        # Evaluate forward survey
         (X_forward, Y_forward, Z_forward, theta_forward, phi_forward,
-            psi_forward) = compute_survey(X0, Y0, Z0, theta0, phi0, psi0,
-                                    drift_forward, angle_forward, tilt_forward)
+            psi_forward)    = compute_survey(
+            X0              = X0,
+            Y0              = Y0,
+            Z0              = Z0,
+            theta0          = theta0,
+            phi0            = phi0,
+            psi0            = psi0,
+            drift_length    = drift_forward,
+            angle           = angle_forward,
+            tilt            = tilt_forward,
+            dx              = dx_forward,
+            dy              = dy_forward,
+            transf_x_rad    = transf_x_rad_forward,
+            transf_y_rad    = transf_y_rad_forward,
+            transf_s_rad    = transf_s_rad_forward,
+            element0        = 0,
+            reverse_xs      = False)
 
-        drift_backward = drift_length[:element0][::-1]
-        angle_backward = -np.array(angle[:element0][::-1])
-        tilt_backward = -np.array(tilt[:element0][::-1])
+        # Backward section of survey
+        drift_backward          = drift_length[:element0][::-1]
+        angle_backward          = -np.array(angle[:element0][::-1])
+        tilt_backward           = -np.array(tilt[:element0][::-1])
+        dx_backward             = -np.array(dx[:element0][::-1])
+        dy_backward             = -np.array(dy[:element0][::-1])
+        transf_x_rad_backward   = -np.array(transf_x_rad[:element0][::-1])
+        transf_y_rad_backward   = -np.array(transf_y_rad[:element0][::-1])
+        transf_s_rad_backward   = -np.array(transf_s_rad[:element0][::-1])
+
+        # Evaluate backward survey
         (X_backward, Y_backward, Z_backward, theta_backward, phi_backward,
-            psi_backward) = compute_survey(X0, Y0, Z0, theta0, phi0, psi0,
-                                    drift_backward, angle_backward, tilt_backward,
-                                    reverse_xs=True)
+            psi_backward)   = compute_survey(
+            X0              = X0,
+            Y0              = Y0,
+            Z0              = Z0,
+            theta0          = theta0,
+            phi0            = phi0,
+            psi0            = psi0,
+            drift_length    = drift_backward,
+            angle           = angle_backward,
+            tilt            = tilt_backward,
+            dx              = dx_backward,
+            dy              = dy_backward,
+            transf_x_rad    = transf_x_rad_backward,
+            transf_y_rad    = transf_y_rad_backward,
+            transf_s_rad    = transf_s_rad_backward,
+            element0        = 0,
+            reverse_xs      = True)
 
-        X = np.array(X_backward[::-1][:-1] + X_forward)
-        Y = np.array(Y_backward[::-1][:-1] + Y_forward)
-        Z = np.array(Z_backward[::-1][:-1] + Z_forward)
-        theta = np.array(theta_backward[::-1][:-1] + theta_forward)
-        phi = np.array(phi_backward[::-1][:-1] + phi_forward)
-        psi = np.array(psi_backward[::-1][:-1]+ psi_forward)
+        # Concatenate forward and backward
+        X       = np.array(X_backward[::-1][:-1] + X_forward)
+        Y       = np.array(Y_backward[::-1][:-1] + Y_forward)
+        Z       = np.array(Z_backward[::-1][:-1] + Z_forward)
+        theta   = np.array(theta_backward[::-1][:-1] + theta_forward)
+        phi     = np.array(phi_backward[::-1][:-1] + phi_forward)
+        psi     = np.array(psi_backward[::-1][:-1]+ psi_forward)
         return X, Y, Z, theta, phi, psi
 
-    X = []
-    Y = []
-    Z = []
-    theta = []
-    phi = []
-    psi = []
-    v = np.array([X0, Y0, Z0])
-    w = get_w_from_angles(theta=theta0, phi=phi0, psi=psi0,
-                          reverse_xs=reverse_xs)
+    # Initialise lists for storing the survey
+    X       = []
+    Y       = []
+    Z       = []
+    theta   = []
+    phi     = []
+    psi     = []
+
+    # Initial position and orientation
+    v   = np.array([X0, Y0, Z0])
+    w   = get_w_from_angles(
+        theta       = theta0,
+        phi         = phi0,
+        psi         = psi0,
+        reverse_xs  = reverse_xs)
+
     # Advancing element by element
-    for ll, aa, tt in zip(drift_length, angle, tilt):
+    for ll, aa, tt, xx, yy, tx, ty, ts, in zip(
+        drift_length, angle, tilt, dx, dy, transf_x_rad, transf_y_rad, transf_s_rad):
 
-        th, ph, ps = get_angles_from_w(w, reverse_xs=reverse_xs)
+        # Get angles from w matrix after previous element
+        th, ph, ps = get_angles_from_w(w, reverse_xs = reverse_xs)
 
+        # Store position and orientation at element entrance
         X.append(v[0])
         Y.append(v[1])
         Z.append(v[2])
@@ -308,10 +509,20 @@ def compute_survey(X0, Y0, Z0, theta0, phi0, psi0, drift_length, angle, tilt,
         psi.append(ps)
 
         # Advancing
-        v, w = advance_element(v, w, length=ll, angle=aa, tilt=tt)
+        v, w = advance_element(
+            v               = v,
+            w               = w,
+            length          = ll,
+            angle           = aa,
+            tilt            = tt,
+            dx              = xx,
+            dy              = yy,
+            transf_x_rad    = tx,
+            transf_y_rad    = ty,
+            transf_s_rad    = ts)
 
     # Last marker
-    th, ph, ps = get_angles_from_w(w, reverse_xs=reverse_xs)
+    th, ph, ps = get_angles_from_w(w, reverse_xs = reverse_xs)
     X.append(v[0])
     Y.append(v[1])
     Z.append(v[2])
@@ -319,5 +530,5 @@ def compute_survey(X0, Y0, Z0, theta0, phi0, psi0, drift_length, angle, tilt,
     phi.append(ph)
     psi.append(ps)
 
-    # Returns as SurveyTable object
+    # Return data for SurveyTable object
     return X, Y, Z, theta, phi, psi


### PR DESCRIPTION
## Description
Updates to the survey
The survey now includes the effect of XYShift, XRotation, YRotation and SRotation.
To enable this, the line table has been updated to include outputs for xy shifts (dx and dy) and the reference shift angles.

Developed to enable matching of the solenoid IR region of SuperKEKB
(IR offset example shown)
![sv_old](https://github.com/user-attachments/assets/804d3fc0-667c-4618-b492-0beea9512aeb)
![sv_new](https://github.com/user-attachments/assets/c48aaece-b778-42e6-a8b6-b645818fc2bd)


Closes # .

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
