### PR TITLE
feat: trajectory correction with bounds

### DIFF
--- a/tests/test_trajectory_correcton.py
+++ b/tests/test_trajectory_correcton.py
@@ -567,8 +567,8 @@ def test_orbit_correction_with_bounds():
     tw_before = line.twiss4d()
 
     # Define bounds for correctors (in radians)
-    bounds_x = (-1e-6, 1e-6)  # 200 nrad
-    bounds_y = (-1e-6, 1e-6)  # 200 nrad
+    bounds_x = (-1e-6, 1e-6)  # 1 urad
+    bounds_y = (-1e-6, 1e-6)  # 1 urad
 
     # Orbit correction without bounds as reference
     orbit_correction_basic_no_bounds = line.correct_trajectory(twiss_table=tw_ref)

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -155,6 +155,8 @@ class Line:
         self._extra_config['steering_monitors_y'] = None
         self._extra_config['steering_correctors_x'] = None
         self._extra_config['steering_correctors_y'] = None
+        self._extra_config['corrector_bounds_x'] = None
+        self._extra_config['corrector_bounds_y'] = None
 
         if env is None:
             env = xt.Environment()
@@ -1575,8 +1577,8 @@ class Line:
                  monitor_names_x=None, corrector_names_x=None,
                  monitor_names_y=None, corrector_names_y=None,
                  n_micado=None, n_singular_values=None, rcond=None,
-                 monitor_alignment=None,
-                 ):
+                 monitor_alignment=None, corrector_bounds_x=None,
+                 corrector_bounds_y=None):
 
         '''
         Correct the beam trajectory using linearized response matrix from optics
@@ -1627,6 +1629,14 @@ class Line:
         rcond : float
             Cutoff for small singular values (relative to the largest singular
             value). Singular values smaller than `rcond` are considered zero.
+        corrector_bounds_x : tuple of array-like or None
+            Bounds for the horizontal corrector strengths. If not None, it should be a tuple
+            of two arrays (lower_bounds, upper_bounds) with the same length as
+            the number of horizontal correctors. If None, no bounds are applied.
+        corrector_bounds_y : tuple of array-like or None
+            Bounds for the vertical corrector strengths. If not None, it should be a tuple
+            of two arrays (lower_bounds, upper_bounds) with the same length as
+            the number of vertical correctors. If None, no bounds are applied.
 
         Returns
         -------
@@ -1643,7 +1653,9 @@ class Line:
                  corrector_names_y=corrector_names_y,
                  n_micado=n_micado, n_singular_values=n_singular_values,
                  rcond=rcond,
-                 monitor_alignment=monitor_alignment)
+                 monitor_alignment=monitor_alignment,
+                 corrector_bounds_x=corrector_bounds_x,
+                 corrector_bounds_y=corrector_bounds_y)
 
         if run:
             correction.correct(planes=planes, n_iter=n_iter)
@@ -4584,6 +4596,22 @@ class Line:
     @steering_correctors_y.setter
     def steering_correctors_y(self, value):
         self._extra_config['steering_correctors_y'] = value
+
+    @property
+    def corrector_bounds_x(self):
+        return self._extra_config.get('corrector_bounds_x', None)
+
+    @corrector_bounds_x.setter
+    def corrector_bounds_x(self, value):
+        self._extra_config['corrector_bounds_x'] = value
+
+    @property
+    def corrector_bounds_y(self):
+        return self._extra_config.get('corrector_bounds_y', None)
+
+    @corrector_bounds_y.setter
+    def corrector_bounds_y(self, value):
+        self._extra_config['corrector_bounds_y'] = value
 
     def __getitem__(self, key):
         if np.issubdtype(key.__class__, np.integer):

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -155,8 +155,8 @@ class Line:
         self._extra_config['steering_monitors_y'] = None
         self._extra_config['steering_correctors_x'] = None
         self._extra_config['steering_correctors_y'] = None
-        self._extra_config['corrector_bounds_x'] = None
-        self._extra_config['corrector_bounds_y'] = None
+        self._extra_config['corrector_limits_x'] = None
+        self._extra_config['corrector_limits_y'] = None
 
         if env is None:
             env = xt.Environment()
@@ -1577,8 +1577,8 @@ class Line:
                  monitor_names_x=None, corrector_names_x=None,
                  monitor_names_y=None, corrector_names_y=None,
                  n_micado=None, n_singular_values=None, rcond=None,
-                 monitor_alignment=None, corrector_bounds_x=None,
-                 corrector_bounds_y=None):
+                 monitor_alignment=None, corrector_limits_x=None,
+                 corrector_limits_y=None):
 
         '''
         Correct the beam trajectory using linearized response matrix from optics
