### PR TITLE
RF-Track element to update the reference momentum

### DIFF
--- a/xtrack/beam_elements/rft_element.py
+++ b/xtrack/beam_elements/rft_element.py
@@ -67,6 +67,7 @@ class RFT_Element:
 
         # Update particles
         self.arr_for_xt = self.arr_for_xt[self.arr_for_xt[:,7].argsort()] # sort by particle id
+        p.p0c = pref1[0].Pc * 1e6
         p.x  = self.arr_for_xt[:,0] / 1e3 # m
         p.px = self.arr_for_xt[:,1] * 1e6 / p.p0c # rad
         p.y  = self.arr_for_xt[:,2] / 1e3 # m


### PR DESCRIPTION
## Description
The RF-Track didn't update the reference momentum when particles were accelerated. Tested on the Linac4 simulation, works perfectly.

<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
