### PR TITLE
Add NormalizedParticles class for coordinate transformations

### DIFF
--- a/tests/test_twiss.py
+++ b/tests/test_twiss.py
@@ -160,6 +160,14 @@ def test_get_normalized_coordinates(test_context):
     xo.assert_allclose(norm_coord['px_norm'], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
     xo.assert_allclose(norm_coord['py_norm'], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
 
+    norm_coord = tw.get_normalized_coordinates(
+        particles, nemitt_x=2.5e-6, nemitt_y=1e-6, _evaluate_in_context=True
+    )
+
+    xo.assert_allclose(norm_coord["x_norm"], [-1, 0, 0.5], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord["y_norm"], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord["px_norm"], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord["py_norm"], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
 
     # Introduce a non-zero closed orbit
     line['mqwa.a4r3.b1..1'].knl[0] = 10e-6
@@ -179,6 +187,15 @@ def test_get_normalized_coordinates(test_context):
     xo.assert_allclose(norm_coord1['y_norm'], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
     xo.assert_allclose(norm_coord1['px_norm'], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
     xo.assert_allclose(norm_coord1['py_norm'], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
+
+    norm_coord1 = tw1.get_normalized_coordinates(
+        particles1, nemitt_x=2.5e-6, nemitt_y=1e-6, _evaluate_in_context=True
+    )
+
+    xo.assert_allclose(norm_coord1["x_norm"], [-1, 0, 0.5], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord1["y_norm"], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord1["px_norm"], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord1["py_norm"], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
 
     # Check computation at different locations
 
@@ -215,10 +232,323 @@ def test_get_normalized_coordinates(test_context):
     xo.assert_allclose(norm_coord23['py_norm'][3:6], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
     xo.assert_allclose(norm_coord23['py_norm'][6:], xt.particles.LAST_INVALID_STATE)
 
+    norm_coord23 = tw1.get_normalized_coordinates(
+        particles23, nemitt_x=2.5e-6, nemitt_y=1e-6, _evaluate_in_context=True
+    )
+
+    assert particles23._capacity == 20
+    xo.assert_allclose(norm_coord23["x_norm"][:3], [-1, 0, 0.5], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord23["x_norm"][3:6], [-1, 0, 0.5], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord23["x_norm"][6:], xt.particles.LAST_INVALID_STATE)
+    xo.assert_allclose(norm_coord23["y_norm"][:3], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
+    xo.assert_allclose(
+        norm_coord23["y_norm"][3:6], [0.3, -0.2, 0.2], atol=1e-10, rtol=0
+    )
+    xo.assert_allclose(norm_coord23["y_norm"][6:], xt.particles.LAST_INVALID_STATE)
+    xo.assert_allclose(norm_coord23["px_norm"][:3], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
+    xo.assert_allclose(
+        norm_coord23["px_norm"][3:6], [0.1, 0.2, 0.3], atol=1e-10, rtol=0
+    )
+    xo.assert_allclose(norm_coord23["px_norm"][6:], xt.particles.LAST_INVALID_STATE)
+    xo.assert_allclose(norm_coord23["py_norm"][:3], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
+    xo.assert_allclose(
+        norm_coord23["py_norm"][3:6], [0.5, 0.6, 0.8], atol=1e-10, rtol=0
+    )
+    xo.assert_allclose(norm_coord23["py_norm"][6:], xt.particles.LAST_INVALID_STATE)
+
     particles23.move(_context=xo.context_default)
     assert np.all(particles23.at_element[:3] == line.element_names.index('s.ds.r3.b1'))
     assert np.all(particles23.at_element[3:6] == line.element_names.index('s.ds.r7.b1'))
     assert np.all(particles23.at_element[6:] == xt.particles.LAST_INVALID_STATE)
+
+
+@for_all_test_contexts
+def test_normalized_particles_get_coordinates(test_context):
+
+    path_line_particles = (
+        test_data_folder / "hllhc15_noerrors_nobb/line_and_particle.json"
+    )
+
+    with open(path_line_particles, "r") as fid:
+        input_data = json.load(fid)
+    line = xt.Line.from_dict(input_data["line"])
+    line.particle_ref = xp.Particles.from_dict(input_data["particle"])
+
+    line.build_tracker(_context=test_context)
+
+    particles = line.build_particles(
+        nemitt_x=2.5e-6,
+        nemitt_y=1e-6,
+        x_norm=[-1, 0, 0.5],
+        y_norm=[0.3, -0.2, 0.2],
+        px_norm=[0.1, 0.2, 0.3],
+        py_norm=[0.5, 0.6, 0.8],
+        zeta=[0, 0.1, -0.1],
+        delta=[1e-4, 0.0, -1e-4],
+    )
+
+    tw = line.twiss()
+
+    norm_coord = xt.NormalizedParticles(
+        tw, particles, nemitt_x=2.5e-6, nemitt_y=1e-6
+    ).get_normalized_coordinates()
+
+    xo.assert_allclose(norm_coord["x_norm"], [-1, 0, 0.5], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord["y_norm"], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord["px_norm"], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord["py_norm"], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
+
+    # Introduce a non-zero closed orbit
+    line["mqwa.a4r3.b1..1"].knl[0] = 10e-6
+    line["mqwa.a4r3.b1..1"].ksl[0] = 5e-6
+
+    particles1 = line.build_particles(
+        nemitt_x=2.5e-6,
+        nemitt_y=1e-6,
+        x_norm=[-1, 0, 0.5],
+        y_norm=[0.3, -0.2, 0.2],
+        px_norm=[0.1, 0.2, 0.3],
+        py_norm=[0.5, 0.6, 0.8],
+        zeta=[0, 0.1, -0.1],
+        delta=[1e-4, 0.0, -1e-4],
+    )
+
+    tw1 = line.twiss()
+    norm_coord1 = xt.NormalizedParticles(
+        tw1, particles1, nemitt_x=2.5e-6, nemitt_y=1e-6
+    ).get_normalized_coordinates()
+
+    xo.assert_allclose(norm_coord1["x_norm"], [-1, 0, 0.5], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord1["y_norm"], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord1["px_norm"], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord1["py_norm"], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
+
+    # Check computation at different locations
+
+    particles2 = line.build_particles(
+        at_element="s.ds.r3.b1",
+        _capacity=10,
+        nemitt_x=2.5e-6,
+        nemitt_y=1e-6,
+        x_norm=[-1, 0, 0.5],
+        y_norm=[0.3, -0.2, 0.2],
+        px_norm=[0.1, 0.2, 0.3],
+        py_norm=[0.5, 0.6, 0.8],
+        zeta=[0, 0.1, -0.1],
+        delta=[1e-4, 0.0, -1e-4],
+    )
+
+    particles3 = line.build_particles(
+        at_element="s.ds.r7.b1",
+        _capacity=10,
+        nemitt_x=2.5e-6,
+        nemitt_y=1e-6,
+        x_norm=[-1, 0, 0.5],
+        y_norm=[0.3, -0.2, 0.2],
+        px_norm=[0.1, 0.2, 0.3],
+        py_norm=[0.5, 0.6, 0.8],
+        zeta=[0, 0.1, -0.1],
+        delta=[1e-4, 0.0, -1e-4],
+    )
+
+    particles23 = xp.Particles.merge([particles2, particles3])
+
+    norm_coord23 = xt.NormalizedParticles(
+        tw1, particles23, nemitt_x=2.5e-6, nemitt_y=1e-6
+    ).get_normalized_coordinates()
+
+    assert particles23._capacity == 20
+    xo.assert_allclose(norm_coord23["x_norm"][:3], [-1, 0, 0.5], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord23["x_norm"][3:6], [-1, 0, 0.5], atol=1e-10, rtol=0)
+    xo.assert_allclose(norm_coord23["x_norm"][6:], xt.particles.LAST_INVALID_STATE)
+    xo.assert_allclose(norm_coord23["y_norm"][:3], [0.3, -0.2, 0.2], atol=1e-10, rtol=0)
+    xo.assert_allclose(
+        norm_coord23["y_norm"][3:6], [0.3, -0.2, 0.2], atol=1e-10, rtol=0
+    )
+    xo.assert_allclose(norm_coord23["y_norm"][6:], xt.particles.LAST_INVALID_STATE)
+    xo.assert_allclose(norm_coord23["px_norm"][:3], [0.1, 0.2, 0.3], atol=1e-10, rtol=0)
+    xo.assert_allclose(
+        norm_coord23["px_norm"][3:6], [0.1, 0.2, 0.3], atol=1e-10, rtol=0
+    )
+    xo.assert_allclose(norm_coord23["px_norm"][6:], xt.particles.LAST_INVALID_STATE)
+    xo.assert_allclose(norm_coord23["py_norm"][:3], [0.5, 0.6, 0.8], atol=1e-10, rtol=0)
+    xo.assert_allclose(
+        norm_coord23["py_norm"][3:6], [0.5, 0.6, 0.8], atol=1e-10, rtol=0
+    )
+    xo.assert_allclose(norm_coord23["py_norm"][6:], xt.particles.LAST_INVALID_STATE)
+
+    particles23.move(_context=xo.context_default)
+    assert np.all(particles23.at_element[:3] == line.element_names.index("s.ds.r3.b1"))
+    assert np.all(particles23.at_element[3:6] == line.element_names.index("s.ds.r7.b1"))
+    assert np.all(particles23.at_element[6:] == xt.particles.LAST_INVALID_STATE)
+
+
+@for_all_test_contexts
+def test_normalized_particles_conversion(test_context):
+
+    path_line_particles = (
+        test_data_folder / "hllhc15_noerrors_nobb/line_and_particle.json"
+    )
+
+    with open(path_line_particles, "r") as fid:
+        input_data = json.load(fid)
+    line = xt.Line.from_dict(input_data["line"])
+    line.particle_ref = xp.Particles.from_dict(input_data["particle"])
+
+    line.build_tracker(_context=test_context)
+
+    particles = line.build_particles(
+        nemitt_x=2.5e-6,
+        nemitt_y=1e-6,
+        x_norm=[-1, 0, 0.5],
+        y_norm=[0.3, -0.2, 0.2],
+        px_norm=[0.1, 0.2, 0.3],
+        py_norm=[0.5, 0.6, 0.8],
+        zeta=[0, 0.1, -0.1],
+        delta=[1e-4, 0.0, -1e-4],
+    )
+
+    particles_bis = particles.copy()
+    particles_bis.x = 0.0
+    particles_bis.y = 0.0
+    particles_bis.px = 0.0
+    particles_bis.py = 0.0
+    particles_bis.zeta = 0.0
+    particles_bis.delta = 0.0
+    particles_bis.ptau = 0.0
+
+    tw = line.twiss()
+
+    norm_coord = xt.NormalizedParticles(tw, particles, nemitt_x=2.5e-6, nemitt_y=1e-6)
+
+    particles_bis = norm_coord.norm_to_phys(
+        particles_bis, nemitt_x=2.5e-6, nemitt_y=1e-6
+    )
+
+    xo.assert_allclose(particles_bis.x, particles.x, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.y, particles.y, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.px, particles.px, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.py, particles.py, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.zeta, particles.zeta, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.delta, particles.delta, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.ptau, particles.ptau, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.rpp, particles.rpp, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.rvv, particles.rvv, atol=1e-10, rtol=0)
+
+    # Let's do a couple more times...
+    for i in range(42):
+        norm_coord.phys_to_norm(particles_bis, nemitt_x=2.5e-6, nemitt_y=1e-6)
+        particles_bis = norm_coord.norm_to_phys(
+            particles_bis, nemitt_x=2.5e-6, nemitt_y=1e-6
+        )
+
+    xo.assert_allclose(particles_bis.x, particles.x, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.y, particles.y, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.px, particles.px, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.py, particles.py, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.zeta, particles.zeta, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.delta, particles.delta, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.ptau, particles.ptau, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.rpp, particles.rpp, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.rvv, particles.rvv, atol=1e-10, rtol=0)
+
+    # Introduce a non-zero closed orbit
+    line["mqwa.a4r3.b1..1"].knl[0] = 10e-6
+    line["mqwa.a4r3.b1..1"].ksl[0] = 5e-6
+
+    particles1 = line.build_particles(
+        nemitt_x=2.5e-6,
+        nemitt_y=1e-6,
+        x_norm=[-1, 0, 0.5],
+        y_norm=[0.3, -0.2, 0.2],
+        px_norm=[0.1, 0.2, 0.3],
+        py_norm=[0.5, 0.6, 0.8],
+        zeta=[0, 0.1, -0.1],
+        delta=[1e-4, 0.0, -1e-4],
+    )
+
+    tw1 = line.twiss()
+    norm_coord1 = xt.NormalizedParticles(
+        tw1, particles1, nemitt_x=2.5e-6, nemitt_y=1e-6
+    )
+
+    particles_bis = norm_coord1.norm_to_phys(
+        particles_bis, nemitt_x=2.5e-6, nemitt_y=1e-6
+    )
+    xo.assert_allclose(particles_bis.x, particles1.x, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.y, particles1.y, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.px, particles1.px, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.py, particles1.py, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.zeta, particles.zeta, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.delta, particles.delta, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.ptau, particles.ptau, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.rpp, particles.rpp, atol=1e-10, rtol=0)
+    xo.assert_allclose(particles_bis.rvv, particles.rvv, atol=1e-10, rtol=0)
+
+    # Check computation at different locations
+
+    particles2 = line.build_particles(
+        at_element="s.ds.r3.b1",
+        _capacity=10,
+        nemitt_x=2.5e-6,
+        nemitt_y=1e-6,
+        x_norm=[-1, 0, 0.5],
+        y_norm=[0.3, -0.2, 0.2],
+        px_norm=[0.1, 0.2, 0.3],
+        py_norm=[0.5, 0.6, 0.8],
+        zeta=[0, 0.1, -0.1],
+        delta=[1e-4, 0.0, -1e-4],
+    )
+
+    particles3 = line.build_particles(
+        at_element="s.ds.r7.b1",
+        _capacity=10,
+        nemitt_x=2.5e-6,
+        nemitt_y=1e-6,
+        x_norm=[-1, 0, 0.5],
+        y_norm=[0.3, -0.2, 0.2],
+        px_norm=[0.1, 0.2, 0.3],
+        py_norm=[0.5, 0.6, 0.8],
+        zeta=[0, 0.1, -0.1],
+        delta=[1e-4, 0.0, -1e-4],
+    )
+
+    particles23 = xp.Particles.merge([particles2, particles3])
+    particles23_copy = particles23.copy()
+    particles23_copy.x = 0.0
+    particles23_copy.y = 0.0
+    particles23_copy.px = 0.0
+    particles23_copy.py = 0.0
+    particles23_copy.zeta = 0.0
+    particles23_copy.delta = 0.0
+    particles23_copy.ptau = 0.0
+
+    norm_coord23 = xt.NormalizedParticles(
+        tw1, particles23, nemitt_x=2.5e-6, nemitt_y=1e-6
+    )
+    particles23_copy = norm_coord23.norm_to_phys(
+        particles23_copy, nemitt_x=2.5e-6, nemitt_y=1e-6
+    )
+    xo.assert_allclose(particles23_copy.x[:6], particles23.x[:6], atol=1e-10, rtol=0)
+    xo.assert_allclose(particles23_copy.y[:6], particles23.y[:6], atol=1e-10, rtol=0)
+    xo.assert_allclose(particles23_copy.px[:6], particles23.px[:6], atol=1e-10, rtol=0)
+    xo.assert_allclose(particles23_copy.py[:6], particles23.py[:6], atol=1e-10, rtol=0)
+    xo.assert_allclose(
+        particles23_copy.zeta[:6], particles23.zeta[:6], atol=1e-10, rtol=0
+    )
+    xo.assert_allclose(
+        particles23_copy.delta[:6], particles23.delta[:6], atol=1e-10, rtol=0
+    )
+    xo.assert_allclose(
+        particles23_copy.ptau[:6], particles23.ptau[:6], atol=1e-10, rtol=0
+    )
+    xo.assert_allclose(
+        particles23_copy.rpp[:6], particles23.rpp[:6], atol=1e-10, rtol=0
+    )
+    xo.assert_allclose(
+        particles23_copy.rvv[:6], particles23.rvv[:6], atol=1e-10, rtol=0
+    )
+
 
 @for_all_test_contexts
 def test_get_normalized_coordinates_twiss_init(test_context):
@@ -583,7 +913,6 @@ def collider_for_test_twiss_range():
     collider.lhcb1.particle_ref.move(_buffer=xo.ContextCpu().new_buffer())
     collider.lhcb2.particle_ref.move(_buffer=xo.ContextCpu().new_buffer())
     return collider
-
 
 
 @for_all_test_contexts

--- a/xtrack/__init__.py
+++ b/xtrack/__init__.py
@@ -20,7 +20,7 @@ from .match import (Vary, Target, TargetList, VaryList, TargetInequality, Action
                     TargetRmatrixTerm, TargetRmatrix)
 from .targets import (TargetLuminosity, TargetSeparationOrthogonalToCrossing,
                       TargetSeparation)
-from .twiss import TwissInit, TwissTable
+from .twiss import TwissInit, TwissTable, NormalizedParticles
 from .loss_location_refinement import LossLocationRefinement
 from .internal_record import (RecordIdentifier, RecordIndex, new_io_buffer,
                              start_internal_logging, stop_internal_logging)

--- a/xtrack/particles/normalized_particles_src/norm_to_phys.h
+++ b/xtrack/particles/normalized_particles_src/norm_to_phys.h
@@ -1,0 +1,79 @@
+#ifndef XNLBD_NORM_TO_PHYS_H
+#define XNLBD_NORM_TO_PHYS_H
+
+/*gpukern*/
+void norm_to_phys(ParticlesData part, NormalizedParticlesData norm_part, const int64_t nelem)
+{
+    for (int ii = 0; ii < nelem; ii++){ // vectorize_over ii nelem
+
+        const int at_element = NormalizedParticlesData_get_force_at_element(norm_part) != -1 ? 0 : ParticlesData_get_at_element(part, ii);
+
+        if (at_element >= 0 && at_element < NormalizedParticlesData_get_num_elements(norm_part))
+        {
+            const double part_beta0 = ParticlesData_get_beta0(part, ii);
+            const double part_gamma0 = ParticlesData_get_gamma0(part, ii);
+            const double *closed_orbit_data = NormalizedParticlesData_getp2_closed_orbit_data(norm_part, at_element, 0);
+            const double *w = NormalizedParticlesData_getp3_w(norm_part, at_element, 0, 0);
+
+            const double gemitt_x = isnan(NormalizedParticlesData_get_nemitt_x(norm_part)) ? 1.0 : NormalizedParticlesData_get_nemitt_x(norm_part) / part_beta0 / part_gamma0;
+            const double gemitt_y = isnan(NormalizedParticlesData_get_nemitt_y(norm_part)) ? 1.0 : NormalizedParticlesData_get_nemitt_y(norm_part) / part_beta0 / part_gamma0;
+            const double gemitt_zeta = isnan(NormalizedParticlesData_get_nemitt_zeta(norm_part)) ? 1.0 : NormalizedParticlesData_get_nemitt_zeta(norm_part) / part_beta0 / part_gamma0;
+
+            const double x_norm = NormalizedParticlesData_get_x_norm(norm_part, ii) * sqrt(gemitt_x);
+            const double px_norm = NormalizedParticlesData_get_px_norm(norm_part, ii) * sqrt(gemitt_x);
+            const double y_norm = NormalizedParticlesData_get_y_norm(norm_part, ii) * sqrt(gemitt_y);
+            const double py_norm = NormalizedParticlesData_get_py_norm(norm_part, ii) * sqrt(gemitt_y);
+            const double zeta_norm = NormalizedParticlesData_get_zeta_norm(norm_part, ii) * sqrt(gemitt_zeta);
+            const double pzeta_norm = NormalizedParticlesData_get_pzeta_norm(norm_part, ii) * sqrt(gemitt_zeta);
+
+            ParticlesData_set_x(part, ii,
+                                (w[0] * x_norm + w[1] * px_norm + w[2] * y_norm + w[3] * py_norm + w[4] * zeta_norm + w[5] * pzeta_norm) + closed_orbit_data[0]);
+            ParticlesData_set_px(part, ii,
+                                 (w[6] * x_norm + w[7] * px_norm + w[8] * y_norm + w[9] * py_norm + w[10] * zeta_norm + w[11] * pzeta_norm) + closed_orbit_data[1]);
+            ParticlesData_set_y(part, ii,
+                                (w[12] * x_norm + w[13] * px_norm + w[14] * y_norm + w[15] * py_norm + w[16] * zeta_norm + w[17] * pzeta_norm) + closed_orbit_data[2]);
+            ParticlesData_set_py(part, ii,
+                                 (w[18] * x_norm + w[19] * px_norm + w[20] * y_norm + w[21] * py_norm + w[22] * zeta_norm + w[23] * pzeta_norm) + closed_orbit_data[3]);
+            ParticlesData_set_zeta(part, ii,
+                                   (w[24] * x_norm + w[25] * px_norm + w[26] * y_norm + w[27] * py_norm + w[28] * zeta_norm + w[29] * pzeta_norm) + closed_orbit_data[4]);
+
+            // since we are doing things "raw" without the standard "track" function,
+            // we need to set all energy deviation variables ourselves
+
+            const double ptau = (w[30] * x_norm + w[31] * px_norm + w[32] * y_norm + w[33] * py_norm + w[34] * zeta_norm + w[35] * pzeta_norm) * part_beta0 + closed_orbit_data[5];
+            const double delta = sqrt(ptau * ptau + 2 * ptau / (part_beta0 * part_beta0) + 1) - 1;
+            const double delta_beta0 = delta * part_beta0;
+            const double ptau_beta0 = sqrt(delta_beta0 * delta_beta0 + 2 * delta_beta0 * part_beta0 + 1) - 1;
+
+            const double new_rvv = (1 + delta) / (1 + ptau_beta0);
+            const double new_rpp = 1 / (1 + delta);
+
+            ParticlesData_set_ptau(part, ii, ptau);
+            ParticlesData_set_delta(part, ii, delta);
+            ParticlesData_set_rvv(part, ii, new_rvv);
+            ParticlesData_set_rpp(part, ii, new_rpp);
+        }
+        else
+        {
+            // set everything to xt.particles.LAST_INVALID_STATE = -999999999
+            ParticlesData_set_x(part, ii, -999999999.);
+            ParticlesData_set_px(part, ii, -999999999.);
+            ParticlesData_set_y(part, ii, -999999999.);
+            ParticlesData_set_py(part, ii, -999999999.);
+            ParticlesData_set_zeta(part, ii, -999999999.);
+            ParticlesData_set_ptau(part, ii, -999999999.);
+            ParticlesData_set_delta(part, ii, -999999999.);
+        }
+        // also copy the particle_id, state and at_turn just to be sure
+        ParticlesData_set_particle_id(
+            part, ii, NormalizedParticlesData_get_particle_id(norm_part, ii));
+        ParticlesData_set_state(
+            part, ii, NormalizedParticlesData_get_state(norm_part, ii));
+        ParticlesData_set_at_turn(
+            part, ii, NormalizedParticlesData_get_at_turn(norm_part, ii));
+        ParticlesData_set_at_element(
+            part, ii, NormalizedParticlesData_get_at_element(norm_part, ii));
+    } // end_vectorize
+}
+
+#endif /* XNLBD_NORM_TO_PHYS_H */

--- a/xtrack/particles/normalized_particles_src/phys_to_norm.h
+++ b/xtrack/particles/normalized_particles_src/phys_to_norm.h
@@ -1,0 +1,70 @@
+#ifndef XNLBD_PHYS_TO_NORM_H
+#define XNLBD_PHYS_TO_NORM_H
+
+/*gpukern*/
+void phys_to_norm(ParticlesData part, NormalizedParticlesData norm_part, const int64_t nelem)
+{
+    for (int ii = 0; ii < nelem; ii++){ // vectorize_over ii nelem
+
+        const int at_element = NormalizedParticlesData_get_force_at_element(norm_part) != -1 ? 0 : ParticlesData_get_at_element(part, ii);
+
+        if (at_element >= 0 && at_element < NormalizedParticlesData_get_num_elements(norm_part))
+        {
+            const double particle_gamma0 = ParticlesData_get_gamma0(part, ii);
+            const double particle_beta0 = ParticlesData_get_beta0(part, ii);
+            const double *closed_orbit_data = NormalizedParticlesData_getp2_closed_orbit_data(norm_part, at_element, 0);
+            const double *w_inv = NormalizedParticlesData_getp3_w_inv(norm_part, at_element, 0, 0);
+
+            const double gemitt_x = isnan(NormalizedParticlesData_get_nemitt_x(norm_part)) ? 1.0 : NormalizedParticlesData_get_nemitt_x(norm_part) / particle_beta0 / particle_gamma0;
+            const double gemitt_y = isnan(NormalizedParticlesData_get_nemitt_y(norm_part)) ? 1.0 : NormalizedParticlesData_get_nemitt_y(norm_part) / particle_beta0 / particle_gamma0;
+            const double gemitt_zeta = isnan(NormalizedParticlesData_get_nemitt_zeta(norm_part)) ? 1.0 : NormalizedParticlesData_get_nemitt_zeta(norm_part) / particle_beta0 / particle_gamma0;
+
+            const double x_norm = ParticlesData_get_x(part, ii) - closed_orbit_data[0];
+            const double px_norm = ParticlesData_get_px(part, ii) - closed_orbit_data[1];
+            const double y_norm = ParticlesData_get_y(part, ii) - closed_orbit_data[2];
+            const double py_norm = ParticlesData_get_py(part, ii) - closed_orbit_data[3];
+            const double zeta_norm = ParticlesData_get_zeta(part, ii) - closed_orbit_data[4];
+            const double pzeta_norm = (ParticlesData_get_ptau(part, ii) - closed_orbit_data[5]) / particle_beta0;
+
+            NormalizedParticlesData_set_x_norm(norm_part, ii,
+                (w_inv[0] * x_norm + w_inv[1] * px_norm + w_inv[2] * y_norm +
+                w_inv[3] * py_norm + w_inv[4] * zeta_norm + w_inv[5] * pzeta_norm) / sqrt(gemitt_x));
+            NormalizedParticlesData_set_px_norm(norm_part, ii,
+                (w_inv[6] * x_norm + w_inv[7] * px_norm + w_inv[8] * y_norm +
+                w_inv[9] * py_norm + w_inv[10] * zeta_norm + w_inv[11] * pzeta_norm) / sqrt(gemitt_x));
+            NormalizedParticlesData_set_y_norm(norm_part, ii,
+                (w_inv[12] * x_norm + w_inv[13] * px_norm + w_inv[14] * y_norm +
+                w_inv[15] * py_norm + w_inv[16] * zeta_norm + w_inv[17] * pzeta_norm) / sqrt(gemitt_y));
+            NormalizedParticlesData_set_py_norm(norm_part, ii,
+                (w_inv[18] * x_norm + w_inv[19] * px_norm + w_inv[20] * y_norm +
+                w_inv[21] * py_norm + w_inv[22] * zeta_norm + w_inv[23] * pzeta_norm) / sqrt(gemitt_y));
+            NormalizedParticlesData_set_zeta_norm(norm_part, ii,
+                (w_inv[24] * x_norm + w_inv[25] * px_norm + w_inv[26] * y_norm +
+                w_inv[27] * py_norm + w_inv[28] * zeta_norm + w_inv[29] * pzeta_norm) / sqrt(gemitt_zeta));
+            NormalizedParticlesData_set_pzeta_norm(norm_part, ii,
+                (w_inv[30] * x_norm + w_inv[31] * px_norm + w_inv[32] * y_norm +
+                w_inv[33] * py_norm + w_inv[34] * zeta_norm + w_inv[35] * pzeta_norm) / sqrt(gemitt_zeta));            
+        }
+        else
+        {
+            // set everything to xt.particles.LAST_INVALID_STATE = -999999999
+            NormalizedParticlesData_set_x_norm(norm_part, ii, -999999999.);
+            NormalizedParticlesData_set_px_norm(norm_part, ii, -999999999.);
+            NormalizedParticlesData_set_y_norm(norm_part, ii, -999999999.);
+            NormalizedParticlesData_set_py_norm(norm_part, ii, -999999999.);
+            NormalizedParticlesData_set_zeta_norm(norm_part, ii, -999999999.);
+            NormalizedParticlesData_set_pzeta_norm(norm_part, ii, -999999999.);
+        }
+        // also copy the particle_id, state, at_turn and at_element
+        NormalizedParticlesData_set_particle_id(
+            norm_part, ii, ParticlesData_get_particle_id(part, ii));
+        NormalizedParticlesData_set_state(
+            norm_part, ii, ParticlesData_get_state(part, ii));
+        NormalizedParticlesData_set_at_turn(
+            norm_part, ii, ParticlesData_get_at_turn(part, ii));
+        NormalizedParticlesData_set_at_element(
+            norm_part, ii, ParticlesData_get_at_element(part, ii));
+    } // end_vectorize
+}
+
+#endif /* XNLBD_PHYS_TO_NORM_H */

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -4,6 +4,9 @@
 # ######################################### #
 
 import logging
+from pathlib import Path
+from typing import Optional
+from warnings import warn
 
 import io
 import json
@@ -15,6 +18,7 @@ from scipy.constants import epsilon_0
 from scipy.constants import e as qe
 from scipy.special import factorial
 from scipy.constants import electron_volt
+import xobjects as xo
 
 if hasattr(np, 'trapezoid'): # numpy >= 2.0
     trapz = np.trapezoid
@@ -3213,66 +3217,71 @@ class TwissTable(Table):
         return Table(out_dct)
 
     def get_normalized_coordinates(self, particles, nemitt_x=None, nemitt_y=None,
-                                   nemitt_zeta=None, _force_at_element=None):
-
+                                   nemitt_zeta=None, _force_at_element=None,
+                                  _evaluate_in_context=False):
         # TODO: check consistency of gamma0
+        if not _evaluate_in_context:
+            ctx2np = particles._context.nparray_from_context_array
+            at_element_particles = ctx2np(particles.at_element)
 
-        ctx2np = particles._context.nparray_from_context_array
-        at_element_particles = ctx2np(particles.at_element)
+            part_id = ctx2np(particles.particle_id).copy()
+            at_element = part_id.copy() * 0 + xt.particles.LAST_INVALID_STATE
+            x_norm = ctx2np(particles.x).copy() * 0 + xt.particles.LAST_INVALID_STATE
+            px_norm = x_norm.copy()
+            y_norm = x_norm.copy()
+            py_norm = x_norm.copy()
+            zeta_norm = x_norm.copy()
+            pzeta_norm = x_norm.copy()
 
-        part_id = ctx2np(particles.particle_id).copy()
-        at_element = part_id.copy() * 0 + xt.particles.LAST_INVALID_STATE
-        x_norm = ctx2np(particles.x).copy() * 0 + xt.particles.LAST_INVALID_STATE
-        px_norm = x_norm.copy()
-        y_norm = x_norm.copy()
-        py_norm = x_norm.copy()
-        zeta_norm = x_norm.copy()
-        pzeta_norm = x_norm.copy()
+            at_element_no_rep = list(set(
+                at_element_particles[part_id > xt.particles.LAST_INVALID_STATE]))
 
-        at_element_no_rep = list(set(
-            at_element_particles[part_id > xt.particles.LAST_INVALID_STATE]))
+            for at_ele in at_element_no_rep:
 
-        for at_ele in at_element_no_rep:
+                if _force_at_element is not None:
+                    at_ele = _force_at_element
 
-            if _force_at_element is not None:
-                at_ele = _force_at_element
+                W = self.W_matrix[at_ele]
 
-            W = self.W_matrix[at_ele]
+                mask_at_ele = at_element_particles == at_ele
 
-            mask_at_ele = at_element_particles == at_ele
-
-            if _force_at_element is not None:
-                mask_at_ele = ctx2np(particles.state) > xt.particles.LAST_INVALID_STATE
+                if _force_at_element is not None:
+                    mask_at_ele = ctx2np(particles.state) > xt.particles.LAST_INVALID_STATE
 
 
-            XX_norm  = _W_phys2norm(x = ctx2np(particles.x)[mask_at_ele],
-                                    px = ctx2np(particles.px)[mask_at_ele],
-                                    y = ctx2np(particles.y)[mask_at_ele],
-                                    py = ctx2np(particles.py)[mask_at_ele],
-                                    zeta = ctx2np(particles.zeta)[mask_at_ele],
-                                    pzeta = ctx2np(particles.ptau)[mask_at_ele]/ctx2np(particles.beta0)[mask_at_ele],
-                                    W_matrix = W,
-                                    co_dict = {'x': self.x[at_ele], 'px': self.px[at_ele],
-                                               'y': self.y[at_ele], 'py': self.py[at_ele],
-                                               'zeta': self.zeta[at_ele], 'ptau': self.ptau[at_ele],
-                                               'beta0': self.particle_on_co._xobject.beta0[0],
-                                               'gamma0': self.particle_on_co._xobject.gamma0[0]},
-                                    nemitt_x = nemitt_x,
-                                    nemitt_y = nemitt_y,
-                                    nemitt_zeta = nemitt_zeta)
+                XX_norm  = _W_phys2norm(x = ctx2np(particles.x)[mask_at_ele],
+                                        px = ctx2np(particles.px)[mask_at_ele],
+                                        y = ctx2np(particles.y)[mask_at_ele],
+                                        py = ctx2np(particles.py)[mask_at_ele],
+                                        zeta = ctx2np(particles.zeta)[mask_at_ele],
+                                        pzeta = ctx2np(particles.ptau)[mask_at_ele]/ctx2np(particles.beta0)[mask_at_ele],
+                                        W_matrix = W,
+                                        co_dict = {'x': self.x[at_ele], 'px': self.px[at_ele],
+                                                'y': self.y[at_ele], 'py': self.py[at_ele],
+                                                'zeta': self.zeta[at_ele], 'ptau': self.ptau[at_ele],
+                                                'beta0': self.particle_on_co._xobject.beta0[0],
+                                                'gamma0': self.particle_on_co._xobject.gamma0[0]},
+                                        nemitt_x = nemitt_x,
+                                        nemitt_y = nemitt_y,
+                                        nemitt_zeta = nemitt_zeta)
 
-            x_norm[mask_at_ele] = XX_norm[0, :]
-            px_norm[mask_at_ele] = XX_norm[1, :]
-            y_norm[mask_at_ele] = XX_norm[2, :]
-            py_norm[mask_at_ele] = XX_norm[3, :]
-            zeta_norm[mask_at_ele] = XX_norm[4, :]
-            pzeta_norm[mask_at_ele] = XX_norm[5, :]
-            at_element[mask_at_ele] = at_ele
+                x_norm[mask_at_ele] = XX_norm[0, :]
+                px_norm[mask_at_ele] = XX_norm[1, :]
+                y_norm[mask_at_ele] = XX_norm[2, :]
+                py_norm[mask_at_ele] = XX_norm[3, :]
+                zeta_norm[mask_at_ele] = XX_norm[4, :]
+                pzeta_norm[mask_at_ele] = XX_norm[5, :]
+                at_element[mask_at_ele] = at_ele
 
-        return Table({'particle_id': part_id, 'at_element': at_element,
-                      'x_norm': x_norm, 'px_norm': px_norm, 'y_norm': y_norm,
-                      'py_norm': py_norm, 'zeta_norm': zeta_norm,
-                      'pzeta_norm': pzeta_norm}, index='particle_id')
+            return Table({'particle_id': part_id, 'at_element': at_element,
+                        'x_norm': x_norm, 'px_norm': px_norm, 'y_norm': y_norm,
+                        'py_norm': py_norm, 'zeta_norm': zeta_norm,
+                        'pzeta_norm': pzeta_norm}, index='particle_id')
+        else:
+            return NormalizedParticles._get_normalized_coordinates(
+                self, part=particles, nemitt_x=nemitt_x, nemitt_y=nemitt_y,
+                nemitt_zeta=nemitt_zeta, _force_at_element=_force_at_element)
+            
 
     def reverse(self):
 
@@ -4179,3 +4188,433 @@ def _add_strengths_to_twiss_res(twiss_res, line):
         twiss_res._data[kk] = tt[kk].copy()
 
 
+class NormalizedParticles(xo.HybridClass):
+    """Class to store particles in normalized coordinates, with the possibility
+    of transforming to and from physical coordinates without the need of breaking
+    GPU parallelism. Can be used in collective elements and other HybridClass
+    elements to perform normalizations and de-normalizations in parallel.
+    """
+
+    _cname = "NormalizedParticlesData"
+
+    size_vars = (
+        (xo.Int64, "_len"),
+        (xo.Int64, "_capacity"),
+        (xo.Int64, "_start_tracking_at_element"),
+    )
+
+    twiss_vars = (
+        (xo.Float64[:, 6], "closed_orbit_data"),
+        (xo.Float64[:, 6, 6], "w"),
+        (xo.Float64[:, 6, 6], "w_inv"),
+        (xo.Float64, "nemitt_x"),
+        (xo.Float64, "nemitt_y"),
+        (xo.Float64, "nemitt_zeta"),
+        (xo.Int64, "force_at_element"),
+        (xo.Int64, "num_elements"),
+    )
+
+    per_particle_vars = (
+        (xo.Float64, "zeta_norm"),
+        (xo.Float64, "pzeta_norm"),
+        (xo.Float64, "x_norm"),
+        (xo.Float64, "y_norm"),
+        (xo.Float64, "px_norm"),
+        (xo.Float64, "py_norm"),
+        (xo.Int64, "particle_id"),
+        (xo.Int64, "state"),
+        (xo.Int64, "at_element"),
+        (xo.Int64, "at_turn"),
+    )
+
+    _xofields = {
+        **{nn: tt for tt, nn in size_vars},
+        **{nn: tt for tt, nn in twiss_vars},
+        **{nn: tt[:] for tt, nn in per_particle_vars},
+    }
+
+    _extra_c_sources = [
+        Path(__file__).parent.joinpath(
+            "particles", "normalized_particles_src", "norm_to_phys.h"
+        ),
+        Path(__file__).parent.joinpath(
+            "particles", "normalized_particles_src", "phys_to_norm.h"
+        ),
+    ]
+
+    _kernels = {
+        "norm_to_phys": xo.Kernel(
+            args=[
+                xo.Arg(xt.Particles._XoStruct, name="part"),
+                xo.Arg(xo.ThisClass, name="norm_part"),
+                xo.Arg(xo.Int64, name="nelem"),
+            ],
+            n_threads="nelem",
+        ),
+        "phys_to_norm": xo.Kernel(
+            args=[
+                xo.Arg(xt.Particles._XoStruct, name="part"),
+                xo.Arg(xo.ThisClass, name="norm_part"),
+                xo.Arg(xo.Int64, name="nelem"),
+            ],
+            n_threads="nelem",
+        ),
+    }
+
+    _depends_on = [xt.Particles]
+
+    def __len__(self):
+        return self._capacity
+
+    def __init__(
+        self,
+        twiss: TwissTable,
+        part: Optional[xt.Particles] = None,
+        nemitt_x: Optional[float] = None,
+        nemitt_y: Optional[float] = None,
+        nemitt_zeta: Optional[float] = None,
+        _force_at_element: Optional[int] = None,
+        _capacity: Optional[int] = None,
+        _context=None,
+        **kwargs,
+    ):
+        """Initialize the NormedParticles object.
+
+        Parameters
+        ----------
+        twiss : xtrack.TwissTable
+            Twiss table of the line to be used for the normalization.
+        part : _type_, optional
+            Particle object to be used as base, by default None
+        nemitt_x : float
+            Normalized emittance in the horizontal plane.
+        nemitt_y : float
+            Normalized emittance in the vertical plane.
+        nemitt_zeta : float, optional
+            Normalized emittance in the longitudinal plane, by default None.
+            If None, a unitary emittance is assumed.
+        _force_at_element : int, optional
+            Index to the fixed element wanted for the normalization, by default None.
+            If None, all the twiss data is used and normalization is done at the
+            "_force_at_element" position of each particle.
+        _capacity : int, optional
+            If no part is given, a storage of size _capacity is allocated.
+        _context : xo.Context, optional
+            xobjects context to be used.
+
+        Raises
+        ------
+        ValueError
+            If neither part nor _capacity is given.
+        """
+        if "_xobject" in kwargs.keys():
+            # Initialize xobject
+            self.xoinitialize(**kwargs)
+            return
+
+        # validate _capacity, is it given or is it to be taken from part?
+        if part is not None:
+            _capacity = part._capacity
+            if _context is not None:
+                if _context != part._context:
+                    raise ValueError(
+                        "The context of the part and the context of the "
+                        "NormalizedParticles object must be the same"
+                    )
+            else:
+                _context = part._context
+        else:
+            if _capacity is None:
+                raise ValueError("Either part or _capacity must be given")
+            if _context is None:
+                raise ValueError("The context must be given if no part is given")
+
+        twiss_data_len = twiss.x.shape[0] if _force_at_element is None else 1
+
+        # Allocate the xobject of the right size
+        self.xoinitialize(
+            _context=_context,
+            _buffer=kwargs.pop("_buffer", None),
+            _offset=kwargs.pop("_offset", None),
+            **{field: _capacity for _, field in self.per_particle_vars},
+            **{
+                "closed_orbit_data": twiss_data_len,
+                "w": twiss_data_len,
+                "w_inv": twiss_data_len,
+            },
+        )
+
+        self._capacity = _capacity
+        self.num_elements = twiss_data_len
+
+        # Get the twiss data for the given twiss object and the given
+        # normalized emittance values
+        self.closed_orbit_data = self._context.nparray_to_context_array(
+            np.array(
+                [
+                    twiss.x,
+                    twiss.px,
+                    twiss.y,
+                    twiss.py,
+                    twiss.zeta,
+                    twiss.ptau,
+                ]
+            ).T
+        )
+
+        self.nemitt_x = np.nan if nemitt_y is None else nemitt_x
+        self.nemitt_y = np.nan if nemitt_x is None else nemitt_y
+        self.nemitt_zeta = np.nan if nemitt_zeta is None else nemitt_zeta
+
+        self.force_at_element = -1 if _force_at_element is None else _force_at_element
+
+        if _force_at_element is not None:
+            self.w = self._context.nparray_to_context_array(
+                np.array(twiss.W_matrix[_force_at_element])
+            )
+            self.w_inv = self._context.nparray_to_context_array(
+                np.linalg.inv(twiss.W_matrix[_force_at_element])
+            )
+        else:
+            self.w = self._context.nparray_to_context_array(
+                [www for www in twiss.W_matrix]
+            )
+            self.w_inv = self._context.nparray_to_context_array(
+                [np.linalg.inv(www) for www in twiss.W_matrix]
+            )
+
+        self.compile_kernels(only_if_needed=True)
+
+        if part is not None:
+            self.phys_to_norm(part=part)
+
+    def phys_to_norm(
+        self,
+        part: xt.Particles,
+        nemitt_x: Optional[float] = None,
+        nemitt_y: Optional[float] = None,
+        nemitt_zeta: Optional[float] = None,
+    ):
+        """Transform the physical coordinates to normalized coordinates.
+        Updates the normed_part attribute.
+
+        Parameters
+        ----------
+        part : xtrack.Particles
+            Particles object to be normalized.
+        nemitt_x : float, optional
+            Normalized emittance in the horizontal plane, by default None.
+            If None, the value in the object is used. If provided, it will
+            override the value in the object.
+        nemitt_y : float, optional
+            Normalized emittance in the vertical plane, by default None.
+            If None, the value in the object is used. If provided, it will
+            override the value in the object.
+        nemitt_zeta : float, optional
+            Normalized emittance in the longitudinal plane, by default None.
+            If None, the value in the object is used. If provided, it will
+            override the value in the object.
+
+        """
+        if nemitt_x is not None:
+            self.nemitt_x = nemitt_x
+        if nemitt_y is not None:
+            self.nemitt_y = nemitt_y
+        if nemitt_zeta is not None:
+            self.nemitt_zeta = nemitt_zeta
+
+        if self._capacity != part._capacity:
+            raise NotImplementedError(
+                "Dynamically resizing the xobject is not implemented yet, consider "
+                "recreating the NormalizedParticles object with the new size"
+            )
+        self._context.kernels.phys_to_norm(
+            part=part,
+            norm_part=self,
+            nelem=self._capacity,
+        )
+
+    def norm_to_phys(
+        self,
+        part: xt.Particles,
+        nemitt_x: Optional[float] = None,
+        nemitt_y: Optional[float] = None,
+        nemitt_zeta: Optional[float] = None,
+    ):
+        """Transform the normalized coordinates to physical coordinates.
+        Updates the given Particles object.
+
+        Parameters
+        ----------
+        part : xtrack.Particles
+            Target particles object to receive the physical coordinates.
+        nemitt_x : float, optional
+            Normalized emittance in the horizontal plane, by default None.
+            If None, the value in the object is used. If provided, it will
+            override the value in the object.
+        nemitt_y : float, optional
+            Normalized emittance in the vertical plane, by default None.
+            If None, the value in the object is used. If provided, it will
+            override the value in the object.
+        nemitt_zeta : float, optional
+            Normalized emittance in the longitudinal plane, by default None.
+            If None, the value in the object is used. If provided, it will
+            override the value in the object.
+
+        Returns
+        -------
+        xtrack.Particles
+            The given particle object with physical coordinates updated.
+        """
+
+        if nemitt_x is not None:
+            self.nemitt_x = nemitt_x
+        if nemitt_y is not None:
+            self.nemitt_y = nemitt_y
+        if nemitt_zeta is not None:
+            self.nemitt_zeta = nemitt_zeta
+
+        self._context.kernels.norm_to_phys(
+            part=part,
+            norm_part=self,
+            nelem=self._capacity,
+        )
+
+        return part
+
+    def get_normalized_coordinates(
+        self,
+        part: Optional[xt.Particles] = None,
+        nemitt_x: Optional[float] = None,
+        nemitt_y: Optional[float] = None,
+        nemitt_zeta: Optional[float] = None,
+    ):
+        """Get the normalized coordinates of the particles in a Table.
+
+        Parameters
+        ----------
+        update : bool, optional
+            If True, the normalized coordinates are updated, by default True.
+        part : xtrack.Particles, optional
+            Particles object to be used, by default None.
+        nemitt_x : float, optional
+            Normalized emittance in the horizontal plane, by default None.
+            If None, the value in the object is used. If provided, it will
+            override the value in the object.
+        nemitt_y : float, optional
+            Normalized emittance in the vertical plane, by default None.
+            If None, the value in the object is used. If provided, it will
+            override the value in the object.
+        nemitt_zeta : float, optional
+            Normalized emittance in the longitudinal plane, by default None.
+            If None, the value in the object is used. If provided, it will
+            override the value in the object.
+
+        Returns
+        -------
+        Table
+            Table object with the normalized coordinates.
+        """
+        if part is not None:
+            if part._capacity != self._capacity:
+                raise NotImplementedError(
+                    "Dynamically resizing the xobject is not implemented yet"
+                )
+            if nemitt_x is not None:
+                self.nemitt_x = nemitt_x
+            if nemitt_y is not None:
+                self.nemitt_y = nemitt_y
+            if nemitt_zeta is not None:
+                self.nemitt_zeta = nemitt_zeta
+
+            self.phys_to_norm(part=part)
+        else:
+            if any([
+                nemitt_x is not None,
+                nemitt_y is not None,
+                nemitt_zeta is not None,
+            ]):
+                raise ValueError(
+                    "If no part is given, nemitt_x, nemitt_y and nemitt_zeta "
+                    "must be None"
+                )
+
+        ctx2np = self._context.nparray_from_context_array
+
+        return Table(
+            {
+                "particle_id": ctx2np(self.particle_id),
+                "at_element": ctx2np(self.at_element),
+                "at_turn": ctx2np(self.at_turn),
+                "x_norm": ctx2np(self.x_norm),
+                "px_norm": ctx2np(self.px_norm),
+                "y_norm": ctx2np(self.y_norm),
+                "py_norm": ctx2np(self.py_norm),
+                "zeta_norm": ctx2np(self.zeta_norm),
+                "pzeta_norm": ctx2np(self.pzeta_norm),
+            },
+            index="particle_id",
+        )
+
+    @classmethod
+    def _get_normalized_coordinates(
+        cls,
+        twiss: TwissTable,
+        part: xt.Particles,
+        nemitt_x: Optional[float] = None,
+        nemitt_y: Optional[float] = None,
+        nemitt_zeta: Optional[float] = None,
+        _force_at_element: Optional[int] = None,
+    ) -> Table:
+        """Helper classmethod to get normalized coordinates in a Table.
+
+        Parameters
+        ----------
+        twiss : xtrack.TwissTable
+            Twiss table of the line to be used for the normalization.
+        part : xtrack.Particles
+            Particles object to be used as base.
+        nemitt_x : float, optional
+            Normalized emittance in the horizontal plane. By default None.
+            If None, a unitary emittance is assumed.
+        nemitt_y : float, optional
+            Normalized emittance in the vertical plane. By default None.
+            If None, a unitary emittance is assumed.
+        nemitt_zeta : float, optional
+            Normalized emittance in the longitudinal plane, by default None.
+            If None, a unitary emittance is assumed.
+        _force_at_element : int, optional
+            Index to the fixed element wanted for the normalization, by default None.
+            If None, all the twiss data is used and normalization is done at the
+            "_force_at_element" position of each particle.
+
+        Returns
+        -------
+        Table
+            Table object with the normalized coordinates.
+        """
+        norm_part = cls(
+            twiss=twiss,
+            part=part,
+            nemitt_x=nemitt_x,
+            nemitt_y=nemitt_y,
+            nemitt_zeta=nemitt_zeta,
+            _force_at_element=_force_at_element,
+        )
+
+        ctx2np = norm_part._context.nparray_from_context_array
+
+        return Table(
+            {
+                "particle_id": ctx2np(norm_part.particle_id),
+                "at_element": ctx2np(norm_part.at_element),
+                "at_turn": ctx2np(norm_part.at_turn),
+                "x_norm": ctx2np(norm_part.x_norm),
+                "px_norm": ctx2np(norm_part.px_norm),
+                "y_norm": ctx2np(norm_part.y_norm),
+                "py_norm": ctx2np(norm_part.py_norm),
+                "zeta_norm": ctx2np(norm_part.zeta_norm),
+                "pzeta_norm": ctx2np(norm_part.pzeta_norm),
+            },
+            index="particle_id",
+        )


### PR DESCRIPTION
- Introduced NormalizedParticles class to handle transformations between physical and normalized coordinates efficiently.
- Implemented norm_to_phys and phys_to_norm methods for converting particle data.
- Updated TwissTable to include methods for obtaining normalized coordinates based on the new HybridClass.
- Modified get_normalized_coordinates method to support both direct and context-based evaluations.
- Added tests for NormalizedParticles in xtrack/tests/test_twiss.py

## Description
NormalizedParticles enables the conversion to and from Twiss normalized coordinates directly on a xobjects context. This HybridClass can then be used for specific applications where a user may want to perform multiple coordinate conversions without breaking GPU parallelism (e.g. chaos indicators evaluations via ghost particle tracking, where re-normalization on normalized coordinates is required).

Future developments may consider the extension of this object as a beam element, in order to avoid the need to break a tracking action.

Closes # .

## Checklist

Mandatory: 

- [ x ] I have added tests to cover my changes
- [ x ] All the tests are passing, including my new ones
- [ x ] I described my changes in this PR description

Optional:

- [ x ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ x ] I have tested also GPU contexts