@@ -1629,14 +1629,14 @@ class Line:
         rcond : float
             Cutoff for small singular values (relative to the largest singular
             value). Singular values smaller than `rcond` are considered zero.
-        corrector_bounds_x : tuple of array-like or None
-            Bounds for the horizontal corrector strengths. If not None, it should be a tuple
-            of two arrays (lower_bounds, upper_bounds) with the same length as
-            the number of horizontal correctors. If None, no bounds are applied.
-        corrector_bounds_y : tuple of array-like or None
-            Bounds for the vertical corrector strengths. If not None, it should be a tuple
-            of two arrays (lower_bounds, upper_bounds) with the same length as
-            the number of vertical correctors. If None, no bounds are applied.
+        corrector_limits_x : tuple of array-like or None
+            Limits for the horizontal corrector strengths. If not None, it should be a tuple
+            of two arrays (lower_limits, upper_limits) with the same length as
+            the number of horizontal correctors. If None, no limits are applied.
+        corrector_limits_y : tuple of array-like or None
+            Limits for the vertical corrector strengths. If not None, it should be a tuple
+            of two arrays (lower_limits, upper_limits) with the same length as
+            the number of vertical correctors. If None, no limits are applied.
 
         Returns
         -------
@@ -1654,8 +1654,8 @@ class Line:
                  n_micado=n_micado, n_singular_values=n_singular_values,
                  rcond=rcond,
                  monitor_alignment=monitor_alignment,
-                 corrector_bounds_x=corrector_bounds_x,
-                 corrector_bounds_y=corrector_bounds_y)
+                 corrector_limits_x=corrector_limits_x,
+                 corrector_limits_y=corrector_limits_y)
 
         if run:
             correction.correct(planes=planes, n_iter=n_iter)
@@ -4598,20 +4598,20 @@ class Line:
         self._extra_config['steering_correctors_y'] = value
 
     @property
-    def corrector_bounds_x(self):
-        return self._extra_config.get('corrector_bounds_x', None)
+    def corrector_limits_x(self):
+        return self._extra_config.get('corrector_limits_x', None)
 
-    @corrector_bounds_x.setter
-    def corrector_bounds_x(self, value):
-        self._extra_config['corrector_bounds_x'] = value
+    @corrector_limits_x.setter
+    def corrector_limits_x(self, value):
+        self._extra_config['corrector_limits_x'] = value
 
     @property
-    def corrector_bounds_y(self):
-        return self._extra_config.get('corrector_bounds_y', None)
+    def corrector_limits_y(self):
+        return self._extra_config.get('corrector_limits_y', None)
 
-    @corrector_bounds_y.setter
-    def corrector_bounds_y(self, value):
-        self._extra_config['corrector_bounds_y'] = value
+    @corrector_limits_y.setter
+    def corrector_limits_y(self, value):
+        self._extra_config['corrector_limits_y'] = value
 
     def __getitem__(self, key):
         if np.issubdtype(key.__class__, np.integer):

--- a/xtrack/trajectory_correction.py
+++ b/xtrack/trajectory_correction.py
@@ -2,6 +2,10 @@ import numpy as np
 from scipy.optimize import lsq_linear
 import xtrack as xt
 
+import logging
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
+
 def _compute_correction(x_iter, response_matrix, n_micado=None, rcond=None,
                         n_singular_values=None, corrector_bounds=None):
 
