### PR TITLE
Fix `madng_twiss` for the reference recv from `pymadng`

### DIFF
--- a/xtrack/madng_interface.py
+++ b/xtrack/madng_interface.py
@@ -71,7 +71,7 @@ def _tw_ng(line, rdts=[], normal_form=True,
     mng_columns_to_send = ["mtbl." + col for col in columns]
     send_cmd = f'''
         columns = {{{", ".join(mng_columns_to_send)}}}
-        py:send(columns)
+        py:send(columns, true)
     '''
 
     if len(rdts) > 0:
@@ -113,7 +113,7 @@ def _tw_ng(line, rdts=[], normal_form=True,
 
     mng.send(mng_script)
 
-    out = mng.recv('columns').eval()
+    out = mng.recv('columns')
     out_dct = {k: v for k, v in zip(columns, out)}
 
     # Add to table


### PR DESCRIPTION
## Description

This fixes a current issue with the madng_interface in Xsuite: pymadng now sends dictionaries as references, this adapts Xsuite to this. There is a somewhat related issue on pymadng: https://github.com/MethodicalAcceleratorDesign/MAD-NG.py/issues/24.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
