### PR TITLE
Add missing gpu gl mem annotations in `limitpolygon.h` and add a vectorization macro

### DIFF
--- a/xtrack/beam_elements/apertures_src/limitpolygon.h
+++ b/xtrack/beam_elements/apertures_src/limitpolygon.h
@@ -56,27 +56,27 @@ void LimitPolygon_track_local_particle(LimitPolygonData el,
 GPUKERN
 void LimitPolygon_impact_point_and_normal(
 		             LimitPolygonData el,
-                /*gpuglmem*/ const double* x_in,
-                /*gpuglmem*/ const double* y_in, 
-                /*gpuglmem*/ const double* z_in,
-                /*gpuglmem*/ const double* x_out,
-                /*gpuglmem*/ const double* y_out, 
-                /*gpuglmem*/ const double* z_out,
-                             const int64_t n_impacts,
-                /*gpuglmem*/       double* x_inters,
-                /*gpuglmem*/       double* y_inters, 
-                /*gpuglmem*/       double* z_inters,
-                /*gpuglmem*/       double* Nx_inters,
-                /*gpuglmem*/       double* Ny_inters,
-                /*gpuglmem*/       int64_t* i_found){ 
-			           
+                GPUGLMEM const double* x_in,
+                GPUGLMEM const double* y_in,
+                GPUGLMEM const double* z_in,
+                GPUGLMEM const double* x_out,
+                GPUGLMEM const double* y_out,
+                GPUGLMEM const double* z_out,
+                         const int64_t n_impacts,
+                GPUGLMEM double* x_inters,
+                GPUGLMEM double* y_inters,
+                GPUGLMEM double* z_inters,
+                GPUGLMEM double* Nx_inters,
+                GPUGLMEM double* Ny_inters,
+                GPUGLMEM int64_t* i_found){
+
     double const tol = 1e-13;
 
     int64_t N_edg = LimitPolygonData_len_x_vertices(el);
-    /*gpuglmem*/ const double* Vx = LimitPolygonData_getp1_x_vertices(el, 0);
-    /*gpuglmem*/ const double* Vy = LimitPolygonData_getp1_y_vertices(el, 0);
-    /*gpuglmem*/ const double* Nx = LimitPolygonData_getp1_x_normal(el, 0);
-    /*gpuglmem*/ const double* Ny = LimitPolygonData_getp1_y_normal(el, 0);
+    GPUGLMEM const double* Vx = LimitPolygonData_getp1_x_vertices(el, 0);
+    GPUGLMEM const double* Vy = LimitPolygonData_getp1_y_vertices(el, 0);
+    GPUGLMEM const double* Nx = LimitPolygonData_getp1_x_normal(el, 0);
+    GPUGLMEM const double* Ny = LimitPolygonData_getp1_y_normal(el, 0);
     double resc_fac = LimitPolygonData_get_resc_fac(el);
 
     for (int64_t i_imp=0; i_imp<n_impacts; i_imp++){ //vectorize_over i_imp n_impacts

--- a/xtrack/beam_elements/apertures_src/limitpolygon.h
+++ b/xtrack/beam_elements/apertures_src/limitpolygon.h
@@ -79,7 +79,7 @@ void LimitPolygon_impact_point_and_normal(
     GPUGLMEM const double* Ny = LimitPolygonData_getp1_y_normal(el, 0);
     double resc_fac = LimitPolygonData_get_resc_fac(el);
 
-    for (int64_t i_imp=0; i_imp<n_impacts; i_imp++){ //vectorize_over i_imp n_impacts
+    VECTORIZE_OVER(i_imp, n_impacts);
 
         double t_min_curr = 1.;
         int64_t i_found_curr = -1;
@@ -89,9 +89,8 @@ void LimitPolygon_impact_point_and_normal(
         double y_out_curr = y_out[i_imp];
 
         for (int64_t ii=0; ii<N_edg; ii++){
-
-	    double t_border;
-	    double t_ii;
+	        double t_border;
+	        double t_ii;
             double const den = ((y_out_curr-y_in_curr)*(Vx[ii+1]-Vx[ii])
 			    +(x_in_curr-x_out_curr)*(Vy[ii+1]-Vy[ii]));
             if (den == 0.){
@@ -99,23 +98,23 @@ void LimitPolygon_impact_point_and_normal(
                 // the case case overlapping the edge is not possible (this would not allow Pin inside and Pout outside - a point on the edge is condidered outside)
                 // the only case left is segment parallel to tue edge => no intersection
                 t_border = -2.;
-	    }
+	        }
             else{
                 t_border=((y_out_curr-y_in_curr)*(x_in_curr-Vx[ii])
 		         +(x_in_curr-x_out_curr)*(y_in_curr-Vy[ii]))/den;
-	    }
+	        }
 
             if (t_border>=0.-tol && t_border<=1.+tol){
                 t_ii = (Nx[ii]*(Vx[ii]-x_in_curr)
-		       +Ny[ii]*(Vy[ii]-y_in_curr)) 
-		       /(Nx[ii]*(x_out_curr-x_in_curr)
-	                 +Ny[ii]*(y_out_curr-y_in_curr));
+		            +Ny[ii]*(Vy[ii]-y_in_curr))
+		            /(Nx[ii]*(x_out_curr-x_in_curr)
+	                +Ny[ii]*(y_out_curr-y_in_curr));
                 if (t_ii>=0.-tol && t_ii<t_min_curr+tol){
-                    t_min_curr=t_ii;
+                    t_min_curr = t_ii;
                     i_found_curr = ii;
-		}
+		        }
             }
-	}
+	    }
 
         t_min_curr=resc_fac*t_min_curr;
         x_inters[i_imp]=t_min_curr*x_out_curr+(1.-t_min_curr)*x_in_curr;
@@ -125,10 +124,10 @@ void LimitPolygon_impact_point_and_normal(
         if (i_found_curr>=0){
             Nx_inters[i_imp] = Nx[i_found_curr];
             Ny_inters[i_imp] = Ny[i_found_curr];
-	}
+	    }
         i_found[i_imp] = i_found_curr;
-    } //end_vectorize
-    
+
+    END_VECTORIZE;
 }
 
 #endif