@@ -45,7 +49,8 @@ def _compute_correction(x_iter, response_matrix, n_micado=None, rcond=None,
                     active_bounds = (corrector_bounds[0][mask_corr], corrector_bounds[1][mask_corr])
                     result = lsq_linear(response_matrix[:, mask_corr], -x_iter, 
                                       bounds=active_bounds)
-                    assert result.success, result.message
+                    if not result.success:
+                        logger.warning(f'Bounded Least Squares warning: {result.message}')
                     residual_x = np.array([result.cost])
                 residuals.append(residual_x[0])
             used_correctors.append(np.nanargmin(residuals))
@@ -73,7 +78,8 @@ def _compute_correction(x_iter, response_matrix, n_micado=None, rcond=None,
             active_bounds = (corrector_bounds[0][mask_corr], corrector_bounds[1][mask_corr])
             result = lsq_linear(response_matrix[:, mask_corr], -x_iter, 
                               bounds=active_bounds)
-            assert result.success, result.message
+            if not result.success:
+                logger.warning(f'Bounded Least Squares warning: {result.message}')
             correction_masked = result.x
 
     correction_x = np.zeros(n_hcorrectors)

--- a/xtrack/trajectory_correction.py
+++ b/xtrack/trajectory_correction.py
@@ -1,8 +1,9 @@
 import numpy as np
+from scipy.optimize import lsq_linear
 import xtrack as xt
 
 def _compute_correction(x_iter, response_matrix, n_micado=None, rcond=None,
-                        n_singular_values=None):
+                        n_singular_values=None, corrector_bounds=None):
 
     if isinstance(response_matrix, (list, tuple)):
         assert len(response_matrix) == 3 # U, S, Vt
@@ -36,8 +37,16 @@ def _compute_correction(x_iter, response_matrix, n_micado=None, rcond=None,
                     mask_corr[i_used] = True
 
                 # Compute the correction with least squares
-                _, residual_x, rank_x, sval_x = np.linalg.lstsq(
-                            response_matrix[:, mask_corr], -x_iter, rcond=rcond)
+                if corrector_bounds is None:
+                    _, residual_x, rank_x, sval_x = np.linalg.lstsq(
+                                response_matrix[:, mask_corr], -x_iter, rcond=rcond)
+                else:
+                    # Apply bounds only to the active correctors
+                    active_bounds = (corrector_bounds[0][mask_corr], corrector_bounds[1][mask_corr])
+                    result = lsq_linear(response_matrix[:, mask_corr], -x_iter, 
+                                      bounds=active_bounds)
+                    assert result.success, result.message
+                    residual_x = np.array([result.cost])
                 residuals.append(residual_x[0])
             used_correctors.append(np.nanargmin(residuals))
 
@@ -48,16 +57,25 @@ def _compute_correction(x_iter, response_matrix, n_micado=None, rcond=None,
         mask_corr[:] = True
 
     # Compute the correction with least squares
-    if mask_corr.all() and S is not None:
-        # Can reuse the SVD decomposition
+    if mask_corr.all() and S is not None and corrector_bounds is None:
+        # Can reuse the SVD decomposition only for unbounded case
         S_inv = np.zeros_like(S)
         S_inv[S > 0] = 1 / S[S > 0]
         if rcond is not None:
             S_inv[S < rcond * S[0]] = 0
         correction_masked = Vh.T.conj() @ (np.diag(S_inv) @ (U.T.conj() @ (-x_iter)))
     else:
-        correction_masked, residual_x, rank_x, sval_x = np.linalg.lstsq(
-                    response_matrix[:, mask_corr], -x_iter, rcond=rcond)
+        if corrector_bounds is None:
+            correction_masked, residual_x, rank_x, sval_x = np.linalg.lstsq(
+                        response_matrix[:, mask_corr], -x_iter, rcond=rcond)
+        else:
+            # Apply bounds only to the active correctors
+            active_bounds = (corrector_bounds[0][mask_corr], corrector_bounds[1][mask_corr])
+            result = lsq_linear(response_matrix[:, mask_corr], -x_iter, 
+                              bounds=active_bounds)
+            assert result.success, result.message
+            correction_masked = result.x
+
     correction_x = np.zeros(n_hcorrectors)
     correction_x[mask_corr] = correction_masked
 
@@ -104,7 +122,7 @@ class OrbitCorrectionSinglePlane:
 
     def __init__(self, line, plane, monitor_names, corrector_names,
                  start=None, end=None, twiss_table=None, n_micado=None,
-                 n_singular_values=None, rcond=None,
+                 n_singular_values=None, rcond=None, corrector_bounds=None,
                  x_init=0, px_init=0, y_init=0, py_init=0, zeta_init=0, delta_init=0,
                  monitor_alignment=None):
 
@@ -161,8 +179,16 @@ class OrbitCorrectionSinglePlane:
             else:
                 monitor_names = monitor_names
 
+        if corrector_bounds is None:
+            corrector_bounds = getattr(line, f'corrector_bounds_{plane}')
+
         assert len(monitor_names) > 0
         assert len(corrector_names) > 0
+
+        if corrector_bounds is not None:
+            assert len(corrector_bounds) == 2
+            assert len(corrector_bounds[0]) == len(corrector_bounds[1])
+            assert len(corrector_bounds[0]) == len(corrector_names)
 
         self.line = line
         self.plane = plane
@@ -173,6 +199,7 @@ class OrbitCorrectionSinglePlane:
         self.n_micado = n_micado
         self.rcond = rcond
         self.n_singular_values = n_singular_values
+        self.corrector_bounds = corrector_bounds
 
         self.response_matrix = _build_response_matrix(plane=self.plane,
             tw=self.twiss_table, monitor_names=self.monitor_names,
@@ -208,7 +235,8 @@ class OrbitCorrectionSinglePlane:
         self._add_correction_knobs()
 
     def correct(self, n_iter='auto', n_micado=None, n_singular_values=None,
-                rcond=None, stop_iter_factor=0.1, verbose=True, _tw_orbit=None):
+                rcond=None, stop_iter_factor=0.1, verbose=True, _tw_orbit=None,
+                corrector_bounds=None):
 
         if _tw_orbit is not None and n_iter !=1:
             raise ValueError('`_tw_orbit` can only be used with `n_iter=1`')
@@ -219,6 +247,7 @@ class OrbitCorrectionSinglePlane:
             assert stop_iter_factor < 1
 
         pos_rms_prev = 0
+        relative_bounds = corrector_bounds
 
         i_iter = 0
         while True:
@@ -242,12 +271,18 @@ class OrbitCorrectionSinglePlane:
 
             correction = self._compute_correction(position=position,
                                     n_micado=n_micado, rcond=rcond,
-                                    n_singular_values=n_singular_values)
+                                    n_singular_values=n_singular_values,
+                                    corrector_bounds=relative_bounds)
             self._apply_correction(correction)
 
             i_iter += 1
             if n_iter != 'auto' and i_iter >= n_iter:
                 break
+
+            if corrector_bounds is not None:
+                current_correction = self.get_kick_values()
+                relative_bounds = (corrector_bounds[0] - current_correction,
+                                         corrector_bounds[1] - current_correction)
 
         if _tw_orbit is None:
             position = self._measure_position()
@@ -292,7 +327,7 @@ class OrbitCorrectionSinglePlane:
         return position
 
     def _compute_correction(self, position, n_micado=None,
-                            n_singular_values=None, rcond=None):
+                            n_singular_values=None, rcond=None, corrector_bounds=None):
 
         if rcond is None:
             rcond = self.rcond
@@ -303,10 +338,11 @@ class OrbitCorrectionSinglePlane:
         if n_micado is None:
             n_micado = self.n_micado
 
+
         correction = _compute_correction(position,
             response_matrix=(self.singular_vectors_out, self.singular_values, self.singular_vectors_in),
             n_micado=n_micado,
-            rcond=rcond, n_singular_values=n_singular_values)
+            rcond=rcond, n_singular_values=n_singular_values, corrector_bounds=corrector_bounds)
 
         return correction
 
