### PR TITLE
Release/0.79.3

### DIFF
--- a/tests/test_particles_basics.py
+++ b/tests/test_particles_basics.py
@@ -1,0 +1,681 @@
+# copyright ############################### #
+# This file is part of the Xpart Package.   #
+# Copyright (c) CERN, 2021.                 #
+# ######################################### #
+
+import numpy as np
+import pytest
+import xobjects as xo
+import xtrack as xt
+import xpart as xp
+
+from xobjects.test_helpers import for_all_test_contexts
+
+
+def _check_consistency_energy_variables(particles):
+    # Check consistency between beta0 and gamma0
+    xo.assert_allclose(particles.gamma0, 1/np.sqrt(1 - particles.beta0**2),
+                       rtol=1e-14, atol=1e-14)
+
+    # Assert consistency of p0c
+    xo.assert_allclose(particles.p0c,
+                       particles.mass0 * particles.beta0 * particles.gamma0,
+                       rtol=1e-14, atol=1e-14)
+
+    # Check energy0 property (consistency of p0c and gamma0)
+    xo.assert_allclose(particles.energy0, particles.mass0 * particles.gamma0,
+                       atol=1e-14, rtol=1e-14)
+
+    # Check consistency of rpp and delta
+    xo.assert_allclose(particles.rpp, 1./(particles.delta + 1),
+                       rtol=1e-14, atol=1e-14)
+
+    beta = particles.beta0 * particles.rvv
+    gamma = 1/np.sqrt(1 - beta**2)
+    pc = particles.mass0 * gamma * beta
+
+    # Check consistency of delta with rvv
+    xo.assert_allclose(particles.delta, (pc-particles.p0c)/(particles.p0c),
+                       rtol=1e-14, atol=1e-14)
+
+    # Check consistency of ptau with rvv
+    energy = particles.mass0 * gamma
+    xo.assert_allclose(particles.ptau, (energy - particles.energy0)/particles.p0c,
+                       rtol=1e-14, atol=1e-14)
+
+    # Check consistency of pzeta
+    energy = particles.mass0 * gamma
+    xo.assert_allclose(particles.pzeta, (energy - particles.energy0)/(particles.beta0 * particles.p0c),
+                       rtol=1e-14, atol=1e-14)
+
+
+    # Check energy property
+    xo.assert_allclose(particles.energy, energy, rtol=1e-14, atol=1e-14)
+
+
+@for_all_test_contexts
+def test_basics(test_context):
+    particles = xp.Particles(_context=test_context, _capacity=10,
+                             mass0=xp.PROTON_MASS_EV, q0=1, p0c=7e12,  # 7 TeV
+                             x=[1e-3, 0], px=[1e-6, -1e-6], y=[0, 1e-3],
+                             py=[2e-6, 0], zeta=[1e-2, 2e-2], delta=[0, 1e-4])
+
+    dct = particles.to_dict() # transfers it to cpu
+    assert dct['x'][0] == 1e-3
+    assert dct['ptau'][0] == 0
+    xo.assert_allclose(dct['ptau'][1], 1e-4, rtol=0, atol=1e-9)
+    xo.assert_allclose(1/(dct['rpp'][1]) - 1, 1e-4, rtol=0, atol=1e-14)
+
+    particles = xp.Particles(_context=test_context,
+            mass0=xp.PROTON_MASS_EV, q0=1, p0c=3e9,
+            x=[1e-3, 0], px=[1e-6, -1e-6], y=[0, 1e-3], py=[2e-6, 0],
+            zeta=[1e-2, 2e-2], pzeta=[0, 1e-4])
+
+    dct = particles.to_dict() # transfers it to cpu
+    assert dct['x'][0] == 1e-3
+    xo.assert_allclose(dct['ptau'][0], 0, atol=1e-14, rtol=0)
+    xo.assert_allclose(dct['ptau'][1]/dct['beta0'][1], 1e-4, rtol=0, atol=1e-9)
+    xo.assert_allclose(dct['delta'][1], 9.99995545e-05, rtol=0, atol=1e-13)
+
+    particles.move(_context=xo.ContextCpu())
+    _check_consistency_energy_variables(particles)
+
+
+@for_all_test_contexts
+def test_unallocated_particles(test_context):
+    particles = xp.Particles(_context=test_context, _capacity=10,
+                             mass0=xp.PROTON_MASS_EV, q0=1, p0c=7e12,  # 7 TeV
+                             x=[1e-3, 0], px=[1e-6, -1e-6], y=[0, 1e-3],
+                             py=[2e-6, 0], zeta=[1e-2, 2e-2], delta=[0, 1e-4])
+
+    dct = particles.to_dict() # transfers it to cpu
+    assert dct['x'][0] == 1e-3
+    assert dct['ptau'][0] == 0
+    xo.assert_allclose(dct['ptau'][1], 1e-4, rtol=0, atol=1e-9)
+    xo.assert_allclose(1/(dct['rpp'][1]) - 1, 1e-4, rtol=0, atol=1e-14)
+
+    particles2 = xp.Particles.from_dict(dct, _context=test_context)
+
+
+@for_all_test_contexts(excluding='ContextPyopencl')
+def test_linked_arrays(test_context):
+    ctx2np = test_context.nparray_from_context_array
+    np2ctx = test_context.nparray_to_context_array
+
+    particles = xp.Particles(_context=test_context, p0c=26e9, delta=[1,2,3])
+
+    assert ctx2np(particles.delta[2]) == 3
+    xo.assert_allclose(ctx2np(particles.rvv[2]), 1.00061, rtol=0, atol=1e-5)
+    xo.assert_allclose(ctx2np(particles.rpp[2]), 0.25, rtol=0, atol=1e-10)
+    xo.assert_allclose(ctx2np(particles.ptau[2]), 2.9995115176, rtol=0, atol=1e-6)
+
+    particles.delta[1] = particles.delta[2]
+
+    assert particles.delta[2] == particles.delta[1]
+    assert particles.ptau[2] == particles.ptau[1]
+    assert particles.rpp[2] == particles.rpp[1]
+    assert particles.rvv[2] == particles.rvv[1]
+
+    particles.ptau[0] = particles.ptau[2]
+
+    xo.assert_allclose(particles.delta[2], particles.delta[0], rtol=0, atol=1e-15)
+    xo.assert_allclose(particles.ptau[2], particles.ptau[0], rtol=0, atol=1e-16)
+    xo.assert_allclose(particles.rpp[2], particles.rpp[0], rtol=0, atol=1e-16)
+    xo.assert_allclose(particles.rvv[2], particles.rvv[0], rtol=0, atol=1e-15)
+
+    particles = xp.Particles(_context=test_context, p0c=26e9,
+                             delta=[1,2,3,4,100,0])
+    p0 = particles.copy()
+    particles.state = np2ctx(np.array([1,1,1,1,0,1]))
+    particles.delta[3:] = np2ctx([np.nan, 2, 3])
+
+    assert particles.delta[5] == particles.delta[2]
+    assert particles.ptau[5] == particles.ptau[2]
+    assert particles.rvv[5] == particles.rvv[2]
+    assert particles.rpp[5] == particles.rpp[2]
+
+    assert particles.delta[4] == p0.delta[4]
+    assert particles.ptau[4] == p0.ptau[4]
+    assert particles.rvv[4] == p0.rvv[4]
+    assert particles.rpp[4] == p0.rpp[4]
+
+    assert particles.delta[3] == p0.delta[3]
+    assert particles.ptau[3] == p0.ptau[3]
+    assert particles.rvv[3] == p0.rvv[3]
+    assert particles.rpp[3] == p0.rpp[3]
+
+
+@for_all_test_contexts
+@pytest.mark.parametrize(
+    'varname,values',
+    [
+        ('p0c', [4e9, 5e11, 6e13]),
+        ('gamma0', [3., 4., 5.]),
+        ('beta0', [0.8, 0.9, 0.99999999]),
+    ]
+)
+def test_particles_update_ref_vars(test_context, varname, values):
+    p = xp.Particles(_context=test_context,
+                     delta=[1, 2, 3],
+                     **{varname: values})
+
+    p_ref = p.copy()
+
+    getattr(p, varname)[1] = getattr(p, varname)[0]
+
+    assert p.p0c[0] == p.p0c[1]
+    assert p.gamma0[0] == p.gamma0[1]
+    assert p.beta0[0] == p.beta0[1]
+
+    assert p.p0c[0] == p_ref.p0c[0]
+    assert p.gamma0[0] == p_ref.gamma0[0]
+    assert p.beta0[0] == p_ref.beta0[0]
+
+@for_all_test_contexts
+def test_particles_update_p0c_and_energy_deviations(test_context):
+
+    part = xp.Particles(_context=test_context,
+                     p0c=[1e12, 3e12, 2e12],
+                     delta=[0,  0.1,    0],
+                     state=[1,  0.,     1.])
+
+    part.update_p0c_and_energy_deviations(p0c=2e12)
+
+    part.move(_context=xo.ContextCpu())
+    part.sort(interleave_lost_particles = True)
+    xo.assert_allclose(part.p0c, [2e12, 3e12, 2e12], rtol=0, atol=1e-14)
+    xo.assert_allclose(part.delta, [-0.5, 0.1, 0], rtol=0, atol=1e-14)
+
+
+def test_sort():
+    # Sorting available only on CPU for now
+
+    p = xp.Particles(x=[0, 1, 2, 3, 4, 5, 6], _capacity=10)
+    p.state[[0, 3, 4]] = 0
+
+    line = xt.Line(elements=[xt.Cavity()])
+    line.build_tracker()
+    line.track(p)
+
+    assert np.all(p.particle_id == np.array([6, 1, 2, 5, 4, 3, 0,
+                                             -999999999, -999999999,
+                                             -999999999]))
+    assert np.all(p.x == np.array([6, 1, 2, 5, 4, 3, 0,
+                                   -999999999, -999999999, -999999999]))
+    assert np.all(p.state == np.array([1, 1, 1, 1, 0, 0, 0,
+                                       -999999999, -999999999, -999999999]))
+    assert p._num_active_particles == 4
+    assert p._num_lost_particles == 3
+
+    p.sort()
+
+    assert np.all(p.particle_id == np.array([1, 2, 5, 6, 0, 3, 4,
+                                             -999999999, -999999999,
+                                             -999999999]))
+    assert np.all(p.particle_id == np.array([1, 2, 5, 6, 0, 3, 4,
+                                             -999999999, -999999999,
+                                             -999999999]))
+    assert np.all(p.state == np.array([1, 1, 1, 1, 0, 0, 0,
+                                       -999999999, -999999999, -999999999]))
+    assert p._num_active_particles == 4
+    assert p._num_lost_particles == 3
+
+    p.sort(interleave_lost_particles=True)
+
+    assert np.all(p.particle_id == np.array([0, 1, 2, 3, 4, 5, 6,
+                                             -999999999, -999999999,
+                                             -999999999]))
+    assert np.all(p.particle_id == np.array([0, 1, 2, 3, 4, 5, 6,
+                                             -999999999, -999999999,
+                                             -999999999]))
+    assert np.all(p.state == np.array([0, 1, 1, 0, 0, 1, 1,
+                                       -999999999, -999999999, -999999999]))
+    assert p._num_active_particles == -2
+    assert p._num_lost_particles == -2
+
+    p = xp.Particles(x=[6, 5, 4, 3, 2, 1, 0], _capacity=10)
+    p.state[[0,3,4]] = 0
+
+    line.track(p)
+
+    assert np.all(p.particle_id == np.array([6, 1, 2, 5, 4, 3, 0,
+                                             -999999999, -999999999,
+                                             -999999999]))
+    assert np.all(p.x == np.array([0, 5, 4, 1, 2, 3, 6,
+                                   -999999999, -999999999, -999999999]))
+    assert np.all(p.state == np.array([1, 1, 1, 1, 0, 0, 0,
+                                       -999999999, -999999999, -999999999]))
+    assert p._num_active_particles == 4
+    assert p._num_lost_particles == 3
+
+    p.sort(by='x')
+
+    assert np.all(p.particle_id == np.array([6, 5, 2, 1, 4, 3, 0,
+                                             -999999999, -999999999,
+                                             -999999999]))
+    assert np.all(p.x == np.array([0, 1, 4, 5, 2, 3, 6,
+                                   -999999999, -999999999, -999999999]))
+    assert np.all(p.state == np.array([1, 1, 1, 1, 0, 0, 0,
+                                       -999999999, -999999999, -999999999]))
+    assert p._num_active_particles == 4
+    assert p._num_lost_particles == 3
+
+    p.sort(by='x', interleave_lost_particles=True)
+
+    assert np.all(p.particle_id == np.array([6, 5, 4, 3, 2, 1, 0,
+                                             -999999999, -999999999,
+                                             -999999999]))
+    assert np.all(p.x == np.array([0, 1, 2, 3, 4, 5, 6,
+                                   -999999999, -999999999, -999999999]))
+    assert np.all(p.state == np.array([1, 1, 0, 0, 1, 1, 0,
+                                       -999999999, -999999999, -999999999]))
+    assert p._num_active_particles == -2
+    assert p._num_lost_particles == -2
+
+
+@for_all_test_contexts
+def test_python_add_to_energy(test_context):
+    particles = xp.Particles(_context=test_context, mass0=xp.PROTON_MASS_EV,
+                             q0=1, p0c=1.4e9, x=[1e-3, 0], px=[1e-6, -1e-6],
+                             y=[0, 1e-3], py=[2e-6, 0], zeta=[1e-2, 2e-2],
+                             delta=[0, 1e-4])
+
+    energy_before = particles.copy(_context=xo.ContextCpu()).energy
+    zeta_before = particles.copy(_context=xo.ContextCpu()).zeta
+
+    particles.add_to_energy(3e6)
+
+    expected_energy = energy_before + 3e6
+    particles.move(_context=xo.ContextCpu())
+    xo.assert_allclose(particles.energy, expected_energy,
+                       atol=1e-14, rtol=1e-14)
+
+    _check_consistency_energy_variables(particles)
+
+    assert np.all(particles.zeta == zeta_before)
+
+
+@for_all_test_contexts
+def test_python_delta_setter(test_context):
+    particles = xp.Particles(_context=test_context, p0c=1.4e9, delta=[0, 1e-3],
+                             px=[1e-6, -1e-6], py=[2e-6, 0], zeta=0.1)
+    _check_consistency_energy_variables(
+                                particles.copy(_context=xo.ContextCpu()))
+    px_before = particles.copy(_context=xo.ContextCpu()).px
+    py_before = particles.copy(_context=xo.ContextCpu()).py
+    zeta_before = particles.copy(_context=xo.ContextCpu()).zeta
+    gamma0_before = particles.copy(_context=xo.ContextCpu()).gamma0
+
+    particles.delta = -2e-3
+
+    particles.move(_context=xo.ContextCpu())
+    xo.assert_allclose(particles.delta, -2e-3, atol=1e-14, rtol=1e-14)
+
+    _check_consistency_energy_variables(particles)
+
+    assert np.all(particles.gamma0 == gamma0_before)
+    assert np.all(particles.zeta == zeta_before)
+    assert np.all(particles.px == px_before)
+    assert np.all(particles.py == py_before)
+
+
+@for_all_test_contexts
+def test_LocalParticle_add_to_energy(test_context):
+    class TestElement(xt.BeamElement):
+        _xofields={
+            'value': xo.Float64,
+            'pz_only': xo.Int64,
+            }
+        _extra_c_sources = ['''
+            /*gpufun*/
+            void TestElement_track_local_particle(
+                    TestElementData el, LocalParticle* part0){
+                double const value = TestElementData_get_value(el);
+                int const pz_only = (int) TestElementData_get_pz_only(el);
+                //start_per_particle_block (part0->part)
+                    LocalParticle_add_to_energy(part, value, pz_only);
+                //end_per_particle_block
+            }
+            ''']
+
+    # pz_only = 1
+    telem = TestElement(_context=test_context, value=1e6, pz_only=1)
+
+    particles = xp.Particles(_context=test_context, p0c=1.4e9, delta=[0, 1e-3],
+                             px=[1e-6, -1e-6], py=[2e-6, 0], zeta=0.1)
+    _check_consistency_energy_variables(
+                                particles.copy(_context=xo.ContextCpu()))
+    energy_before = particles.copy(_context=xo.ContextCpu()).energy
+    px_before = particles.copy(_context=xo.ContextCpu()).px
+    py_before = particles.copy(_context=xo.ContextCpu()).py
+    zeta_before = particles.copy(_context=xo.ContextCpu()).zeta
+    gamma0_before = particles.copy(_context=xo.ContextCpu()).gamma0
+    telem.track(particles)
+
+    particles.move(_context=xo.ContextCpu())
+    xo.assert_allclose(particles.energy, energy_before + 1e6,
+                       atol=1e-14, rtol=1e-14)
+
+    _check_consistency_energy_variables(particles)
+
+    assert np.all(particles.gamma0 == gamma0_before)
+    assert np.all(particles.zeta == zeta_before)
+    assert np.all(particles.px == px_before)
+    assert np.all(particles.py == py_before)
+
+    # pz_only = 0
+    telem = TestElement(_context=test_context, value=1e6, pz_only=0)
+
+    particles = xp.Particles(_context=test_context, p0c=1.4e9, delta=[0, 1e-3],
+                             px=[1e-6, -1e-6], py=[2e-6, 0], zeta=0.1)
+    _check_consistency_energy_variables(
+                                particles.copy(_context=xo.ContextCpu()))
+    energy_before = particles.copy(_context=xo.ContextCpu()).energy
+    px_before = particles.copy(_context=xo.ContextCpu()).px
+    py_before = particles.copy(_context=xo.ContextCpu()).py
+    rpp_before = particles.copy(_context=xo.ContextCpu()).rpp
+    zeta_before = particles.copy(_context=xo.ContextCpu()).zeta
+    gamma0_before = particles.copy(_context=xo.ContextCpu()).gamma0
+    telem.track(particles)
+
+    particles.move(_context=xo.ContextCpu())
+    xo.assert_allclose(particles.energy, energy_before + 1e6,
+                       atol=1e-14, rtol=1e-14)
+
+    _check_consistency_energy_variables(particles)
+
+    rpp_after = particles.copy(_context=xo.ContextCpu()).rpp
+    assert np.all(particles.gamma0 == gamma0_before)
+    assert np.all(particles.zeta == zeta_before)
+    xo.assert_allclose(particles.px, px_before*rpp_before/rpp_after,
+                       atol=1e-14, rtol=1e-14)
+    xo.assert_allclose(particles.py, py_before*rpp_before/rpp_after,
+                       atol=1e-14, rtol=1e-14)
+
+
+@for_all_test_contexts
+def test_LocalParticle_update_delta(test_context):
+    class TestElement(xt.BeamElement):
+        _xofields={
+            'value': xo.Float64,
+            }
+
+        _extra_c_sources =['''
+            /*gpufun*/
+            void TestElement_track_local_particle(
+                    TestElementData el, LocalParticle* part0){
+                double const value = TestElementData_get_value(el);
+                //start_per_particle_block (part0->part)
+                    LocalParticle_update_delta(part, value);
+                //end_per_particle_block
+            }
+            ''']
+
+    telem = TestElement(_context=test_context, value=-2e-3)
+
+    particles = xp.Particles(_context=test_context, p0c=1.4e9, delta=[0, 1e-3],
+                             px=[1e-6, -1e-6], py=[2e-6, 0], zeta=0.1)
+    _check_consistency_energy_variables(
+                                particles.copy(_context=xo.ContextCpu()))
+    px_before = particles.copy(_context=xo.ContextCpu()).px
+    py_before = particles.copy(_context=xo.ContextCpu()).py
+    zeta_before = particles.copy(_context=xo.ContextCpu()).zeta
+    gamma0_before = particles.copy(_context=xo.ContextCpu()).gamma0
+    telem.track(particles)
+
+    particles.move(_context=xo.ContextCpu())
+    xo.assert_allclose(particles.delta, -2e-3, atol=1e-14, rtol=1e-14)
+
+    _check_consistency_energy_variables(particles)
+
+    assert np.all(particles.gamma0 == gamma0_before)
+    assert np.all(particles.zeta == zeta_before)
+    assert np.all(particles.px == px_before)
+    assert np.all(particles.py == py_before)
+
+
+@for_all_test_contexts
+def test_LocalParticle_update_ptau(test_context):
+    class TestElement(xt.BeamElement):
+        _xofields={
+            'value': xo.Float64,
+            }
+
+        _extra_c_sources = ['''
+            /*gpufun*/
+            void TestElement_track_local_particle(
+                    TestElementData el, LocalParticle* part0){
+                double const value = TestElementData_get_value(el);
+                //start_per_particle_block (part0->part)
+                    LocalParticle_update_ptau(part, value);
+                //end_per_particle_block
+            }
+            ''']
+
+    telem = TestElement(_context=test_context, value=-2e-3)
+
+    particles = xp.Particles(_context=test_context, p0c=1.4e9, delta=[0, 1e-3],
+                             px=[1e-6, -1e-6], py=[2e-6, 0], zeta=0.1)
+    _check_consistency_energy_variables(
+                                particles.copy(_context=xo.ContextCpu()))
+    px_before = particles.copy(_context=xo.ContextCpu()).px
+    py_before = particles.copy(_context=xo.ContextCpu()).py
+    zeta_before = particles.copy(_context=xo.ContextCpu()).zeta
+    gamma0_before = particles.copy(_context=xo.ContextCpu()).gamma0
+    telem.track(particles)
+
+    particles.move(_context=xo.ContextCpu())
+    xo.assert_allclose(particles.ptau, -2e-3, atol=1e-14, rtol=1e-14)
+
+    _check_consistency_energy_variables(particles)
+
+    assert np.all(particles.gamma0 == gamma0_before)
+    assert np.all(particles.zeta == zeta_before)
+    assert np.all(particles.px == px_before)
+    assert np.all(particles.py == py_before)
+
+
+@for_all_test_contexts
+def test_LocalParticle_update_pzeta(test_context):
+    class TestElement(xt.BeamElement):
+        _xofields={
+            'value': xo.Float64,
+            }
+        _extra_c_sources = ['''
+            /*gpufun*/
+            void TestElement_track_local_particle(
+                    TestElementData el, LocalParticle* part0){
+                double const value = TestElementData_get_value(el);
+                //start_per_particle_block (part0->part)
+                    double const pzeta = LocalParticle_get_pzeta(part);
+                    LocalParticle_update_pzeta(part, pzeta+value);
+                //end_per_particle_block
+            }
+            ''']
+
+    telem = TestElement(_context=test_context, value=-2e-3)
+
+    particles = xp.Particles(_context=test_context, p0c=1.4e9, delta=[0, 1e-3],
+                             px=[1e-6, -1e-6], py=[2e-6, 0], zeta=0.1)
+    _check_consistency_energy_variables(
+                                particles.copy(_context=xo.ContextCpu()))
+    px_before = particles.copy(_context=xo.ContextCpu()).px
+    py_before = particles.copy(_context=xo.ContextCpu()).py
+    ptau_before  = particles.copy(_context=xo.ContextCpu()).ptau
+    zeta_before = particles.copy(_context=xo.ContextCpu()).zeta
+    gamma0_before = particles.copy(_context=xo.ContextCpu()).gamma0
+    telem.track(particles)
+
+    particles.move(_context=xo.ContextCpu())
+    xo.assert_allclose((particles.ptau - ptau_before)/particles.beta0,
+                       -2e-3, atol=1e-14, rtol=1e-14)
+
+    _check_consistency_energy_variables(particles)
+
+    assert np.all(particles.gamma0 == gamma0_before)
+    assert np.all(particles.zeta == zeta_before)
+    assert np.all(particles.px == px_before)
+    assert np.all(particles.py == py_before)
+
+
+@for_all_test_contexts
+def test_LocalParticle_update_p0c(test_context):
+    class TestElement(xt.BeamElement):
+        _xofields={
+            'value': xo.Float64,
+            }
+        _extra_c_sources = ['''
+            /*gpufun*/
+            void TestElement_track_local_particle(
+                    TestElementData el, LocalParticle* part0){
+                double const value = TestElementData_get_value(el);
+                //start_per_particle_block (part0->part)
+                    LocalParticle_update_p0c(part, value);
+                //end_per_particle_block
+            }
+            ''']
+
+    telem = TestElement(_context=test_context, value=1.5e9)
+
+    particles = xp.Particles(_context=test_context, p0c=1.4e9, delta=[0, 1e-3],
+                             px=[1e-6, -1e-6], py=[2e-6, 0], zeta=0.1)
+
+    _check_consistency_energy_variables(
+                                particles.copy(_context=xo.ContextCpu()))
+    px_before = particles.copy(_context=xo.ContextCpu()).px
+    py_before = particles.copy(_context=xo.ContextCpu()).py
+    energy_before  = particles.copy(_context=xo.ContextCpu()).energy
+    beta0_before = particles.copy(_context=xo.ContextCpu()).beta0
+    p0c_before = particles.copy(_context=xo.ContextCpu()).p0c
+    zeta_before = particles.copy(_context=xo.ContextCpu()).zeta
+    telem.track(particles)
+
+    particles.move(_context=xo.ContextCpu())
+    xo.assert_allclose(particles.p0c, 1.5e9, atol=1e-14, rtol=1e-14)
+    xo.assert_allclose(particles.energy, energy_before, atol=1e-14, rtol=1e-14)
+
+    _check_consistency_energy_variables(particles)
+
+    xo.assert_allclose(particles.zeta, zeta_before*particles.beta0/beta0_before, atol=1e-14)
+    xo.assert_allclose(particles.px, px_before*p0c_before/particles.p0c, atol=1e-14)
+    xo.assert_allclose(particles.py, py_before*p0c_before/particles.p0c, atol=1e-14)
+
+
+
+@for_all_test_contexts
+def test_LocalParticle_angles(test_context):
+    class ScaleAng(xt.BeamElement):
+        _xofields={
+            'scale_x':   xo.Float64,
+            'scale_y':   xo.Float64,
+            'scale_x2':  xo.Float64,
+            'scale_y2':  xo.Float64,
+            }
+        _extra_c_sources = ['''
+            /*gpufun*/
+            void ScaleAng_track_local_particle(
+                    ScaleAngData el, LocalParticle* part0){
+                double const scale_x = ScaleAngData_get_scale_x(el);
+                double const scale_y = ScaleAngData_get_scale_y(el);
+                double const scale_x2 = ScaleAngData_get_scale_x2(el);
+                double const scale_y2 = ScaleAngData_get_scale_y2(el);
+                //start_per_particle_block (part0->part)
+                    LocalParticle_scale_xp(part, scale_x);
+                    LocalParticle_scale_yp(part, scale_y);
+                    LocalParticle_scale_xp_yp(part, scale_x2, scale_y2);
+                //end_per_particle_block
+            }
+            ''']
+
+    class KickAng(xt.BeamElement):
+        _xofields={
+            'kick_x':  xo.Float64,
+            'kick_y':  xo.Float64,
+            'kick_x2': xo.Float64,
+            'kick_y2': xo.Float64,
+            }
+        _extra_c_sources = ['''
+            /*gpufun*/
+            void KickAng_track_local_particle(
+                    KickAngData el, LocalParticle* part0){
+                double const kick_x = KickAngData_get_kick_x(el);
+                double const kick_y = KickAngData_get_kick_y(el);
+                double const kick_x2 = KickAngData_get_kick_x2(el);
+                double const kick_y2 = KickAngData_get_kick_y2(el);
+                //start_per_particle_block (part0->part)
+                    LocalParticle_add_to_xp(part, kick_x);
+                    LocalParticle_add_to_yp(part, kick_y);
+                    LocalParticle_add_to_xp_yp(part, kick_x2, kick_y2);
+                //end_per_particle_block
+            }
+            ''']
+
+    telem1 = KickAng(_context=test_context, kick_x=-5.0e-3, kick_y=2.0e-3, kick_x2=12.0e-3, kick_y2=-6.0e-3)
+    telem2 = ScaleAng(_context=test_context, scale_x=2.5, scale_y=1.3, scale_x2=1.2, scale_y2=0.7)
+    line = xt.Line(elements=[xt.Drift(length=1.2), telem1, xt.Drift(length=0.3),
+                             telem2, xt.Drift(length=2.8)])
+    line.build_tracker(_context=test_context)
+    particles = xp.Particles(_context=test_context, p0c=1.4e9, delta=[0, 1e-3],
+                             px=[1.0e-3, -1.0e-3], py=[2.0e-3, -1.2e-3], zeta=0.1)
+    line.track(particles)
+    particles.move(_context=xo.ContextCpu())
+    xo.assert_allclose(particles.px, [24.0e-3, 18.021e-3], atol=1e-14, rtol=1e-14)
+    xo.assert_allclose(particles.py, [-1.82e-3, -4.73564e-3], atol=1e-14, rtol=1e-14)
+
+    class ScaleAngExact(xt.BeamElement):
+        _xofields={
+            'scale_x':   xo.Float64,
+            'scale_y':   xo.Float64,
+            'scale_x2':  xo.Float64,
+            'scale_y2':  xo.Float64,
+            }
+        _extra_c_sources = ['''
+            /*gpufun*/
+            void ScaleAngExact_track_local_particle(
+                    ScaleAngExactData el, LocalParticle* part0){
+                double const scale_x = ScaleAngExactData_get_scale_x(el);
+                double const scale_y = ScaleAngExactData_get_scale_y(el);
+                double const scale_x2 = ScaleAngExactData_get_scale_x2(el);
+                double const scale_y2 = ScaleAngExactData_get_scale_y2(el);
+                //start_per_particle_block (part0->part)
+                    LocalParticle_scale_exact_xp(part, scale_x);
+                    LocalParticle_scale_exact_yp(part, scale_y);
+                    LocalParticle_scale_exact_xp_yp(part, scale_x2, scale_y2);
+                //end_per_particle_block
+            }
+            ''']
+
+    class KickAngExact(xt.BeamElement):
+        _xofields={
+            'kick_x':  xo.Float64,
+            'kick_y':  xo.Float64,
+            'kick_x2': xo.Float64,
+            'kick_y2': xo.Float64,
+            }
+        _extra_c_sources = ['''
+            /*gpufun*/
+            void KickAngExact_track_local_particle(
+                    KickAngExactData el, LocalParticle* part0){
+                double const kick_x = KickAngExactData_get_kick_x(el);
+                double const kick_y = KickAngExactData_get_kick_y(el);
+                double const kick_x2 = KickAngExactData_get_kick_x2(el);
+                double const kick_y2 = KickAngExactData_get_kick_y2(el);
+                //start_per_particle_block (part0->part)
+                    LocalParticle_add_to_exact_xp(part, kick_x);
+                    LocalParticle_add_to_exact_yp(part, kick_y);
+                    LocalParticle_add_to_exact_xp_yp(part, kick_x2, kick_y2);
+                //end_per_particle_block
+            }
+            ''']
+
+    telem1 = KickAngExact(_context=test_context, kick_x=-5.0e-3, kick_y=2.0e-3, kick_x2=12.0e-3, kick_y2=-6.0e-3)
+    telem2 = ScaleAngExact(_context=test_context, scale_x=2.5, scale_y=1.3, scale_x2=1.2, scale_y2=0.7)
+    line = xt.Line(elements=[xt.Drift(length=1.2), telem1, xt.Drift(length=0.3),
+                             telem2, xt.Drift(length=2.8)])
+    line.build_tracker(_context=test_context)
+    particles = xp.Particles(_context=test_context, p0c=1.4e9, delta=[0, 1e-3],
+                             px=[1.0e-3, -1.0e-3], py=[2.0e-3, -1.2e-3], zeta=0.1)
+    line.track(particles)
+    particles.move(_context=xo.ContextCpu())
+    xo.assert_allclose(particles.px, [23.99302e-3, 18.01805e-3], atol=1e-14)
+    xo.assert_allclose(particles.py, [-1.81976e-3, -4.73529e-3], atol=1e-14, rtol=5e-7)