--- a/xtrack/headers/track.h
+++ b/xtrack/headers/track.h
@@ -22,6 +22,12 @@
     #define END_PER_PARTICLE_BLOCK \
             } \
         }
+
+    #define VECTORIZE_OVER(INDEX_NAME, COUNT) \
+        for (int INDEX_NAME = 0; INDEX_NAME < (COUNT); INDEX_NAME++) {
+
+    #define END_VECTORIZE \
+        }
 #endif  // XO_CONTEXT_CPU_SERIAL
 
 #ifdef XO_CONTEXT_CPU_OPENMP
@@ -42,6 +48,14 @@
                 } \
             } \
         }
+
+    #define VECTORIZE_OVER(INDEX_NAME, COUNT) \
+        _Pragma("omp parallel for") \
+        for (int INDEX_NAME = 0; INDEX_NAME < (COUNT); INDEX_NAME++) {
+
+    #define END_VECTORIZE \
+        }
+
 #endif  // XO_CONTEXT_CPU_OPENMP
 
 
@@ -53,6 +67,13 @@
 
     #define END_PER_PARTICLE_BLOCK \
             }
+
+    #define VECTORIZE_OVER(INDEX_NAME, COUNT) \
+        { \
+            int INDEX_NAME = blockDim.x * blockIdx.x + threadIdx.x;
+
+    #define END_VECTORIZE \
+        }
 #endif  // XO_CONTEXT_CUDA
 
 
@@ -64,6 +85,13 @@
 
     #define END_PER_PARTICLE_BLOCK \
             }
+
+    #define VECTORIZE_OVER(INDEX_NAME, COUNT) \
+        { \
+            int INDEX_NAME = get_global_id(0);
+
+    #define END_VECTORIZE \
+        }
 #endif  // XO_CONTEXT_CL
 
 

--- a/xtrack/particles/rng_src/particles_rng.h
+++ b/xtrack/particles/rng_src/particles_rng.h
@@ -12,20 +12,19 @@ GPUKERN
 void Particles_initialize_rand_gen(ParticlesData particles,
     GPUGLMEM uint32_t* seeds, int n_init){
 
-    for (int ii=0; ii<n_init; ii++){//vectorize_over ii n_init
+    VECTORIZE_OVER(ii, n_init);
 
-    uint32_t s1, s2, s3, s4, s;
-    s = seeds[ii];
+        uint32_t s1, s2, s3, s4, s;
+        s = seeds[ii];
 
-    rng_set(&s1, &s2, &s3, &s4, s);
+        rng_set(&s1, &s2, &s3, &s4, s);
 
-    ParticlesData_set__rng_s1(particles, ii, s1);
-    ParticlesData_set__rng_s2(particles, ii, s2);
-    ParticlesData_set__rng_s3(particles, ii, s3);
-    ParticlesData_set__rng_s4(particles, ii, s4);
+        ParticlesData_set__rng_s1(particles, ii, s1);
+        ParticlesData_set__rng_s2(particles, ii, s2);
+        ParticlesData_set__rng_s3(particles, ii, s3);
+        ParticlesData_set__rng_s4(particles, ii, s4);
 
-     }//end_vectorize
-
+    END_VECTORIZE;
 }
 
 #endif /* XTRACK_PARTICLES_RNG_H */


### PR DESCRIPTION
## Description

Fix an issue that causes OpenCL failures due to missing memory qualifiers in `limitpolygon.h`.
Also add a `VECTORIZE_OVER` macro to mirror `//vectorize_over` magic comment, to use in included headers (e.g. `limitpolygon.h`).

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