@@ -375,7 +411,8 @@ class TrajectoryCorrection:
                  monitor_names_y=None, corrector_names_y=None,
                  monitor_alignment=None,
                  x_init=0, px_init=0, y_init=0, py_init=0, zeta_init=0, delta_init=0,
-                 n_micado=None, n_singular_values=None, rcond=None):
+                 n_micado=None, n_singular_values=None, rcond=None,
+                 corrector_bounds_x=None, corrector_bounds_y=None):
 
         '''
         Trajectory correction using linearized response matrix from optics
@@ -418,6 +455,14 @@ class TrajectoryCorrection:
         rcond : float
             Cutoff for small singular values (relative to the largest singular
             value). Singular values smaller than `rcond` are considered zero.
+        corrector_bounds_x : tuple of array-like or None
+            Bounds for the horizontal corrector strengths. If not None, it should be a tuple
+            of two arrays (lower_bounds, upper_bounds) with the same length as
+            the number of horizontal correctors. If None, no bounds are applied.
+        corrector_bounds_y : tuple of array-like or None
+            Bounds for the vertical corrector strengths. If not None, it should be a tuple
+            of two arrays (lower_bounds, upper_bounds) with the same length as
+            the number of vertical correctors. If None, no bounds are applied.
         '''
 
         if isinstance(rcond, (tuple, list)):
@@ -452,6 +497,7 @@ class TrajectoryCorrection:
                 corrector_names=corrector_names_x, start=start, end=end,
                 twiss_table=twiss_table, n_micado=n_micado_x,
                 n_singular_values=n_singular_values_x, rcond=rcond_x,
+                corrector_bounds=corrector_bounds_x,
                 x_init=x_init, px_init=px_init, y_init=y_init, py_init=py_init,
                 zeta_init=zeta_init, delta_init=delta_init,
                 monitor_alignment=monitor_alignment)
@@ -466,6 +512,7 @@ class TrajectoryCorrection:
                 corrector_names=corrector_names_y, start=start, end=end,
                 twiss_table=twiss_table, n_micado=n_micado_y,
                 n_singular_values=n_singular_values_y, rcond=rcond_y,
+                corrector_bounds=corrector_bounds_y,
                 x_init=x_init, px_init=px_init, y_init=y_init, py_init=py_init,
                 zeta_init=zeta_init, delta_init=delta_init,
                 monitor_alignment=monitor_alignment)