--- a/tests/test_particles_pdg.py
+++ b/tests/test_particles_pdg.py
@@ -1,0 +1,293 @@
+# copyright ############################### #
+# This file is part of the Xpart Package.   #
+# Copyright (c) CERN, 2025.                 #
+# ######################################### #
+
+import numpy as np
+
+import xtrack as xt
+import xtrack.particles.pdg as pdg
+import xtrack.particles.masses as masses
+
+from xobjects.test_helpers import for_all_test_contexts
+import xobjects as xo
+
+
+def test_names():
+    # Test that get_name_from_pdg_id and get_pdg_id_from_name are each other's inverse
+    for val in pdg.pdg_table.values():
+        name = val[1]
+        pdg_id = pdg.get_pdg_id_from_name(name)
+        assert pdg.get_name_from_pdg_id(pdg_id, long_name=False) == name
+        assert pdg.get_pdg_id_from_name(
+            pdg.get_name_from_pdg_id(pdg_id, long_name=False)) == pdg_id
+        long_name = val[-1]
+        pdg_id = pdg.get_pdg_id_from_name(long_name)
+        assert pdg.get_name_from_pdg_id(pdg_id, long_name=True) == long_name
+        assert pdg.get_pdg_id_from_name(
+            pdg.get_name_from_pdg_id(pdg_id, long_name=True)) == pdg_id
+    # Test is_proton, is_lepton, is_ion
+    assert pdg.is_proton(2212)
+    assert not any([pdg.is_proton(pdg_id) for pdg_id in range(-10000, 10000) if pdg_id != 2212])
+    assert not any([pdg.is_proton(10*pdg_id) for pdg_id in range(100000000, 100150000)])
+    assert all([pdg.is_lepton(pdg_id) and pdg.is_lepton(-pdg_id) for pdg_id in range(11,17)])
+    assert not any([pdg.is_lepton(pdg_id) for pdg_id in range(-10000, 10000) if abs(pdg_id) not in range(11,17)])
+    assert not any([pdg.is_lepton(10*pdg_id) for pdg_id in range(100000000, 100150000)])
+    def _A_geq_Z(pdg_id):
+        tmpid = pdg_id - 1000000000
+        L = int(tmpid/1e7)
+        tmpid -= L*1e7
+        Z = int(tmpid /1e4)
+        tmpid -= Z*1e4
+        A = int(tmpid /10)
+        return A > Z > 0
+    assert all([pdg.is_ion(10*pdg_id) if _A_geq_Z(10*pdg_id) else not pdg.is_ion(10*pdg_id)
+                for pdg_id in range(100000000, 100150000)])
+    assert not any([pdg.is_ion(pdg_id) for pdg_id in range(-10000, 10000)])
+    # Test table names
+    _names = [
+        [['e⁻', 'e', 'electron'], 11],
+        [['e⁺', 'positron'], -11],
+        [['νₑ', 'electron neutrino'], 12],
+        [['μ⁻', 'μ', 'muon-', 'muon'], 13],
+        [['μ⁺', 'muon+', 'anti-muon'], -13],
+        [['νμ', 'muon neutrino'], 14],
+        [['τ⁻', 'τ', 'tau-', 'tau'], 15],
+        [['τ⁺', 'tau+', 'anti-tau'], -15],
+        [['ντ', 'tau neutrino'], 16],
+        [['γ⁰', 'γ', 'photon'], 22],
+        [['π⁰', 'π', 'pion', 'pion0', 'pi0'], 111],
+        [['π⁺', 'pion+', 'pi+'], 211],
+        [['π⁻', 'pion-', 'pi-'], -211],
+        [['K⁰', 'kaon', 'kaon0'], 311],
+        [['K⁺', 'kaon+'], 321],
+        [['K⁻', 'kaon-'], -321],
+        [['KL', 'long kaon'], 130],
+        [['Kₛ', 'short kaon'], 310],
+        [['D⁰', 'D'], 421],
+        [['D⁺'], 411],
+        [['D⁻'], -411],
+        [['Dₛ⁺'], 431],
+        [['Dₛ⁻'], -431],
+        [['p⁺', 'p', 'proton'], 2212],
+        [[ 'p⁻', 'anti-proton'], -2212],
+        [['n⁰', 'n', 'neutron'], 2112],
+        [['Δ⁺⁺', 'delta++'], 2224],
+        [['Δ⁺', 'delta+'], 2214],
+        [['Δ⁰', 'delta0'], 2114],
+        [['Δ⁻', 'delta-'], 1114],
+        [['Λ⁰', 'Λ', 'lambda'], 3122],
+        [['Λc⁺', 'lambdac+'], 4122],
+        [['Σ⁺', 'sigma+'], 3222],
+        [['Σ⁰', 'Σ', 'sigma', 'sigma0'], 3212],
+        [['Σ⁻', 'sigma-'], 3112],
+        [['Ξ⁰', 'Ξ', 'xi', 'xi0'], 3322],
+        [['Ξ⁻', 'xi-'], 3312],
+        [['Ξc⁰', 'Ξc', 'xic', 'xic0'], 4132],
+        [['Ξc⁺', 'xic+'], 4232],
+        [["Ξ'c⁰", "Ξ'c", "xiprimec", "xiprimec0"], 4312],
+        [["Ξ'c⁺", "xiprimec+"], 4322],
+        [['Ω⁻', 'omega-'], 3334],
+        [['Ωc⁰', 'Ωc', 'omegac', 'omegac0'], 4332],
+        [['²H', 'H2', 'hydrogen-2', 'deuteron'], 1000010020],
+        [['³H', 'H3', 'hydrogen-3', 'triton'], 1000010030]
+    ]
+    for names, pdg_id in _names:
+        for name in names:
+            name_variants = [[nn, nn.lower(), nn.upper(), nn.capitalize()]
+                             for nn in [name, pdg._to_normal_script(name),
+                                        pdg._digits_to_superscript(name)]]
+            name_variants = [nnn for nn in name_variants for nnn in nn]
+            pdg_ids = np.unique(pdg.get_pdg_id_from_name(name_variants))
+            assert len(pdg_ids) == 1
+            assert pdg_ids[0] == pdg_id
+            antiname_variants = [[f'anti{pdg._flip_end_sign(nn)}',
+                                  f'anti-{pdg._flip_end_sign(nn)}',
+                                  f'anti {pdg._flip_end_sign(nn)}']
+                                 for nn in name_variants]
+            antiname_variants = [nnn for nn in antiname_variants for nnn in nn]
+            pdg_ids = np.unique(pdg.get_pdg_id_from_name(antiname_variants))
+            assert len(pdg_ids) == 1
+            assert pdg_ids[0] == -pdg_id
+    # Test ion names
+    for Z, name in pdg.elements_long.items():
+        assert name == pdg.get_element_full_name_from_Z(Z)
+        for A in range(Z+1, 4*Z):
+            if Z == 1 and A < 4:
+                long_name = 'deuteron' if A == 2 else 'triton'
+            else:
+                long_name = f'{name}-{A}'
+            pdg_id = pdg.get_pdg_id_ion(A, Z)
+            assert pdg.get_pdg_id_from_name(f'{name}{A}') == pdg_id
+            assert pdg.get_pdg_id_from_name(f'{name} {A}') == pdg_id
+            assert pdg.get_pdg_id_from_name(f'{name}-{A}') == pdg_id
+            assert pdg.get_pdg_id_from_name(f'{name}_{A}') == pdg_id
+            assert pdg.get_pdg_id_from_name(f'{name}.{A}') == pdg_id
+            assert pdg.get_name_from_pdg_id(pdg_id, long_name=True) == long_name
+            assert pdg.get_name_from_pdg_id(
+                        pdg.get_pdg_id_from_name(long_name),
+                        long_name=True) == long_name
+            assert pdg.get_pdg_id_from_name(
+                        pdg.get_name_from_pdg_id(pdg_id,
+                        long_name=True)) == pdg_id
+    for Z, name in pdg.elements.items():
+        assert name == pdg.get_element_name_from_Z(Z)
+        for A in range(Z+1, 4*Z):
+            short_name = f'{pdg._digits_to_superscript(A)}{name}'
+            pdg_id = pdg.get_pdg_id_ion(A, Z)
+            assert pdg.get_pdg_id_from_name(f'{A}{name}') == pdg_id
+            assert pdg.get_pdg_id_from_name(f'{name}{A}') == pdg_id
+            assert pdg.get_pdg_id_from_name(f'{name} {A}') == pdg_id
+            assert pdg.get_pdg_id_from_name(f'{name}-{A}') == pdg_id
+            assert pdg.get_pdg_id_from_name(f'{name}_{A}') == pdg_id
+            assert pdg.get_pdg_id_from_name(f'{name}.{A}') == pdg_id
+            assert pdg.get_name_from_pdg_id(pdg_id, long_name=False) == short_name
+            assert pdg.get_name_from_pdg_id(
+                        pdg.get_pdg_id_from_name(short_name),
+                        long_name=False) == short_name
+            assert pdg.get_pdg_id_from_name(
+                        pdg.get_name_from_pdg_id(pdg_id,
+                        long_name=False)) == pdg_id
+
+
+def test_charge_and_properties():
+    for pdg_id, vals in pdg.pdg_table.items():
+        q, _, _, _ = pdg.get_properties_from_pdg_id(pdg_id)
+        assert q == vals[0]
+        anti_q, _, _, _ = pdg.get_properties_from_pdg_id(-pdg_id)
+        if vals[1].endswith('⁺') or vals[1].endswith('+'):
+            assert np.sign(q) == 1
+            assert np.sign(anti_q) == -1
+        elif vals[1].endswith('⁻') or vals[1].endswith('-'):
+            assert np.sign(q) == -1
+            assert np.sign(anti_q) == 1
+        elif vals[1].endswith('⁰') or vals[1].endswith('0'):
+            assert np.sign(q) == 0
+            assert np.sign(anti_q) == 0
+        else:
+            # Particle names without a charge in the first column of the PDG table
+            # should be neutral (except for Hydrogen isotopes)
+            if 0 < abs(pdg_id) < 1000000000:
+                assert np.sign(q) == 0
+                assert np.sign(anti_q) == 0
+    for pdg_id in range(100000000, 100119000):
+        pdg_id *= 10
+        if pdg.is_ion(pdg_id):
+            q, A, Z, name = pdg.get_properties_from_pdg_id(pdg_id, long_name=False, subscripts=False)
+            assert A > Z > 0
+            assert q > 0
+            assert q == Z
+            name = name.replace(f"{A}", '')
+            assert pdg.get_Z_from_element_name(name) == Z
+            assert name == pdg.get_element_name_from_Z(Z)
+            q, A, Z, name = pdg.get_properties_from_pdg_id(pdg_id, long_name=True)
+            if name == 'deuteron':
+                assert A == 2
+                assert Z == 1
+                assert q == 1
+            elif name == 'triton':
+                assert A == 3
+                assert Z == 1
+                assert q == 1
+            else:
+                assert A > Z > 0
+                assert q > 0
+                assert q == Z
+                name_parts = name.split('-')
+                assert pdg.get_Z_from_element_name(name_parts[0]) == Z
+                assert name_parts[1] == f"{A}"
+                assert name_parts[0] == pdg.get_element_full_name_from_Z(Z)
+
+
+def test_masses():
+    assert pdg.get_pdg_id_from_mass_charge(0, 0) == 22
+    assert pdg.get_pdg_id_from_mass_charge(511e3, -1) == 11
+    assert pdg.get_pdg_id_from_mass_charge(511e3, 1) == -11
+    assert pdg.get_pdg_id_from_mass_charge(105.7e6, -1) == 13
+    assert pdg.get_pdg_id_from_mass_charge(105.7e6, 1) == -13
+    assert pdg.get_pdg_id_from_mass_charge(135.0e6, 0) == 111
+    assert pdg.get_pdg_id_from_mass_charge(139.6e6, 1) == 211
+    assert pdg.get_pdg_id_from_mass_charge(139.6e6, -1) == -211
+    assert pdg.get_pdg_id_from_mass_charge(497.6e6, 0) == 311
+    assert pdg.get_pdg_id_from_mass_charge(493.7e6, 1) == 321
+    assert pdg.get_pdg_id_from_mass_charge(493.7e6, -1) == -321
+    assert pdg.get_pdg_id_from_mass_charge(938.3e6, 1) == 2212
+    assert pdg.get_pdg_id_from_mass_charge(938.3e6, -1) == -2212
+    assert pdg.get_pdg_id_from_mass_charge(939.6e6, 0) == 2112
+    assert pdg.get_pdg_id_from_mass_charge(1875.6e6, 1) == 1000010020
+    assert pdg.get_pdg_id_from_mass_charge(2808.9e6, 1) == 1000010030
+    assert np.isclose(pdg.get_mass_from_pdg_id(22), 0, rtol=1e-4)
+    assert np.isclose(pdg.get_mass_from_pdg_id(11), 511e3, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(-11), 511e3, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(13), 105.7e6, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(-13), 105.7e6, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(111), 135.0e6, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(211), 139.6e6, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(-211), 139.6e6, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(311), 497.6e6, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(321), 493.7e6, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(-321), 493.7e6, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(2212), 938.3e6, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(-2212), 938.3e6, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(2112), 939.6e6, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(1000010020), 1875.6e6, rtol=1e-3)
+    assert np.isclose(pdg.get_mass_from_pdg_id(1000010030), 2808.9e6, rtol=1e-3)
+    # Test the ion masses defined in the mass table
+    for massdef, mass in masses.__dict__.items():
+        if massdef.endswith('_MASS_EV'):
+            massdef = massdef[:-8]
+            if any([i.isdigit() for i in massdef]):
+                A = int(''.join([i for i in massdef if i.isdigit()]))
+                el = massdef.replace(f'{A}', '')
+                if el in pdg.elements:
+                    Z = pdg.get_Z_from_element_name(el)
+                    pdg_id = pdg.get_pdg_id_ion(A, Z)
+                    assert pdg.get_pdg_id_from_mass_charge(mass, Z) == pdg_id
+                    assert assertnp.isclose(pdg.get_mass_from_pdg_id(pdg_id), mass, rtol=1e-7)
+    for Z in pdg.elements.keys():
+        if Z < 3 or Z == 6 or Z==26:
+            rtol = 1e-2
+        else:
+            rtol = 1e-3
+        for A in range(Z+1, 4*Z):
+            pdg_id = pdg.get_pdg_id_ion(A, Z)
+            assert pdg.get_pdg_id_from_mass_charge(A*masses.U_MASS_EV, Z) == pdg_id
+            assert np.isclose(pdg.get_mass_from_pdg_id(pdg_id), A*masses.U_MASS_EV, rtol=rtol)
+
+
+def test_lead_208():
+    pdg_id = 1000822080
+    assert pdg.get_pdg_id_ion(208, 82) == pdg_id
+    assert pdg.get_pdg_id_from_mass_charge(masses.Pb208_MASS_EV, 82) == pdg_id
+    assert pdg.get_name_from_pdg_id(pdg_id, long_name=False) == '²⁰⁸Pb'
+    assert pdg.get_name_from_pdg_id(pdg_id, long_name=True) == 'Lead-208'
+    assert pdg.get_pdg_id_from_name('Pb208')    == pdg_id
+    assert pdg.get_pdg_id_from_name('Pb 208')   == pdg_id
+    assert pdg.get_pdg_id_from_name('Pb-208')   == pdg_id
+    assert pdg.get_pdg_id_from_name('Pb_208')   == pdg_id
+    assert pdg.get_pdg_id_from_name('Pb.208')   == pdg_id
+    assert pdg.get_pdg_id_from_name('pb208')    == pdg_id
+    assert pdg.get_pdg_id_from_name('208pb')    == pdg_id
+    assert pdg.get_pdg_id_from_name('208Pb')    == pdg_id
+    assert pdg.get_pdg_id_from_name('lead208')  == pdg_id
+    assert pdg.get_pdg_id_from_name('Lead 208') == pdg_id
+    assert pdg.get_pdg_id_from_name('Lead_208') == pdg_id
+    assert pdg._mass_consistent(pdg_id, masses.Pb208_MASS_EV)
+    assert pdg.get_element_name_from_Z(82) == 'Pb'
+    assert pdg.get_element_full_name_from_Z(82) == 'Lead'
+    xo.assert_allclose(pdg.get_mass_from_pdg_id(pdg_id), masses.Pb208_MASS_EV,
+                       rtol=1e-10, atol=0)
+    assert pdg.get_properties_from_pdg_id(pdg_id) == (82., 208, 82, '²⁰⁸Pb')
+
+
+@for_all_test_contexts
+def test_build_reference_from_pdg_id(test_context):
+    particle_ref_proton  = xt.particles.reference_from_pdg_id(pdg_id='proton',
+                                                    _context=test_context)
+    particle_ref_proton.move(_context=xo.context_default)
+    assert particle_ref_proton.pdg_id == 2212
+    particle_ref_lead = xt.particles.reference_from_pdg_id(pdg_id='Pb208',
+                                                 _context=test_context)
+    particle_ref_lead.move(_context=xo.context_default)
+    xo.assert_allclose(particle_ref_lead.q0, 82.)
+    xo.assert_allclose(particle_ref_lead.mass0, masses.Pb208_MASS_EV)

