### PR TITLE
Fix get_amplitude_detuning_coefficients

### DIFF
--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -2021,6 +2021,10 @@ class Line:
         qx = np.zeros(4)
         qy = np.zeros(4)
 
+        # remove average in case there is a closed orbit
+        mon.x-=mon.x.mean(axis=1,keepdims=True)
+        mon.y-=mon.y.mean(axis=1,keepdims=True)
+
         for ii in range(len(qx)):
             qx[ii] = np.abs(nl.get_tune(mon.x[ii, :]))
             qy[ii] = np.abs(nl.get_tune(mon.y[ii, :]))


### PR DESCRIPTION
## Description
get_amplitude_detuning_coefficients could lock on 0 tune if there is closed orbit

Closes https://github.com/xsuite/xsuite/issues/653

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
