### PR TITLE
Fix memory error on CUDA related to vectorize

### DIFF
--- a/xtrack/headers/track.h
+++ b/xtrack/headers/track.h
@@ -68,11 +68,12 @@
     #define END_PER_PARTICLE_BLOCK \
             }
 
-    #define VECTORIZE_OVER(INDEX_NAME, COUNT) \
-        { \
-            int INDEX_NAME = blockDim.x * blockIdx.x + threadIdx.x;
+    #define VECTORIZE_OVER(INDEX_NAME, COUNT) { \
+            int INDEX_NAME = blockDim.x * blockIdx.x + threadIdx.x; \
+            if (INDEX_NAME < (COUNT)) {
 
     #define END_VECTORIZE \
+            } \
         }
 #endif  // XO_CONTEXT_CUDA
 


### PR DESCRIPTION
## Description

This fixes the memory error currently occurring on CUDA contexts (when `particles_rng.h` is involved).

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
