### PR TITLE
Update trajectory_correction.py

### DIFF
--- a/xtrack/trajectory_correction.py
+++ b/xtrack/trajectory_correction.py
@@ -93,7 +93,7 @@ def _build_response_matrix(tw, monitor_names, corrector_names,
     elif mode == 'closed':
         # Slide 28
         # https://indico.cern.ch/event/1328128/contributions/5589794/attachments/2786478/4858384/linearimperfections_2024.pdf
-        tune = tw.qx
+        tune = tw['q' + plane]
         response_matrix = (np.sqrt(bet_prod) / 2 / np.sin(np.pi * tune)
                              * np.cos(np.pi * tune - 2*np.pi*np.abs(mu_diff)))
 


### PR DESCRIPTION
I identified a minor issue in the computation of the response matrix used for trajectory correction: where it uses the horizontal tune instead of the vertical tune when calculating the vertical response matrix.