### PR TITLE
Allow Zeta Shifts in env.new()

### DIFF
--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -59,8 +59,9 @@ log = logging.getLogger(__name__)
 _ALLOWED_ELEMENT_TYPES_IN_NEW = [xt.Drift, xt.Bend, xt.Quadrupole, xt.Sextupole,
                                  xt.Octupole, xt.Cavity, xt.Multipole, xt.Solenoid,
                                  xt.Marker, xt.Replica, xt.XYShift, xt.XRotation,
-                                 xt.YRotation, xt.SRotation, xt.LimitRacetrack,
-                                 xt.LimitRectEllipse, xt.LimitRect, xt.LimitEllipse,
+                                 xt.YRotation, xt.SRotation, xt.ZetaShift,
+                                 xt.LimitRacetrack, xt.LimitRectEllipse,
+                                 xt.LimitRect, xt.LimitEllipse,
                                  xt.LimitPolygon, xt.RFMultipole, xt.RBend]
 
 _ALLOWED_ELEMENT_TYPES_DICT = {'Drift': xt.Drift, 'Bend': xt.Bend,
@@ -74,6 +75,7 @@ _ALLOWED_ELEMENT_TYPES_DICT = {'Drift': xt.Drift, 'Bend': xt.Bend,
                                'LimitPolygon': xt.LimitPolygon,
                                'XYShift': xt.XYShift, 'XRotation': xt.XRotation,
                                'YRotation': xt.YRotation, 'SRotation': xt.SRotation,
+                               'ZetaShift': xt.ZetaShift,
                                'RFMultipole': xt.RFMultipole, 'RBend': xt.RBend}
 
 _STR_ALLOWED_ELEMENT_TYPES_IN_NEW = ', '.join([tt.__name__ for tt in _ALLOWED_ELEMENT_TYPES_IN_NEW])


### PR DESCRIPTION
## Description
Allow Zeta Shifts in env.new()

Closes # .

As discussed with @giadarol
Currently forbidden, but works