--- a/tests/test_random_gen.py
+++ b/tests/test_random_gen.py
@@ -15,6 +15,7 @@ from xobjects.test_helpers import for_all_test_contexts, fix_random_seed
 
 
 @for_all_test_contexts
+@fix_random_seed(1465841)
 @pytest.mark.parametrize('generator', ['RandomUniform', 'RandomUniformAccurate'])
 def test_random_generation(test_context, generator):
 

--- a/tests/test_random_gen_exp.py
+++ b/tests/test_random_gen_exp.py
@@ -10,10 +10,11 @@ import numpy as np
 import xobjects as xo
 import xpart as xp
 import xtrack as xt
-from xobjects.test_helpers import for_all_test_contexts
+from xobjects.test_helpers import for_all_test_contexts, fix_random_seed
 
 
 @for_all_test_contexts
+@fix_random_seed(46543143)
 def test_random_generation(test_context):
 
     part = xp.Particles(_context=test_context, p0c=6.5e12, x=[1,2,3])
@@ -59,6 +60,7 @@ def test_random_generation(test_context):
 
 
 @for_all_test_contexts
+@fix_random_seed(187542)
 def test_direct_sampling(test_context):
     n_seeds = 3
     n_samples = 3e6

--- a/xtrack/particles/__init__.py
+++ b/xtrack/particles/__init__.py
@@ -3,7 +3,7 @@
 # Copyright (c) CERN, 2024.                 #
 # ######################################### #
 