@@ -543,19 +590,26 @@ class TrajectoryCorrection:
 
         tw_orbit = a_correction._compute_tw_orbit()
 
+        if self.x_correction is not None:
+            relative_bounds_x = self.x_correction.corrector_bounds
+        if self.y_correction is not None:
+            relative_bounds_y = self.y_correction.corrector_bounds
+
         while True:
 
             if self.x_correction is not None and 'x' in planes:
                 self.x_correction.correct(n_micado=n_micado_x,
                             n_singular_values=n_singular_values_x,
                             rcond=rcond_x, verbose=False, n_iter=1,
-                            _tw_orbit=tw_orbit)
+                            _tw_orbit=tw_orbit,
+                            corrector_bounds=relative_bounds_x)
 
             if self.y_correction is not None and 'y' in planes:
                 self.y_correction.correct(n_micado=n_micado_y,
                             n_singular_values=n_singular_values_y,
                             rcond=rcond_y, verbose=False, n_iter=1,
-                            _tw_orbit=tw_orbit)
+                            _tw_orbit=tw_orbit,
+                            corrector_bounds=relative_bounds_y)
 
             tw_orbit_prev = tw_orbit
             tw_orbit = a_correction._compute_tw_orbit()
@@ -579,11 +633,19 @@ class TrajectoryCorrection:
                     old_position = self.x_correction._measure_position(tw_orbit_prev)
                     str_2print += (f'x_rms: {old_position.std():.2e}'
                         f' -> {new_position.std():.2e}, ')
+                    if self.x_correction.corrector_bounds is not None:
+                        correction_kicks_x = self.x_correction.get_kick_values()
+                        relative_bounds_x = (self.x_correction.corrector_bounds[0] - correction_kicks_x,
+                                             self.x_correction.corrector_bounds[1] - correction_kicks_x)
                 if self.y_correction is not None and 'y' in planes:
                     new_position = self.y_correction._measure_position(tw_orbit)
                     old_position = self.y_correction._measure_position(tw_orbit_prev)
                     str_2print += (f'y_rms: {old_position.std():.2e}'
                         f' -> {new_position.std():.2e}')
+                    if self.y_correction.corrector_bounds is not None:
+                        correction_kicks_y = self.y_correction.get_kick_values()
+                        relative_bounds_y = (self.y_correction.corrector_bounds[0] - correction_kicks_y,
+                                             self.y_correction.corrector_bounds[1] - correction_kicks_y)
                 print(str_2print)
             if stop_x and stop_y:
                 break

--- a/xtrack/trajectory_correction.py
+++ b/xtrack/trajectory_correction.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 
 def _compute_correction(x_iter, response_matrix, n_micado=None, rcond=None,
-                        n_singular_values=None, corrector_bounds=None):
+                        n_singular_values=None, corrector_limits=None):
 
     if isinstance(response_matrix, (list, tuple)):
         assert len(response_matrix) == 3 # U, S, Vt
@@ -41,14 +41,14 @@ def _compute_correction(x_iter, response_matrix, n_micado=None, rcond=None,
                     mask_corr[i_used] = True
 
                 # Compute the correction with least squares
-                if corrector_bounds is None:
+                if corrector_limits is None:
                     _, residual_x, rank_x, sval_x = np.linalg.lstsq(
                                 response_matrix[:, mask_corr], -x_iter, rcond=rcond)
                 else:
-                    # Apply bounds only to the active correctors
-                    active_bounds = (corrector_bounds[0][mask_corr], corrector_bounds[1][mask_corr])
+                    # Apply limits only to the active correctors
+                    active_limits = (corrector_limits[0][mask_corr], corrector_limits[1][mask_corr])
                     result = lsq_linear(response_matrix[:, mask_corr], -x_iter, 
-                                      bounds=active_bounds)
+                                      bounds=active_limits)
                     if not result.success:
                         logger.warning(f'Bounded Least Squares warning: {result.message}')
                     residual_x = np.array([result.cost])
