### PR TITLE
Fix add to energy

### DIFF
--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -1873,9 +1873,9 @@ class Particles(xo.HybridClass):
                         double const p0c = LocalParticle_get_p0c(part);
                         double const charge_ratio = LocalParticle_get_charge_ratio(part);
                         double const chi = LocalParticle_get_chi(part);
-                        double const mass_ratio = chi / charge_ratio;
-                        
-                        ptau += delta_energy/p0c * mass_ratio;
+                        double const mass_ratio = charge_ratio / chi;
+
+                        ptau += delta_energy/p0c / mass_ratio;
 
                         double const old_rpp = LocalParticle_get_rpp(part);
 

--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -349,6 +349,14 @@ class Particles(xo.HybridClass):
             mask=input_mask,
         )
 
+        # Init chi and charge ratio
+        self._update_chi_charge_ratio(
+            chi=kwargs.get('chi'),
+            charge_ratio=kwargs.get('charge_ratio'),
+            mass_ratio=kwargs.get('mass_ratio'),
+            mask=input_mask,
+        )
+
         # Init energy deviations
         self._update_energy_deviations(
             delta=kwargs.get('delta'),
@@ -363,14 +371,6 @@ class Particles(xo.HybridClass):
         self._update_zeta(
             zeta=kwargs.get('zeta'),
             tau=kwargs.get('tau'),
-            mask=input_mask,
-        )
-
-        # Init chi and charge ratio
-        self._update_chi_charge_ratio(
-            chi=kwargs.get('chi'),
-            charge_ratio=kwargs.get('charge_ratio'),
-            mass_ratio=kwargs.get('mass_ratio'),
             mask=input_mask,
         )
 
@@ -2083,6 +2083,9 @@ class Particles(xo.HybridClass):
             if _rpp is not None or _rvv is not None:
                 raise ValueError('Setting `delta` and `ptau` by only giving '
                                  '`_rpp` and `_rvv` is not supported.')
+            if any(self.mass_ratio != 1.0):
+                raise ValueError('Need to provide `delta` or `ptau` with '
+                                 'non-default mass ratios.')
             self._delta = 0.0
             delta = self._delta  # Cupy complains if we later assign LinkedArray
 

--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -1394,7 +1394,7 @@ class Particles(xo.HybridClass):
         Add `delta_energy` to the `energy` of the particles object. `delta`,
         'ptau', `rvv` and `rpp` are updated accordingly.
         """
-        self.ptau += delta_energy / self.p0c * self.mass_ratio
+        self.ptau += delta_energy / self.p0c / self.mass_ratio
 
     def set_particle(self, index, set_scalar_vars=False, **kwargs):
         raise NotImplementedError('This functionality has been removed')


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

- Bugfix in `Particles.add_to_energy`. The correct formula is $\Delta p_\tau = \frac{\Delta E}{p_0c}\frac{m_0}{m}$ but $\Delta p_\tau = \frac{\Delta E}{p_0c}\frac{m}{m_0}$ was used.
- Code was correct in C (in `LocalParticle_add_to_energy`), however, it was using a temporary variable `mass_ratio` equal to $\frac{m_0}{m}$ which is confusing as it is the inverse of the same variable in python. Homogenised the naming to the Python one (no practical impact as it was only a temporary variable).
- Adapted `test_python_add_to_energy` in  `test_python_add_to_energy` to assert the correct behaviour (fails with the old behaviour).
- When initialising particles with some masses different from $m_0$, throw an error when neither $\delta\$ or $p_\tau$ are provided. This is to force the user to think of the implications, as the default $\delta$ and $p_\tau$ (default value is 0) will lead to a momentum very different from $p_0 c$.

## Checklist

Mandatory: 

- [X] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [X] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