-from .constants import PROTON_MASS_EV, ELECTRON_MASS_EV, MUON_MASS_EV, Pb208_MASS_EV
+from .masses import PROTON_MASS_EV, ELECTRON_MASS_EV, MUON_MASS_EV, Pb208_MASS_EV
 from .particles import Particles, reference_from_pdg_id, LAST_INVALID_STATE
 
 

--- a/xtrack/particles/constants.py
+++ b/xtrack/particles/constants.py
@@ -3,10 +3,5 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
-import scipy.constants as sc
-
-PROTON_MASS_EV = sc.m_p * sc.c**2 / sc.e
-ELECTRON_MASS_EV = sc.m_e * sc.c**2 / sc.e
-MUON_MASS_EV = sc.physical_constants['muon mass'][0] * sc.c**2 / sc.e
-Pb208_MASS_EV = 193729024900.
-U_MASS_EV = 931494102.42
+# For backwards compatibility
+from .masses import PROTON_MASS_EV, ELECTRON_MASS_EV, MUON_MASS_EV, Pb208_MASS_EV, U_MASS_EV

--- a/xtrack/particles/masses.py
+++ b/xtrack/particles/masses.py
@@ -1,0 +1,181 @@
+# copyright ############################### #
+# This file is part of the Xtrack Package.  #
+# Copyright (c) CERN, 2025.                 #
+# ######################################### #
+
+
+# Standard particle masses in eV
+ELECTRON_MASS_EV =        510998.95     # best known value:    510998.95000 ± 0.15 meV    PDG (2024)
+MUON_MASS_EV     =     105658375.5      # best known value:    105658375.5 ± 2.3 eV       PDG (2024)
+PION_MASS_EV     =     139570390.0      # best known value:    139570390 ± 180 eV         PDG (2024)
+KAON_MASS_EV     =     493677000.0      # best known value:    493677000 ± 15 keV         PDG (2024)
+PROTON_MASS_EV   =     938272088.16     # best known value:    938272088.16 ± 0.29 eV     PDG (2024)
+DEUTERON_MASS_EV =    1875612945.00     # best known value:    1875612945.00 ± 0.58 eV    NIST (2024)
+TRITON_MASS_EV   =    2808921136.68     # best known value:    2808921136.68 ± 0.88 eV    NIST (2024)
+He3_MASS_EV      =    2808391611.12     # best known value:    2808391611.12 ± 0.88 eV    NIST (2024)
+He4_MASS_EV      =    3727379411.8      # best known value:    3727379411.8 ± 1.2 eV      NIST (2024)
+
+# Ions
+U_MASS_EV        =     931494102.42     # best known value:    931494102.42 ± 0.28 eV     2018 CODATA
+
+C10_MASS_EV      =    9330639707.0      # estimate:       10.01685322 ± 8e-8 u            => σ = 75 eV
+C11_MASS_EV      =   10257084532.0      # estimate:       11.01143260 ± 6e-8 u            => σ = 56 eV
+C12_MASS_EV      =   11177929229.0      # defined as 12 u                                 => σ = 3.4 eV
+C13_MASS_EV      =   12112548340.8      # estimate:       13.003354835336 ± 2.52e-10 u    => σ = 3.7 eV
+C14_MASS_EV      =   13043937327.9      # estimate:       14.003241989 ± 4e-9 u           => σ = 5.4 eV
+C15_MASS_EV      =   13982284810.0      # estimate:       15.0105993 ± 9e-7 u             => σ = 840 eV
+
+O14_MASS_EV      =   13048925215.0      # estimate:       14.008596706 ± 2.7e-8 u         => σ = 26 eV
+O15_MASS_EV      =   13975267170.0      # estimate:       15.0030656 ± 5e-7 u             => σ = 470 eV
+O16_MASS_EV      =   14899168636.6      # estimate:       15.994914619257 ± 3.19e-10 u    => σ = 4.5 eV
+O17_MASS_EV      =   15834590977.0      # estimate:       16.999131755953 ± 6.92e-10 u    => σ = 4.8 eV
+O18_MASS_EV      =   16766111027.3      # estimate:       17.999159612136 ± 6.90e-10 u    => σ = 5.1 eV
+O19_MASS_EV      =   17701720900.0      # estimate:       19.0035780 ± 2.8e-6 u           => σ = 2.7 keV
+O20_MASS_EV      =   18633678340.0      # estimate:       20.0040754 ± 9e-7 u             => σ = 840 eV
+
+Ne19_MASS_EV     =   17700140000.0      # estimate:       19.00188091 ± 1.7e-7 u          => σ = 160 eV
+Ne20_MASS_EV     =   18622840116.3      # estimate:       19.9924401753 ± 1.6e-9 u        => σ = 5.9 eV
+Ne21_MASS_EV     =   19555644383.0      # estimate:       20.99384669 ± 4e-8 u            => σ = 38 eV
+Ne22_MASS_EV     =   20484845538.0      # estimate:       21.991385114 ± 1.9e-8 u         => σ = 19 eV
+Ne23_MASS_EV     =   21419210320.0      # estimate:       22.99446691 ± 1.1e-7 u          => σ = 110 eV
+Ne24_MASS_EV     =   22349906830.0      # estimate:       23.9936106 ± 6e-7 u             => σ = 560 eV
+
+Ar35_MASS_EV     =   32579246300.0      # estimate:       34.97525772 ± 7.3e-7 u          => σ = 680 eV
+Ar36_MASS_EV     =   33503556145.0      # estimate:       35.967545106 ± 2.8e-8 u         => σ = 28 eV
+Ar37_MASS_EV     =   34434334110.0      # estimate:       36.96677630 ± 2.2e-7 u          => σ = 210 eV
+Ar38_MASS_EV     =   35362061070.0      # estimate:       37.96273210 ± 2.1e-7 u          => σ = 200 eV
+Ar39_MASS_EV     =   36295027800.0      # estimate:       38.9643130 ± 5.4e-6 u           => σ = 5.1 keV
+Ar40_MASS_EV     =   37224724197.0      # estimate:       39.9623831220 ± 2.3e-9 u        => σ = 12 eV
+Ar41_MASS_EV     =   38158190689.0      # estimate:       40.96450057 ± 3.7e-7 u          => σ = 350 eV
+Ar42_MASS_EV     =   39088329600.0      # estimate:       41.9630457 ± 6.2e-6 u           => σ = 5.8 keV
+Ar43_MASS_EV     =   40022236600.0      # estimate:       42.9656361 ± 5.7e-6 u           => σ = 5.4 keV
+Ar44_MASS_EV     =   40953067200.0      # estimate:       43.9649238 ± 1.7e-6 u           => σ = 1.6 keV
+Ar45_MASS_EV     =   41887463810.0      # estimate:       44.96803973 ± 5.5e-7 u          => σ = 520 eV
+Ar46_MASS_EV     =   42818957400.0      # estimate:       45.9680392 ± 2.5e-6 u           => σ = 2.4 keV
+Ar47_MASS_EV     =   43754855500.0      # estimate:       46.9727671 ± 1.3e-6 u           => σ = 1.3 keV
+
+Fe52_MASS_EV     =   48389361230.0      # estimate:       51.94811336 ± 1.9e-7 u          => σ = 180 eV
+Fe53_MASS_EV     =   49318239900.0      # estimate:       52.9453056 ± 1.8e-6 u           => σ = 1.7 keV
+Fe54_MASS_EV     =   50244426920.0      # estimate:       53.93960819 ± 3.7e-7 u          => σ = 350 eV
+Fe55_MASS_EV     =   51174694210.0      # estimate:       54.93829116 ± 3.3e-7 u          => σ = 310 eV
+Fe56_MASS_EV     =   52103062570.0      # estimate:       55.93493554 ± 2.9e-7 u          => σ = 270 eV
+Fe57_MASS_EV     =   53034981820.0      # estimate:       56.93539195 ± 2.9e-7 u          => σ = 270 eV
+Fe58_MASS_EV     =   53964502670.0      # estimate:       57.93327358 ± 3.4e-7 u          => σ = 320 eV
+Fe59_MASS_EV     =   54897487080.0      # estimate:       58.93487349 ± 3.5e-7 u          => σ = 330 eV
+Fe60_MASS_EV     =   55828232900.0      # estimate:       59.9340702 ± 3.7e-6 u           => σ = 3.5 keV
+Fe61_MASS_EV     =   56762219700.0      # estimate:       60.9367462 ± 2.8e-6 u           => σ = 2.6 keV
+Fe62_MASS_EV     =   57693756300.0      # estimate:       61.9367918 ± 3.0e-6 u           => σ = 2.8 keV
+Fe63_MASS_EV     =   58628492800.0      # estimate:       62.9402727 ± 4.6e-6 u           => σ = 4.3 keV
+Fe64_MASS_EV     =   59560653000.0      # estimate:       63.9409878 ± 5.4e-6 u           => σ = 5.1 keV
+
+Xe112_MASS_EV    =  104267313200.0      # estimate:      111.9355591 ± 8.9e-6 u           => σ = 8.3 keV
+Xe113_MASS_EV    =  105196621000.0      # estimate:      112.9332217 ± 7.3e-6 u           => σ = 6.8 keV
+Xe114_MASS_EV    =  106123241000.0      # estimate:      113.927980 ± 1.2e-5 u            => σ = 12 keV
+Xe115_MASS_EV    =  107053165000.0      # estimate:      114.926294 ± 1.3e-5 u            => σ = 13 keV
+Xe116_MASS_EV    =  107980269000.0      # estimate:      115.921581 ± 1.4e-5 u            => σ = 13 keV
+Xe117_MASS_EV    =  108910625000.0      # estimate:      116.920359 ± 1.1e-5 u            => σ = 11 keV
+Xe118_MASS_EV    =  109838225000.0      # estimate:      117.916179 ± 1.1e-5 u            => σ = 11 keV
+Xe119_MASS_EV    =  110769004000.0      # estimate:      118.915411 ± 1.1e-5 u            => σ = 11 keV
+Xe120_MASS_EV    =  111697120000.0      # estimate:      119.911784 ± 1.3e-5 u            => σ = 13 keV
+Xe121_MASS_EV    =  112628305000.0      # estimate:      120.911453 ± 1.1e-5 u            => σ = 11 keV
+Xe122_MASS_EV    =  113556926000.0      # estimate:      121.908368 ± 1.2e-5 u            => σ = 12 keV
+Xe123_MASS_EV    =  114488526100.0      # estimate:      122.908482 ± 1.0e-5 u            => σ = 9.3 keV
+Xe124_MASS_EV    =  115417601300.0      # estimate:      123.9058852 ± 1.5e-6 u           => σ = 1.4 keV
+Xe125_MASS_EV    =  116349563400.0      # estimate:      124.9063876 ± 1.5e-6 u           => σ = 1.4 keV
+Xe126_MASS_EV    =  117279110518.0      # estimate:      125.9042974220 ± 6.0e-9 u        => σ = 37 eV
+Xe127_MASS_EV    =  118211430100.0      # estimate:      126.9051836 ± 4.4e-6 u           => σ = 4.1 keV
+Xe128_MASS_EV    =  119141384575.0      # estimate:      127.9035307534 ± 5.6e-9 u        => σ = 37 eV
+Xe129_MASS_EV    =  120074043142.0      # estimate:      128.9047808574 ± 5.4e-9 u        => σ = 37 eV
+Xe130_MASS_EV    =  121004352839.0      # estimate:      129.903509346 ± 1.0e-8 u         => σ = 38 eV
+Xe131_MASS_EV    =  121937313842.0      # estimate:      130.9050841281 ± 5.5e-9 u        => σ = 37 eV
+Xe132_MASS_EV    =  122867942545.0      # estimate:      131.9041550835 ± 5.4e-9 u        => σ = 38 eV
+Xe133_MASS_EV    =  123801072000.0      # estimate:      132.9059107 ± 2.6e-6 u           => σ = 2.5 keV
+Xe134_MASS_EV    =  124732083890.0      # estimate:      133.9053930300 ± 6.0e-9 u        => σ = 38 eV
+Xe135_MASS_EV    =  125665290400.0      # estimate:      134.9072314 ± 3.9e-6 u           => σ = 3.7 keV
+Xe136_MASS_EV    =  126596768759.0      # estimate:      135.9072144740 ± 7.0e-9 u        => σ = 39 eV
+Xe137_MASS_EV    =  127532308620.0      # estimate:      136.91155777 ± 1.1e-7 u          => σ = 110 eV
+Xe138_MASS_EV    =  128466214000.0      # estimate:      137.9141463 ± 3.0e-6 u           => σ = 2.8 keV
+Xe139_MASS_EV    =  129402035700.0      # estimate:      138.9187922 ± 2.3e-6 u           => σ = 2.2 keV
+Xe140_MASS_EV    =  130336187900.0      # estimate:      139.9216458 ± 2.5e-6 u           => σ = 2.4 keV
+Xe141_MASS_EV    =  131272471200.0      # estimate:      140.9267872 ± 3.1e-6 u           => σ = 2.9 keV
+Xe142_MASS_EV    =  132206932900.0      # estimate:      141.9299731 ± 2.9e-6 u           => σ = 2.7 keV
+
+Au176_MASS_EV    =  163924444000.0      # estimate:      175.980120  ±  4.0e-5 u          => σ = 38 keV
+Au177_MASS_EV    =  164852911000.0      # estimate:      176.976870  ±  1.1e-5 u          => σ = 11 keV
+Au178_MASS_EV    =  165783647000.0      # estimate:      177.976057  ±  1.1e-5 u          => σ = 11 keV
+Au179_MASS_EV    =  166712456000.0      # estimate:      178.973174  ±  1.3e-5 u          => σ = 13 keV
+Au180_MASS_EV    =  167643312800.0      # estimate:      179.9724898  ±  5.1e-6 u         => σ = 4.8 keV
+Au181_MASS_EV    =  168572561000.0      # estimate:      180.970079  ±  2.1e-5 u          => σ = 20 keV
+Au182_MASS_EV    =  169503622000.0      # estimate:      181.969614  ±  2.0e-5 u          => σ = 19 keV
+Au183_MASS_EV    =  170433229200.0      # estimate:      182.967588  ±  1.0e-5 u          => σ = 9.4 keV
+Au184_MASS_EV    =  171364597000.0      # estimate:      183.967452  ±  2.4e-5 u          => σ = 23 keV
+Au185_MASS_EV    =  172294550800.0      # estimate:      184.9657989  ±  2.8e-6 u         => σ = 2.7 keV
+Au186_MASS_EV    =  173226188000.0      # estimate:      185.965953  ±  2.3e-5 u          => σ = 22 keV
+Au187_MASS_EV    =  174156368000.0      # estimate:      186.964542  ±  2.4e-5 u          => σ = 23 keV
+Au188_MASS_EV    =  175088520000.0      # estimate:      187.9652480  ±  2.9e-6 u         => σ = 2.7 keV
+Au189_MASS_EV    =  176018803000.0      # estimate:      188.963948  ±  2.2e-5 u          => σ = 21 keV
+Au190_MASS_EV    =  176951046200.0      # estimate:      189.9647520  ±  4.0e-6 u         => σ = 3.8 keV
+Au191_MASS_EV    =  177881575200.0      # estimate:      190.9637160  ±  5.0e-6 u         => σ = 4.7 keV
+Au192_MASS_EV    =  178814096000.0      # estimate:      191.964818  ±  1.7e-5 u          => σ = 16 keV
+Au193_MASS_EV    =  179744956500.0      # estimate:      192.9641380  ±  9.0e-6 u         => σ = 8.4 keV
+Au194_MASS_EV    =  180677644000.0      # estimate:      193.9654191  ±  2.3e-6 u         => σ = 2.2 keV
+Au195_MASS_EV    =  181608782900.0      # estimate:      194.9650378  ±  1.2e-6 u         => σ = 1.2 keV
+Au196_MASS_EV    =  182541705200.0      # estimate:      195.9665710  ±  3.0e-6 u         => σ = 2.8 keV
+Au197_MASS_EV    =  183473198420.0      # estimate:      196.96657010  ±  6.0e-7 u        => σ = 570 eV
+Au198_MASS_EV    =  184406251470.0      # estimate:      197.96824370  ±  6.0e-7 u        => σ = 570 eV
+Au199_MASS_EV    =  185338232650.0      # estimate:      198.96876660  ±  6.0e-7 u        => σ = 570 eV
+Au200_MASS_EV    =  186271581000.0      # estimate:      199.970757  ±  2.9e-5 u          => σ = 27 keV
+Au201_MASS_EV    =  187203914200.0      # estimate:      200.9716580  ±  3.0e-6 u         => σ = 2.8 keV
+Au202_MASS_EV    =  188137456000.0      # estimate:      201.973856  ±  2.5e-5 u          => σ = 24 keV
+Au203_MASS_EV    =  189070159400.0      # estimate:      202.9751545  ±  3.3e-6 u         => σ = 3.1 keV
+Au204_MASS_EV    =  190004410000.0      # estimate:      203.97811  ±  2.2e-4 u           => σ = 210 keV
+Au205_MASS_EV    =  190937720000.0      # estimate:      204.98006  ±  2.2e-4 u           => σ = 210 keV
+Au206_MASS_EV    =  191873600000.0      # estimate:      205.98477  ±  3.2e-4 u           => σ = 300 keV
+Au207_MASS_EV    =  192808640000.0      # estimate:      206.98858  ±  3.2e-4 u           => σ = 300 keV
+Au208_MASS_EV    =  193744870000.0      # estimate:      207.99366  ±  3.2e-4 u           => σ = 300 keV
+Au209_MASS_EV    =  194680040000.0      # estimate:      208.99761  ±  4.3e-4 u           => σ = 410 keV
+Au210_MASS_EV    =  195616440000.0      # estimate:      210.00288  ±  4.3e-4 u           => σ = 410 keV
+
+Pb185_MASS_EV    =  172314868000.0      # estimate:      184.987610 ± 1.7e-5 u            => σ = 16 keV
+Pb186_MASS_EV    =  173243222000.0      # estimate:      185.984239 ± 1.2e-5 u            => σ = 12 keV
+Pb187_MASS_EV    =  174174410200.0      # estimate:      186.9839108 ± 5.5e-6 u           => σ = 5.2 keV
+Pb188_MASS_EV    =  175103080000.0      # estimate:      187.980879 ± 1.1e-5 u            => σ = 11 keV
+Pb189_MASS_EV    =  176034542000.0      # estimate:      188.980844 ± 1.5e-5 u            => σ = 14 keV
+Pb190_MASS_EV    =  176963463000.0      # estimate:      189.978082 ± 1.3e-5 u            => σ = 13 keV
+Pb191_MASS_EV    =  177895082400.0      # estimate:      190.9782165 ± 7.1e-6 u           => σ = 6.7 keV
+Pb192_MASS_EV    =  178824315800.0      # estimate:      191.9757896 ± 6.1e-6 u           => σ = 5.7 keV
+Pb193_MASS_EV    =  179756133000.0      # estimate:      192.976136 ± 1.1e-5 u            => σ = 11 keV
+Pb194_MASS_EV    =  180685648000.0      # estimate:      193.974012 ± 1.9e-5 u            => σ = 18 keV
+Pb195_MASS_EV    =  181617612000.0      # estimate:      194.9745162 ± 5.5e-6 u           => σ = 5.2 keV
+Pb196_MASS_EV    =  182547495900.0      # estimate:      195.9727876 ± 8.3e-6 u           => σ = 7.8 keV
+Pb197_MASS_EV    =  183479592800.0      # estimate:      196.9734347 ± 5.2e-6 u           => σ = 4.9 keV
+Pb198_MASS_EV    =  184409764900.0      # estimate:      197.9720155 ± 9.4e-6 u           => σ = 8.8 keV
+Pb199_MASS_EV    =  185342094600.0      # estimate:      198.9729126 ± 7.3e-6 u           => σ = 6.8 keV
+Pb200_MASS_EV    =  186272570000.0      # estimate:      199.971819 ± 1.1e-5 u            => σ = 11 keV
+Pb201_MASS_EV    =  187205043000.0      # estimate:      200.972870 ± 1.5e-5 u            => σ = 14 keV
+Pb202_MASS_EV    =  188135868100.0      # estimate:      201.9721516 ± 4.1e-6 u           => σ = 3.9 keV
+Pb203_MASS_EV    =  189068516300.0      # estimate:      202.9733906 ± 7.0e-6 u           => σ = 6.6 keV
+Pb204_MASS_EV    =  189999687100.0      # estimate:      203.9730435 ± 1.2e-6 u           => σ = 1.2 keV
+Pb205_MASS_EV    =  190932520900.0      # estimate:      204.9744817 ± 1.2e-6 u           => σ = 1.2 keV
+Pb206_MASS_EV    =  191863999600.0      # estimate:      205.9744652 ± 1.2e-6 u           => σ = 1.2 keV
+Pb207_MASS_EV    =  192796827200.0      # estimate:      206.9758968 ± 1.2e-6 u           => σ = 1.2 keV
+Pb208_MASS_EV    =  193729024800.0      # estimate:      207.9766520 ± 1.2e-6 u           => σ = 1.2 keV
+Pb209_MASS_EV    =  194664652900.0      # estimate:      208.9810900 ± 1.9e-6 u           => σ = 1.8 keV
+Pb210_MASS_EV    =  195599033100.0      # estimate:      209.9841884 ± 1.6e-6 u           => σ = 1.5 keV
+Pb211_MASS_EV    =  196534762600.0      # estimate:      210.9887353 ± 2.4e-6 u           => σ = 2.3 keV
+Pb212_MASS_EV    =  197469200800.0      # estimate:      211.9918959 ± 2.0e-6 u           => σ = 1.9 keV
+Pb213_MASS_EV    =  198405040200.0      # estimate:      212.9965608 ± 7.5e-6 u           => σ = 7.0 keV
+Pb214_MASS_EV    =  199339554900.0      # estimate:      213.9998035 ± 2.1e-6 u           => σ = 2.0 keV
+Pb215_MASS_EV    =  200275575000.0      # estimate:      215.004662 ± 5.7e-5 u            => σ = 53 keV
+Pb216_MASS_EV    =  201210230000.0      # estimate:      216.00806 ± 2.2e-4 u             => σ = 210 keV
+Pb217_MASS_EV    =  202146480000.0      # estimate:      217.01316 ± 3.2e-4 u             => σ = 300 keV
+Pb218_MASS_EV    =  203081340000.0      # estimate:      218.01678 ± 3.2e-4 u             => σ = 300 keV
+Pb219_MASS_EV    =  204017830000.0      # estimate:      219.02214 ± 4.3e-4 u             => σ = 400 keV
+Pb220_MASS_EV    =  204952840000.0      # estimate:      220.02591 ± 4.3e-4 u             => σ = 400 keV
+
+
+# Other particles in xpart.pdg database. Listed here for convenience (very incomplete list).
+PHOTON_MASS_EV   =            0.0
+PION0_MASS_EV    =    134976800.0      # best known value:    134976800 ± 500 eV         PDG (2024)
+KAON0_MASS_EV    =    497611000.0      # best known value:    497611000 ± 13 keV         PDG (2024)
+NEUTRON_MASS_EV  =    939565420.5      # best known value:    939565420.5 ± 0.5 eV       PDG  (2024)