@@ -62,7 +62,7 @@ def _compute_correction(x_iter, response_matrix, n_micado=None, rcond=None,
         mask_corr[:] = True
 
     # Compute the correction with least squares
-    if mask_corr.all() and S is not None and corrector_bounds is None:
+    if mask_corr.all() and S is not None and corrector_limits is None:
         # Can reuse the SVD decomposition only for unbounded case
         S_inv = np.zeros_like(S)
         S_inv[S > 0] = 1 / S[S > 0]
@@ -70,14 +70,14 @@ def _compute_correction(x_iter, response_matrix, n_micado=None, rcond=None,
             S_inv[S < rcond * S[0]] = 0
         correction_masked = Vh.T.conj() @ (np.diag(S_inv) @ (U.T.conj() @ (-x_iter)))
     else:
-        if corrector_bounds is None:
+        if corrector_limits is None:
             correction_masked, residual_x, rank_x, sval_x = np.linalg.lstsq(
                         response_matrix[:, mask_corr], -x_iter, rcond=rcond)
         else:
-            # Apply bounds only to the active correctors
-            active_bounds = (corrector_bounds[0][mask_corr], corrector_bounds[1][mask_corr])
+            # Apply limits only to the active correctors
+            active_limits = (corrector_limits[0][mask_corr], corrector_limits[1][mask_corr])
             result = lsq_linear(response_matrix[:, mask_corr], -x_iter, 
-                              bounds=active_bounds)
+                              bounds=active_limits)
             if not result.success:
                 logger.warning(f'Bounded Least Squares warning: {result.message}')
             correction_masked = result.x
@@ -128,7 +128,7 @@ class OrbitCorrectionSinglePlane:
 
     def __init__(self, line, plane, monitor_names, corrector_names,
                  start=None, end=None, twiss_table=None, n_micado=None,
-                 n_singular_values=None, rcond=None, corrector_bounds=None,
+                 n_singular_values=None, rcond=None, corrector_limits=None,
                  x_init=0, px_init=0, y_init=0, py_init=0, zeta_init=0, delta_init=0,
                  monitor_alignment=None):
 
@@ -188,28 +188,28 @@ class OrbitCorrectionSinglePlane:
         assert len(monitor_names) > 0
         assert len(corrector_names) > 0
 
-        if corrector_bounds is None:
-            corrector_bounds = getattr(line, f'corrector_bounds_{plane}')
+        if corrector_limits is None:
+            corrector_limits = getattr(line, f'corrector_limits_{plane}')
 
-        if corrector_bounds is not None:
-            assert isinstance(corrector_bounds, tuple)
-            assert len(corrector_bounds) == 2
+        if corrector_limits is not None:
+            assert isinstance(corrector_limits, tuple)
+            assert len(corrector_limits) == 2
 
-            if isinstance(corrector_bounds[0], (int, float)):
-                corrector_bounds = (
-                    np.ones(len(corrector_names)) * corrector_bounds[0],
-                    np.ones(len(corrector_names)) * corrector_bounds[1]
+            if isinstance(corrector_limits[0], (int, float)):
+                corrector_limits = (
+                    np.ones(len(corrector_names)) * corrector_limits[0],
+                    np.ones(len(corrector_names)) * corrector_limits[1]
                 )
 
-            elif isinstance(corrector_bounds[0], (list, tuple)):
-                corrector_bounds = (
-                    np.array(corrector_bounds[0]),
-                    np.array(corrector_bounds[1])
+            elif isinstance(corrector_limits[0], (list, tuple)):
+                corrector_limits = (
+                    np.array(corrector_limits[0]),
+                    np.array(corrector_limits[1])
                 )
             
-            assert len(corrector_bounds) == 2
-            assert len(corrector_bounds[0]) == len(corrector_bounds[1])
-            assert len(corrector_bounds[0]) == len(corrector_names)
+            assert len(corrector_limits) == 2
+            assert len(corrector_limits[0]) == len(corrector_limits[1])
+            assert len(corrector_limits[0]) == len(corrector_names)
 
         self.line = line
         self.plane = plane
@@ -220,7 +220,7 @@ class OrbitCorrectionSinglePlane:
         self.n_micado = n_micado
         self.rcond = rcond
         self.n_singular_values = n_singular_values
-        self.corrector_bounds = corrector_bounds
+        self.corrector_limits = corrector_limits
 
         self.response_matrix = _build_response_matrix(plane=self.plane,
             tw=self.twiss_table, monitor_names=self.monitor_names,
@@ -257,7 +257,7 @@ class OrbitCorrectionSinglePlane:
 
     def correct(self, n_iter='auto', n_micado=None, n_singular_values=None,
                 rcond=None, stop_iter_factor=0.1, verbose=True, _tw_orbit=None,
-                corrector_bounds=None):
+                corrector_limits=None):
 
         if _tw_orbit is not None and n_iter !=1:
             raise ValueError('`_tw_orbit` can only be used with `n_iter=1`')
@@ -268,7 +268,7 @@ class OrbitCorrectionSinglePlane:
             assert stop_iter_factor < 1
 
         pos_rms_prev = 0
-        relative_bounds = corrector_bounds
+        relative_limits = corrector_limits
 
         i_iter = 0
         while True:
@@ -293,17 +293,17 @@ class OrbitCorrectionSinglePlane:
             correction = self._compute_correction(position=position,
                                     n_micado=n_micado, rcond=rcond,
                                     n_singular_values=n_singular_values,
-                                    corrector_bounds=relative_bounds)
+                                    corrector_limits=relative_limits)
             self._apply_correction(correction)
 
             i_iter += 1
             if n_iter != 'auto' and i_iter >= n_iter:
                 break
 
-            if corrector_bounds is not None:
+            if corrector_limits is not None:
                 current_correction = self.get_kick_values()
-                relative_bounds = (corrector_bounds[0] - current_correction,
-                                         corrector_bounds[1] - current_correction)
+                relative_limits = (corrector_limits[0] - current_correction,
+                                         corrector_limits[1] - current_correction)
 
         if _tw_orbit is None:
             position = self._measure_position()
@@ -348,7 +348,7 @@ class OrbitCorrectionSinglePlane:
         return position
 
     def _compute_correction(self, position, n_micado=None,
-                            n_singular_values=None, rcond=None, corrector_bounds=None):
+                            n_singular_values=None, rcond=None, corrector_limits=None):
 
         if rcond is None:
             rcond = self.rcond
@@ -363,7 +363,7 @@ class OrbitCorrectionSinglePlane:
         correction = _compute_correction(position,
             response_matrix=(self.singular_vectors_out, self.singular_values, self.singular_vectors_in),
             n_micado=n_micado,
-            rcond=rcond, n_singular_values=n_singular_values, corrector_bounds=corrector_bounds)
+            rcond=rcond, n_singular_values=n_singular_values, corrector_limits=corrector_limits)
 
         return correction
 