--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -15,8 +15,10 @@ import xobjects as xo
 from xobjects.general import Print
 from xobjects import BypassLinked
 
-from .constants import PROTON_MASS_EV
-
+from .masses import PROTON_MASS_EV
+from .masses import __dict__ as mass__dict__
+from .pdg import get_pdg_id_from_name, get_properties_from_pdg_id, \
+                 get_mass_from_pdg_id
 
 LAST_INVALID_STATE = -999999999
 
@@ -1402,7 +1404,11 @@ class Particles(xo.HybridClass):
         if mode != 'no_local_copy':
             raise NotImplementedError
 
-        src_lines = []
+        src_lines = ['']
+        for name, mass in mass__dict__.items():
+            if name.endswith('_MASS_EV'):
+                src_lines.append(f'#define {name} {mass}')
+
         src_lines.append('typedef struct {')
 
         for tt, vv in cls.size_vars + cls.scalar_vars:
@@ -1939,7 +1945,6 @@ class Particles(xo.HybridClass):
 
         pdg_id = kwargs.get('pdg_id')
         try:
-            from xpart.pdg import get_pdg_id_from_name
             pdg_id = get_pdg_id_from_name(pdg_id)
             if not np.isscalar(pdg_id):
                 pdg_id = self._context.nparray_to_context_array(pdg_id)
@@ -1953,9 +1958,6 @@ class Particles(xo.HybridClass):
 
     @classmethod
     def reference_from_pdg_id(cls, pdg_id, **kwargs):
-        from xpart.pdg import (
-            get_pdg_id_from_name, get_properties_from_pdg_id, get_mass_from_pdg_id
-        )
         pdg_id = get_pdg_id_from_name(pdg_id)
         kwargs['pdg_id'] = pdg_id
         q0 = kwargs.get('q0')

--- a/xtrack/particles/pdg.py
+++ b/xtrack/particles/pdg.py
@@ -1,0 +1,549 @@
+# copyright ############################### #
+# This file is part of the Xpart Package.   #
+# Copyright (c) CERN, 2025.                 #
+# ######################################### #
+
+import numpy as np
+from numbers import Number
+
+from .masses import U_MASS_EV
+from .masses import __dict__ as mass__dict__
+
+# Monte Carlo numbering scheme as defined by the Particle Data Group
+# See https://pdg.lbl.gov/2007/reviews/montecarlorpp.pdf for implementation
+# details.
+# Not all particles are implemented yet; this can be appended later
+
+
+# This is the internal dictionary of PDG IDs.
+# For each pdg id, we get the charge and a list of names.
+# The first name is the default short name, the last is the default long name.
+# The other names are accepted alternatives. Any superscript or subscript can be used
+# interchangeably with its normal script (if both are used, subscript comes first).
+
+pdg_table = {
+#   ID       q  NAME
+    0:     [0,  'undefined'],
+    11:    [-1, 'e⁻', 'e', 'electron'],
+    -11:   [1,  'e⁺', 'positron'],
+    12:    [0,  'νₑ', 'electron neutrino'],
+    13:    [-1, 'μ⁻', 'μ', 'muon-', 'muon'],
+    -13:   [1,  'μ⁺', 'muon+', 'anti-muon'],
+    14:    [0,  'νμ', 'muon neutrino'],
+    15:    [-1, 'τ⁻', 'τ', 'tau-', 'tau'],
+    -15:   [1, 'τ⁺', 'tau+', 'anti-tau'],
+    16:    [0,  'ντ', 'tau neutrino'],
+    22:    [0,  'γ⁰', 'γ', 'gamma', 'photon'],
+    111:   [0,  'π⁰', 'π', 'pion', 'pion0', 'pi0'],
+    211:   [1,  'π⁺', 'pion+', 'pi+'],
+    -211:  [-1, 'π⁻', 'pion-', 'pi-'],
+    311:   [0,  'K⁰', 'kaon', 'kaon0'],
+    321:   [1,  'K⁺', 'kaon+'],
+    -321:  [-1, 'K⁻', 'kaon-'],
+    130:   [0,  'KL', 'long kaon'],
+    310:   [0,  'Kₛ', 'short kaon'],
+    421:   [0,  'D⁰', 'D'],
+    411:   [1,  'D⁺'],
+    -411:  [-1, 'D⁻'],
+    431:   [1,  'Dₛ⁺'],
+    -431:  [-1, 'Dₛ⁻'],
+    2212:  [1,  'p⁺', 'p', 'proton'],
+    -2212: [-1,  'p⁻', 'anti-proton'],
+    2112:  [0,  'n⁰', 'n', 'neutron'],
+    2224:  [2,  'Δ⁺⁺', 'delta++'],
+    2214:  [1,  'Δ⁺', 'delta+'],
+    2114:  [0,  'Δ⁰', 'delta0'],
+    1114:  [-1, 'Δ⁻', 'delta-'],
+    3122:  [0,  'Λ⁰', 'Λ', 'lambda'],
+    4122:  [1,  'Λc⁺', 'lambdac+'],
+    3222:  [1,  'Σ⁺', 'sigma+'],
+    3212:  [0,  'Σ⁰', 'Σ', 'sigma', 'sigma0'],
+    3112:  [-1, 'Σ⁻', 'sigma-'],
+    3322:  [0,  'Ξ⁰', 'Ξ', 'xi', 'xi0'],
+    3312:  [-1, 'Ξ⁻', 'xi-'],
+    4132:  [0,  'Ξc⁰', 'Ξc', 'xic', 'xic0'],
+    4232:  [1,  'Ξc⁺', 'xic+'],
+    4312:  [0,  "Ξ'c⁰", "Ξ'c", "xiprimec", "xiprimec0"],
+    4322:  [1,  "Ξ'c⁺", "xiprimec+"],
+    3334:  [-1, 'Ω⁻', 'omega-'],
+    4332:  [0, 'Ωc⁰', 'Ωc', 'omegac', 'omegac0'],
+    1000010020: [1, '²H', 'H2', 'hydrogen-2', 'deuteron'],
+    1000010030: [1, '³H', 'H3', 'hydrogen-3', 'triton']
+}
+
+elements = {
+     1: "H",    2: "He",   3: "Li",   4: "Be",   5: "B",    6: "C",    7: "N",    8: "O",    9: "F",   10: "Ne",
+    11: "Na",  12: "Mg",  13: "Al",  14: "Si",  15: "P",   16: "S",   17: "Cl",  18: "Ar",  19: "K",   20: "Ca",
+    21: "Sc",  22: "Ti",  23: "V",   24: "Cr",  25: "Mn",  26: "Fe",  27: "Co",  28: "Ni",  29: "Cu",  30: "Zn",
+    31: "Ga",  32: "Ge",  33: "As",  34: "Se",  35: "Br",  36: "Kr",  37: "Rb",  38: "Sr",  39: "Y",   40: "Zr",
+    41: "Nb",  42: "Mo",  43: "Tc",  44: "Ru",  45: "Rh",  46: "Pd",  47: "Ag",  48: "Cd",  49: "In",  50: "Sn",
+    51: "Sb",  52: "Te",  53: "I",   54: "Xe",  55: "Cs",  56: "Ba",  57: "La",  58: "Ce",  59: "Pr",  60: "Nd",
+    61: "Pm",  62: "Sm",  63: "Eu",  64: "Gd",  65: "Tb",  66: "Dy",  67: "Ho",  68: "Er",  69: "Tm",  70: "Yb",
+    71: "Lu",  72: "Hf",  73: "Ta",  74: "W",   75: "Re",  76: "Os",  77: "Ir",  78: "Pt",  79: "Au",  80: "Hg",
+    81: "Tl",  82: "Pb",  83: "Bi",  84: "Po",  85: "At",  86: "Rn",  87: "Fr",  88: "Ra",  89: "Ac",  90: "Th",
+    91: "Pa",  92: "U",   93: "Np",  94: "Pu",  95: "Am",  96: "Cm",  97: "Bk",  98: "Cf",  99: "Es", 100: "Fm",
+   101: "Md", 102: "No", 103: "Lr", 104: "Rf", 105: "Db", 106: "Sg", 107: "Bh", 108: "Hs", 109: "Mt", 110: "Ds",
+   111: "Rg", 112: "Cn", 113: "Nh", 114: "Fl", 115: "Mc", 116: "Lv", 117: "Ts", 118: "Og"
+}
+_elements_inv = {vv: kk for kk, vv in elements.items()}
+
+elements_long = {
+    1: "Hydrogen",        2: "Helium",          3: "Lithium",         4: "Beryllium",       5: "Boron",
+    6: "Carbon",          7: "Nitrogen",        8: "Oxygen",          9: "Fluorine",       10: "Neon",
+   11: "Sodium",         12: "Magnesium",      13: "Aluminum",       14: "Silicon",        15: "Phosphorus",
+   16: "Sulfur",         17: "Chlorine",       18: "Argon",          19: "Potassium",      20: "Calcium",
+   21: "Scandium",       22: "Titanium",       23: "Vanadium",       24: "Chromium",       25: "Manganese",
+   26: "Iron",           27: "Cobalt",         28: "Nickel",         29: "Copper",         30: "Zinc",
+   31: "Gallium",        32: "Germanium",      33: "Arsenic",        34: "Selenium",       35: "Bromine",
+   36: "Krypton",        37: "Rubidium",       38: "Strontium",      39: "Yttrium",        40: "Zirconium",
+   41: "Niobium",        42: "Molybdenum",     43: "Technetium",     44: "Ruthenium",      45: "Rhodium",
+   46: "Palladium",      47: "Silver",         48: "Cadmium",        49: "Indium",         50: "Tin",
+   51: "Antimony",       52: "Tellurium",      53: "Iodine",         54: "Xenon",          55: "Cesium",
+   56: "Barium",         57: "Lanthanum",      58: "Cerium",         59: "Praseodymium",   60: "Neodymium",
+   61: "Promethium",     62: "Samarium",       63: "Europium",       64: "Gadolinium",     65: "Terbium",
+   66: "Dysprosium",     67: "Holmium",        68: "Erbium",         69: "Thulium",        70: "Ytterbium",
+   71: "Lutetium",       72: "Hafnium",        73: "Tantalum",       74: "Tungsten",       75: "Rhenium",
+   76: "Osmium",         77: "Iridium",        78: "Platinum",       79: "Gold",           80: "Mercury",
+   81: "Thallium",       82: "Lead",           83: "Bismuth",        84: "Polonium",       85: "Astatine",
+   86: "Radon",          87: "Francium",       88: "Radium",         89: "Actinium",       90: "Thorium",
+   91: "Protactinium",   92: "Uranium",        93: "Neptunium",      94: "Plutonium",      95: "Americium",
+   96: "Curium",         97: "Berkelium",      98: "Californium",    99: "Einsteinium",   100: "Fermium",
+  101: "Mendelevium",   102: "Nobelium",      103: "Lawrencium",    104: "Rutherfordium", 105: "Dubnium",
+  106: "Seaborgium",    107: "Bohrium",       108: "Hassium",       109: "Meitnerium",    110: "Darmstadtium",
+  111: "Roentgenium",   112: "Copernicium",   113: "Nihonium",      114: "Flerovium",     115: "Moscovium",
+  116: "Livermorium",   117: "Tennessine",    118: "Oganesson"
+}
+_elements_long_inv = {vv: kk for kk, vv in elements_long.items()}
+
+
+def is_proton(pdg_id):
+    """Check if a PDG ID corresponds to a proton."""
+    return int(pdg_id) == 2212
+
+def is_ion(pdg_id):
+    """Check if a PDG ID corresponds to a heavy ion (A+Z > 1)."""
+    tmpid = pdg_id - 1000000000
+    L = int(tmpid/1e7)
+    tmpid -= L*1e7
+    Z = int(tmpid /1e4)
+    tmpid -= Z*1e4
+    A = int(tmpid /10)
+    return (int(pdg_id) >= 1000000000) and (Z > 0) and (A > Z)
+
+def is_lepton(pdg_id):
+    """Check if a PDG ID corresponds to a lepton (neutrinos included)."""
+    return 11 <= abs(int(pdg_id)) <= 16
+
+
+def get_name_from_pdg_id(pdg_id, long_name=True, subscripts=True):
+    """
+    Get the name of a particle from its PDG ID.
+
+    Parameters
+    ----------
+    long_name : bool, default True
+        If True, return the long name of the particle (ASCII-compliant). For a
+        particle in the PDF internal table, this is the last name in the list
+        of alternatives. For an ion, it is the full element name, followed by
+        the mass number. If 'long_name' is False, a short name is returned
+        (Unicode). For a particle in the PDF internal table, this is the first
+        name in the list of alternatives. For an ion, it is the element name
+        preceded (when 'subscripts' is True) of followed (when 'subscripts' is
+        False) by the mass number.
+    subscripts : bool, default True
+        Controls whether or not to allow sub- and superscripts in the short
+        name. Has no function if 'long_name' is True.
+
+    Returns
+    -------
+    str
+        The name of the particle.
+    """
+    if hasattr(pdg_id, '__len__') and not isinstance(pdg_id, str):
+        return np.array([get_name_from_pdg_id(pdg) for pdg in pdg_id])
+    return get_properties_from_pdg_id(pdg_id, long_name=long_name, subscripts=subscripts)[-1]
+
+
+def get_pdg_id_from_name(name=None):
+    """
+    Get a particle's PDG ID from its name.
+
+    Parameters
+    ----------
+    name : str
+        The name of the particle. Can be any alternative from the PDF internal
+        table, with or without sub- or superscripts. For ions, the name can be
+        any combination of the element short or long name and the mass number,
+        for instance 'Pb208', 'Pb 208', Pb-208', 'Pb_208', '208Pb', 'Lead-208',
+        'lead 208', etc.
+
+    Returns
+    -------
+    int
+        The PDG ID of the particle.
+    """
+    if hasattr(name, 'get'):
+        name = name.get()
+
+    if name is None:
+        return 0  # undefined
+    elif hasattr(name, '__len__') and not isinstance(name, str):
+        return np.array([get_pdg_id_from_name(nn) for nn in name])
+    elif isinstance(name, Number):
+        return int(name) # fallback
+
+    lname = _to_normal_script(name).lower().replace('ς', 'σ')
+    aname = ""
+    if len(lname) > 4 and lname[:5]=="anti-":
+        aname = _flip_end_sign(lname[5:])
+    elif len(lname) > 4 and lname[:5]=="anti ":
+        aname = _flip_end_sign(lname[5:])
+    elif len(lname) > 3 and lname[:4]=="anti":
+        aname = _flip_end_sign(lname[4:])
+
+    _PDG_inv = get_pdg_inv()
+
+    # particle
+    if lname in _PDG_inv.keys():
+        return _PDG_inv[lname]
+
+    # anti-particle
+    elif aname in _PDG_inv.keys():
+        return -_PDG_inv[aname]
+
+    else:
+        ion_name = lname.lower()
+        ion_name = ion_name.replace('_','').replace('-','')
+        ion_name = ion_name.replace(' ','').replace('.','')
+        for Z, ion in elements_long.items():
+            if ion.lower() in ion_name:
+                A = ion_name.replace(ion.lower(), '')
+                if A.isnumeric() and int(A) > 0:
+                    return get_pdg_id_ion(int(A), Z)
+        for Z, ion in elements.items():
+            if ion.lower() in ion_name:
+                A = ion_name.replace(ion.lower(), '')
+                if A.isnumeric() and int(A) > 0:
+                    return get_pdg_id_ion(int(A), Z)
+        raise ValueError(f"Particle {name} not found in pdg dictionary, or wrongly "
+                        + f"formatted ion name!\nFor ions, use e.g. 'Pb208', 'Pb 208', "
+                        + f"'Pb-208', 'Pb_208', 'Pb.208', '208Pb', 'lead-208', ...")
+
+
+def get_properties_from_pdg_id(pdg_id, long_name=False, subscripts=True):
+    """
+    Get the properties of a particle from its PDG ID.
+
+    Parameters
+    ----------
+    pdg_id : int or str
+        The PDG ID of the particle.
+    long_name : bool, default True
+        If True, return the long name of the particle (ASCII-compliant). For a
+        particle in the PDF internal table, this is the last name in the list
+        of alternatives. For an ion, it is the full element name, followed by
+        the mass number. If 'long_name' is False, a short name is returned
+        (Unicode). For a particle in the PDF internal table, this is the first
+        name in the list of alternatives. For an ion, it is the element name
+        preceded (when 'subscripts' is True) of followed (when 'subscripts' is
+        False) by the mass number.
+    subscripts : bool, default True
+        Controls whether or not to allow sub- and superscripts in the short
+        name. Has no function if 'long_name' is True.
+    name : str
+
+    Returns
+    -------
+    q : int
+        The charge of the particle.
+    A : int
+        The mass number of the particle (total number of protons and neutrons).
+    Z : int
+        The atomic number of the particle (number of protons).
+    name : str
+        The name of the particle, with formatting depending on 'long_name' and
+        'subscripts'.
+    """
+    if hasattr(pdg_id, '__len__') and not isinstance(pdg_id, str):
+        result = np.array([get_properties_from_pdg_id(pdg) for pdg in pdg_id]).T
+        return result[0].astype(np.float64), result[1].astype(np.int64),\
+               result[2].astype(np.int64), result[3]
+
+    pdg_id = int(pdg_id)
+
+    if pdg_id in pdg_table.keys():
+        q = pdg_table[pdg_id][0]
+        if long_name:
+            name = pdg_table[pdg_id][-1]
+        else:
+            name = pdg_table[pdg_id][1]
+            if not subscripts:
+                name = _to_normal_script(name)
+        if abs(pdg_id)==2212 or abs(pdg_id)==2112:
+            A = 1
+            Z = q
+        elif pdg_id==1000010020:
+            A = 2
+            Z = 1
+            if not long_name and not subscripts:
+                name = 'H2'
+        elif pdg_id==1000010030:
+            A = 3
+            Z = 1
+            if not long_name and not subscripts:
+                name = 'H3'
+        else:
+            A = 0
+            Z = 0
+        return int(q), int(A), int(Z), name
+
+    elif pdg_id > 1000000000:
+        # Ion
+        tmpid = pdg_id - 1000000000
+        L = int(tmpid/1e7)
+        tmpid -= L*1e7
+        Z = int(tmpid /1e4)
+        tmpid -= Z*1e4
+        A = int(tmpid /10)
+        tmpid -= A*10
+        isomer_level = int(tmpid)
+        if long_name:
+            return int(Z), int(A), int(Z), f'{get_element_full_name_from_Z(Z)}-{A}'
+        else:
+            if subscripts:
+                name = f'{_digits_to_superscript(A)}{get_element_name_from_Z(Z)}'
+            else:
+                name = f'{get_element_name_from_Z(Z)}{A}'
+            return int(Z), int(A), int(Z), name
+
+    elif -pdg_id in pdg_table.keys() or pdg_id < -1000000000:
+        antipart = get_properties_from_pdg_id(-pdg_id, long_name=long_name, subscripts=subscripts)
+        name = _flip_end_sign(f'anti-{antipart[3]}')
+        return -antipart[0], antipart[1], -antipart[2], name
+
+    else:
+        raise ValueError(f"PDG ID {pdg_id} not recognised!")
+
+
+def get_element_name_from_Z(z):
+    """Get the short element name for the element with Z protons."""
+    if z not in elements:
+        raise ValueError(f"Element with {z} protons not known.")
+    return elements[z]
+
+def get_element_full_name_from_Z(z):
+    """Get the full element name for the element with Z protons."""
+    if z not in elements_long:
+        raise ValueError(f"Element with {z} protons not known.")
+    return elements_long[z]
+
+def get_Z_from_element_name(name):
+    """Get the atomic number from the short or long element name."""
+    if name in _elements_inv:
+        return _elements_inv[name]
+    elif name in _elements_long_inv:
+        return _elements_long_inv[name]
+    else:
+        raise ValueError(f"Element {name} not recognised!")
+
+
+def get_pdg_id_ion(A, Z):
+    """Get the PDG ID for an ion with Z protons and A-Z neutrons."""
+    if hasattr(A, '__len__') and not isinstance(A, str) \
+    and hasattr(Z, '__len__') and not isinstance(Z, str):
+        return np.array([get_pdg_id_ion(aa, zz) for aa, zz in zip(A,Z)])
+    Z = int(Z)
+    A = int(A)
+    if Z < 1 or A < 2 or A < Z:
+        raise ValueError(f"Not an ion ({Z=} and {A=})!")
+    return 1000000000 + Z*10000 + A*10
+
+
+def get_pdg_id_from_mass_charge(m, q, rtol=1e-3):
+    """Get the PDG ID for a given mass and charge. This is always an estimate."""
+    if hasattr(q, '__len__') and not isinstance(q, str) \
+    and hasattr(m, '__len__') and not isinstance(m, str):
+        return np.array([get_pdg_id_from_mass_charge(mm, qq) for qq, mm in zip(q, m)])
+    elif hasattr(q, '__len__') and not isinstance(q, str):
+        return np.array([get_pdg_id_from_mass_charge(m, qq) for qq in q])
+    elif hasattr(m, '__len__') and not isinstance(m, str):
+        return np.array([get_pdg_id_from_mass_charge(mm, q) for mm in m])
+
+    m = float(m)
+    q = int(q)
+    A = round(m/U_MASS_EV)
+
+    # First we check the internal table of masses
+    found_ids = []
+    for pdg_id, val in _get_mass_table().items():
+        if abs(val) < 1e-12:
+            if abs(m) < 1e-12:
+                found_ids.append(pdg_id)
+        elif abs(val-m)/val <= rtol:
+            found_ids.append(pdg_id)
+    if len(found_ids) > 0:
+        pdg_id = []
+        for this_pdg_id in found_ids:
+            this_q, _, _, _ = get_properties_from_pdg_id(this_pdg_id)
+            if this_q == q:
+                pdg_id.append(this_pdg_id)
+            else:
+                this_q, _, _, _ = get_properties_from_pdg_id(-this_pdg_id)
+                if this_q == q:
+                    pdg_id.append(-this_pdg_id)
+        if len(pdg_id) == 1:
+            return pdg_id[0]
+        elif len(pdg_id) > 1:
+            raise ValueError(f"Multiple particles found for {m=} and {q=}: {found_ids}. "
+                           + f"Decrease the tolerance. If this does not work, it might be "
+                           + f"ambiguous and not resolvable with mass and charge alone "
+                           + f"(like for a neutral particle that is not its own anti-particle).")
+
+    # Then we check for ions
+    if q > 0 and A > 1:
+        return get_pdg_id_ion(A, q)
+
+    # Not found
+    else:
+        raise ValueError(f"Particle with charge {q} and mass {m} eV not recognised!\nIf "
+                       + f"the particle mass is expected to be present in the internal "
+                       + f"mass table in Xtrack, try increasing the tolerance.")
+
+
+def get_mass_from_pdg_id(pdg_id, allow_approximation=True, expected_mass=None, verbose=True):
+    """Get the particle mass for a given PDG ID, if in the internal database. If not, it can be extrapolated for ions."""
+    if hasattr(pdg_id, '__len__') and not isinstance(pdg_id, str):
+        return np.array([get_mass_from_pdg_id(pdg,
+                                      allow_approximation=allow_approximation,
+                                      expected_mass=expected_mass)
+                         for pdg in pdg_id])
+
+    pdg_id = int(pdg_id)
+    _mass_table = _get_mass_table()
+    if pdg_id in _mass_table:
+        return _mass_table[pdg_id]
+    elif -pdg_id in _mass_table:
+        return _mass_table[-pdg_id]
+    elif pdg_id > 1000000000 and allow_approximation:
+        _, A, _, _ = get_properties_from_pdg_id(pdg_id)
+        if verbose:
+            print(f"Warning: approximating the mass as {A}u!")
+        return A*U_MASS_EV
+    elif expected_mass is not None and _mass_consistent(pdg_id, expected_mass):
+        # This is a workaround in case an exact mass is given
+        # (like for the reference particle)
+        return expected_mass
+    else:
+        raise ValueError(f"Exact mass not found for particle with PDG ID {pdg_id}.")
+
+
+# Dynamically set _pdg_inv so it can be defined only here
+_PDG_inv = {}
+def get_pdg_inv():
+    if _PDG_inv == {}:
+        for pdg_id, val in pdg_table.items():
+            for vv in val[1:]:
+                _PDG_inv[_to_normal_script(vv).lower()] = pdg_id
+    return _PDG_inv
+
+
+def _flip_end_sign(name):
+    if name[-2:] == '⁺⁺':
+        return name[:-2] + '⁻⁻'
+    elif name[-2:] == '++':
+        return name[:-2] + '--'
+    elif name[-2:] == '⁻⁻':
+        return name[:-2] + '⁺⁺'
+    elif name[-2:] == '--':
+        return name[:-2] + '++'
+    elif name[-1] == '⁺':
+        return name[:-1] + '⁻'
+    elif name[-1] == '+':
+        return name[:-1] + '-'
+    elif name[-1] == '⁻':
+        return name[:-1] + '⁺'
+    elif name[-1] == '-':
+        return name[:-1] + '+'
+    else:
+        return name
+
+
+def _digits_to_superscript(val):
+    val = f'{val}'.replace('0', '⁰').replace('1', '¹').replace('2', '²').replace('3', '³')
+    val = val.replace('4', '⁴').replace('5', '⁵').replace('6', '⁶').replace('7', '⁷')
+    return val.replace('8', '⁸').replace('9', '⁹').replace('+', '⁺').replace('-', '⁻')
+
+def _digits_to_normalscript(val):
+    val = f'{val}'.replace('⁰', '0').replace('¹', '1').replace('²', '2').replace('³', '3')
+    val = val.replace('⁴', '4').replace('⁵', '5').replace('⁶', '6').replace('⁷', '7')
+    return val.replace('⁸', '8').replace('⁹', '9').replace('⁺', '+').replace('⁻', '-')
+
+def _to_normal_script(val):
+    return _digits_to_normalscript(val).replace('ₛ', 's').replace('ₑ', 'e')
+
+
+# Dynamically set mass_table from xtrack.particles.masses to avoid circular imports and loops
+_mass_table = {}
+def _get_mass_table():
+    if _mass_table == {}:
+        for name, mass in mass__dict__.items():
+            if name.endswith('_MASS_EV') and name != 'U_MASS_EV':
+                # Mass definitions for charged particles are without the charge identifier,
+                # so we need to try these first.
+                try:
+                    pdg_id = get_pdg_id_from_name(f'{name[:-8]}+')
+                except ValueError:
+                    pdg_id = get_pdg_id_from_name(name[:-8])
+                if pdg_id not in _mass_table:
+                    _mass_table[pdg_id] = mass
+                else:
+                    raise ValueError(f"Duplicate mass in Xtrack for particle {pdg_id}!")
+    return _mass_table
+
+
+def _mass_consistent(pdg_id, m, mask=None):
+    if hasattr(pdg_id, '__len__') and not isinstance(pdg_id, str) \
+    and hasattr(m, '__len__') and not isinstance(m, str):
+        if mask is None:
+            return np.all([_mass_consistent(pdg, mm) for pdg, mm in zip(pdg_id, m)])
+        else:
+            pdg_id = np.array(pdg_id)[mask]
+            m = np.array(m)[mask]
+            return np.all([_mass_consistent(pdg, mm) for pdg, mm in zip(pdg_id, m)])
+    elif hasattr(pdg_id, '__len__') and not isinstance(pdg_id, str):
+        if mask is None:
+            return np.all([_mass_consistent(pdg, m) for pdg in pdg_id])
+        else:
+            pdg_id = np.array(pdg_id)[mask]
+            return np.all([_mass_consistent(pdg, m) for pdg in pdg_id])
+    elif hasattr(m, '__len__') and not isinstance(m, str):
+        if mask is None:
+            return np.all([_mass_consistent(pdg_id, mm) for mm in m])
+        else:
+            m = np.array(m)[mask]
+            return np.all([_mass_consistent(pdg_id, mm) for mm in m])
+
+    try:
+        q, _, _, _ = get_properties_from_pdg_id(pdg_id)
+        return pdg_id == get_pdg_id_from_mass_charge(m, q)
+    except ValueError:
+        # No check if mass cannot be retrieved
+        return True
+
+
+# Make sure no duouble names exist in the pdg_table, after removing subscripts
+# and going to lower case
+def _check_pdg_table():
+    names = [vvv for vv in pdg_table.values() for vvv in vv[1:]]
+    names = [_to_normal_script(name).lower() for name in names]
+    if len(names) != len(np.unique(names)):
+        double_names = []
+        for i, name1 in enumerate(names):
+            for name2 in names[i+1:]:
+                if _to_normal_script(name1).lower() \
+                == _to_normal_script(name2).lower():
+                    double_names.append(name1)
+                    double_names.append(name2)
+        raise ValueError(f"Duplicate names in pdg_table:\n{double_names}")
+
+_check_pdg_table()


### PR DESCRIPTION
**Changes:**

- Update reference masses for key particles (electron, muon, proton, Pb208), and add new ones, in line with the latest PDG 2024 values and hardcoded them for stability. They are moved from Xpart and centralised in `xtrack/particles/masses.py`. Add new utility functions and fix particle-related bugs.