@@ -433,7 +433,7 @@ class TrajectoryCorrection:
                  monitor_alignment=None,
                  x_init=0, px_init=0, y_init=0, py_init=0, zeta_init=0, delta_init=0,
                  n_micado=None, n_singular_values=None, rcond=None,
-                 corrector_bounds_x=None, corrector_bounds_y=None):
+                 corrector_limits_x=None, corrector_limits_y=None):
 
         '''
         Trajectory correction using linearized response matrix from optics
@@ -476,14 +476,14 @@ class TrajectoryCorrection:
         rcond : float
             Cutoff for small singular values (relative to the largest singular
             value). Singular values smaller than `rcond` are considered zero.
-        corrector_bounds_x : tuple of array-like or None
-            Bounds for the horizontal corrector strengths. If not None, it should be a tuple
-            of two arrays (lower_bounds, upper_bounds) with the same length as
-            the number of horizontal correctors. If None, no bounds are applied.
-        corrector_bounds_y : tuple of array-like or None
-            Bounds for the vertical corrector strengths. If not None, it should be a tuple
-            of two arrays (lower_bounds, upper_bounds) with the same length as
-            the number of vertical correctors. If None, no bounds are applied.
+        corrector_limits_x : tuple of array-like or None
+            Limits for the horizontal corrector strengths. If not None, it should be a tuple
+            of two arrays (lower_limits, upper_limits) with the same length as
+            the number of horizontal correctors. If None, no limits are applied.
+        corrector_limits_y : tuple of array-like or None
+            Limits for the vertical corrector strengths. If not None, it should be a tuple
+            of two arrays (lower_limits, upper_limits) with the same length as
+            the number of vertical correctors. If None, no limits are applied.
         '''
 
         if isinstance(rcond, (tuple, list)):
@@ -518,7 +518,7 @@ class TrajectoryCorrection:
                 corrector_names=corrector_names_x, start=start, end=end,
                 twiss_table=twiss_table, n_micado=n_micado_x,
                 n_singular_values=n_singular_values_x, rcond=rcond_x,
-                corrector_bounds=corrector_bounds_x,
+                corrector_limits=corrector_limits_x,
                 x_init=x_init, px_init=px_init, y_init=y_init, py_init=py_init,
                 zeta_init=zeta_init, delta_init=delta_init,
                 monitor_alignment=monitor_alignment)
@@ -533,7 +533,7 @@ class TrajectoryCorrection:
                 corrector_names=corrector_names_y, start=start, end=end,
                 twiss_table=twiss_table, n_micado=n_micado_y,
                 n_singular_values=n_singular_values_y, rcond=rcond_y,
-                corrector_bounds=corrector_bounds_y,
+                corrector_limits=corrector_limits_y,
                 x_init=x_init, px_init=px_init, y_init=y_init, py_init=py_init,
                 zeta_init=zeta_init, delta_init=delta_init,
                 monitor_alignment=monitor_alignment)
@@ -612,9 +612,9 @@ class TrajectoryCorrection:
         tw_orbit = a_correction._compute_tw_orbit()
 
         if self.x_correction is not None:
-            relative_bounds_x = self.x_correction.corrector_bounds
+            relative_limits_x = self.x_correction.corrector_limits
         if self.y_correction is not None:
-            relative_bounds_y = self.y_correction.corrector_bounds
+            relative_limits_y = self.y_correction.corrector_limits
 
         while True:
 
@@ -623,14 +623,14 @@ class TrajectoryCorrection:
                             n_singular_values=n_singular_values_x,
                             rcond=rcond_x, verbose=False, n_iter=1,
                             _tw_orbit=tw_orbit,
-                            corrector_bounds=relative_bounds_x)
+                            corrector_limits=relative_limits_x)
 
             if self.y_correction is not None and 'y' in planes:
                 self.y_correction.correct(n_micado=n_micado_y,
                             n_singular_values=n_singular_values_y,
                             rcond=rcond_y, verbose=False, n_iter=1,
                             _tw_orbit=tw_orbit,
-                            corrector_bounds=relative_bounds_y)
+                            corrector_limits=relative_limits_y)
 
             tw_orbit_prev = tw_orbit
             tw_orbit = a_correction._compute_tw_orbit()
@@ -654,19 +654,19 @@ class TrajectoryCorrection:
                     old_position = self.x_correction._measure_position(tw_orbit_prev)
                     str_2print += (f'x_rms: {old_position.std():.2e}'
                         f' -> {new_position.std():.2e}, ')
-                    if self.x_correction.corrector_bounds is not None:
+                    if self.x_correction.corrector_limits is not None:
                         correction_kicks_x = self.x_correction.get_kick_values()
-                        relative_bounds_x = (self.x_correction.corrector_bounds[0] - correction_kicks_x,
-                                             self.x_correction.corrector_bounds[1] - correction_kicks_x)
+                        relative_limits_x = (self.x_correction.corrector_limits[0] - correction_kicks_x,
+                                             self.x_correction.corrector_limits[1] - correction_kicks_x)
                 if self.y_correction is not None and 'y' in planes:
                     new_position = self.y_correction._measure_position(tw_orbit)
                     old_position = self.y_correction._measure_position(tw_orbit_prev)
                     str_2print += (f'y_rms: {old_position.std():.2e}'
                         f' -> {new_position.std():.2e}')
-                    if self.y_correction.corrector_bounds is not None:
+                    if self.y_correction.corrector_limits is not None:
                         correction_kicks_y = self.y_correction.get_kick_values()
-                        relative_bounds_y = (self.y_correction.corrector_bounds[0] - correction_kicks_y,
-                                             self.y_correction.corrector_bounds[1] - correction_kicks_y)
+                        relative_limits_y = (self.y_correction.corrector_limits[0] - correction_kicks_y,
+                                             self.y_correction.corrector_limits[1] - correction_kicks_y)
                 print(str_2print)
             if stop_x and stop_y:
                 break

--- a/xtrack/trajectory_correction.py
+++ b/xtrack/trajectory_correction.py
@@ -179,13 +179,28 @@ class OrbitCorrectionSinglePlane:
             else:
                 monitor_names = monitor_names
 
-        if corrector_bounds is None:
-            corrector_bounds = getattr(line, f'corrector_bounds_{plane}')
-
         assert len(monitor_names) > 0
         assert len(corrector_names) > 0
 
+        if corrector_bounds is None:
+            corrector_bounds = getattr(line, f'corrector_bounds_{plane}')
+
         if corrector_bounds is not None:
+            assert isinstance(corrector_bounds, tuple)
+            assert len(corrector_bounds) == 2
+
+            if isinstance(corrector_bounds[0], (int, float)):
+                corrector_bounds = (
+                    np.ones(len(corrector_names)) * corrector_bounds[0],
+                    np.ones(len(corrector_names)) * corrector_bounds[1]
+                )
+
+            elif isinstance(corrector_bounds[0], (list, tuple)):
+                corrector_bounds = (
+                    np.array(corrector_bounds[0]),
+                    np.array(corrector_bounds[1])
+                )
+            
             assert len(corrector_bounds) == 2
             assert len(corrector_bounds[0]) == len(corrector_bounds[1])
             assert len(corrector_bounds[0]) == len(corrector_names)


### PR DESCRIPTION
## Description
Added feature to use bounded least squares ([scipy implementation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.lsq_linear.html)) to perform trajectory correction. If user provides corrector bounds, bounded least squares is used, instead of unbounded least squares (both for SVD and Micado).

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [~] All the tests are passing, including my new ones -> all tests passing on test_trajectory_correcton.py
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable -> updated relevant docstrings
- [ ] I have tested also GPU contexts
