### PR TITLE
Inital commit

### DIFF
--- a/tests/test_acdipole.py
+++ b/tests/test_acdipole.py
@@ -1,0 +1,246 @@
+from collections import namedtuple
+
+import pytest
+import xpart as xp
+from xobjects.test_helpers import for_all_test_contexts
+
+import xtrack as xt
+
+
+# =====================
+# Utility Functions
+# =====================
+def _create_test_particles(at_turn: int) -> xp.Particles:
+    """Create test particles and verify initial conditions."""
+    particles = xp.Particles(at_turn=at_turn)
+    assert particles.x[0] == 0.0, f"Expected initial x=0, but got x={particles.x[0]}"
+    assert particles.y[0] == 0.0, f"Expected initial y=0, but got y={particles.y[0]}"
+    assert particles.py[0] == 0.0, (
+        f"Expected initial py=0, but got py={particles.py[0]}"
+    )
+    assert particles.px[0] == 0.0, (
+        f"Expected initial px=0, but got px={particles.px[0]}"
+    )
+    return particles
+
+
+def get_acdipole_results(
+    test_context,
+    acdipole_class: type[xt.BeamElement],
+    turn: int,
+    test_voltage: float = 1.5,
+    test_freq: float = 0.25,
+    test_lag: float = 0.0,
+) -> tuple:
+    """Track particles through an ACDipole and return coordinates."""
+    particles = _create_test_particles(at_turn=turn)
+
+    acdipole = acdipole_class(
+        volt=test_voltage,
+        freq=test_freq,
+        lag=test_lag,
+        ramp=[0, 10, 100, 110],
+        _context=test_context,
+    )
+
+    acdipole.track(particles)
+    return particles.x[0], particles.px[0], particles.y[0], particles.py[0]
+
+
+def assert_acdipole_kick(
+    *,
+    test_context,
+    acdipole_class,
+    test_turn,
+    test_volt,
+    test_freq,
+    test_lag,
+    kick_attr,
+    expected_kick,
+):
+    """
+    Assert that only the coordinate corresponding to `kick_attr` receives the expected kick,
+    and all other coordinates remain zero.
+    All arguments must be passed as keyword arguments for clarity.
+    """
+    x, px, y, py = get_acdipole_results(
+        test_context, acdipole_class, test_turn, test_volt, test_freq, test_lag
+    )
+    vals = {"x": x, "px": px, "y": y, "py": py}
+    for coord in vals:
+        if coord == kick_attr:
+            assert abs(vals[coord] - expected_kick) < 1e-10, (
+                f"Turn {test_turn}: Expected {coord}={expected_kick}, but got {coord}={vals[coord]}"
+            )
+        else:
+            assert vals[coord] == 0.0, (
+                f"Turn {test_turn}: Expected {coord}=0, but got {coord}={vals[coord]}"
+            )
+
+
+# =====================
+# Flattop Test Parameters and Helper
+# =====================
+flattop_cases = [
+    (2.25, 45, 0.25, 0.0, "flattop, 2.25V, freq=0.25, lag=0.0"),
+    (1.5, 46, 1 / 3, -1 / 3, "flattop, 1.5V, freq=1/3, lag=-0.25"),
+    (1.5, 47, 1 / 3, 1 / 12, "flattop, 1.5V, freq=1/3, lag=+0.25"),
+]
+flattop_params = [(v, t, f, lag) for v, t, f, lag, _ in flattop_cases]
+flattop_ids = [desc for _, _, _, _, desc in flattop_cases]
+
+
+def _calculate_flattop_kick(test_volt, test_turn) -> float:
+    """Compute expected kick for flattop tests."""
+    if test_turn == 45:
+        return test_volt * 300e-3
+    if test_turn == 46:
+        return 0
+    if test_turn == 47:
+        return -test_volt * 300e-3
+    raise ValueError(
+        f"Unexpected test_turn={test_turn} in flattop tests. Expected 45, 46, or 47."
+    )
+
+
+# =====================
+# Flattop Tests
+# =====================
+@for_all_test_contexts
+@pytest.mark.parametrize(
+    "test_volt, test_turn, test_freq, test_lag",
+    flattop_params,
+    ids=flattop_ids,
+)
+def test_vacdipole_flattop(
+    test_context, test_volt, test_turn, test_freq, test_lag
+) -> None:
+    """
+    Test vertical ACDipole flattop for three specific cases.
+    """
+    expected_kick = _calculate_flattop_kick(test_volt, test_turn)
+    assert_acdipole_kick(
+        test_context=test_context,
+        acdipole_class=xt.ACDipoleThickVertical,
+        test_turn=test_turn,
+        test_volt=test_volt,
+        test_freq=test_freq,
+        test_lag=test_lag,
+        kick_attr="py",
+        expected_kick=expected_kick,
+    )
+
+
+@for_all_test_contexts
+@pytest.mark.parametrize(
+    "test_volt, test_turn, test_freq, test_lag",
+    flattop_params,
+    ids=flattop_ids,
+)
+def test_hacdipole_flattop(
+    test_context, test_volt, test_turn, test_freq, test_lag
+) -> None:
+    """
+    Test horizontal ACDipole flattop for three specific cases.
+    """
+    expected_kick = _calculate_flattop_kick(test_volt, test_turn)
+    assert_acdipole_kick(
+        test_context=test_context,
+        acdipole_class=xt.ACDipoleThickHorizontal,
+        test_turn=test_turn,
+        test_volt=test_volt,
+        test_freq=test_freq,
+        test_lag=test_lag,
+        kick_attr="px",
+        expected_kick=expected_kick,
+    )
+
+
+# =====================
+# Ramp Test Parameters and Helper
+# =====================
+AcdipoleRampCase = namedtuple(
+    "AcdipoleRampCase", ["volt", "turn", "freq", "lag", "desc"]
+)
+acdipole_ramp_cases = [
+    AcdipoleRampCase(1.5, 5, 0.25, 0.0, "First ramp up, quarter period, no lag"),
+    AcdipoleRampCase(
+        1.5, 105, 1.25, 0.0, "Ramp down, after 100 turns, freq > 1, no lag"
+    ),
+    AcdipoleRampCase(2.25, 6, 1 / 3, -0.25, "Early ramp, third period, negative lag"),
+    AcdipoleRampCase(
+        1.5, 107, 1 / 3, 1 / 12, "Late ramp, third period, small positive lag"
+    ),
+]
+acdipole_ramp_params = [(c.volt, c.turn, c.freq, c.lag) for c in acdipole_ramp_cases]
+acdipole_ramp_ids = [c.desc for c in acdipole_ramp_cases]
+
+
+def _calculate_ramp_kick(test_volt, test_turn):
+    """
+    Compute expected kick for ramp tests.
+    - For turns <= 100, the kick ramps up linearly.
+    - For turns > 100, the kick ramps down linearly.
+    - The sign alternates based on the turn number.
+    """
+    kick_sign = (-1) ** (test_turn % 5 > 0)
+    if test_turn > 100:
+        return kick_sign * test_volt * 300e-3 * (1 - (test_turn - 100) / 10)
+    return kick_sign * test_volt * 300e-3 * (test_turn / 10)
+
+
+# =====================
+# Ramp Tests
+# =====================
+@for_all_test_contexts
+@pytest.mark.parametrize(
+    "test_volt, test_turn, test_freq, test_lag",
+    acdipole_ramp_params,
+    ids=acdipole_ramp_ids,
+)
+def test_vacdipole_ramp(
+    test_context, test_volt, test_turn, test_freq, test_lag
+) -> None:
+    """
+    Test vertical ACDipole ramp:
+    - Only py should receive the expected kick, all other coordinates should remain zero.
+    - Each test case is described in the test ID.
+    """
+    expected_kick = _calculate_ramp_kick(test_volt, test_turn)
+    assert_acdipole_kick(
+        test_context=test_context,
+        acdipole_class=xt.ACDipoleThickVertical,
+        test_turn=test_turn,
+        test_volt=test_volt,
+        test_freq=test_freq,
+        test_lag=test_lag,
+        kick_attr="py",
+        expected_kick=expected_kick,
+    )
+
+
+@for_all_test_contexts
+@pytest.mark.parametrize(
+    "test_volt, test_turn, test_freq, test_lag",
+    acdipole_ramp_params,
+    ids=acdipole_ramp_ids,
+)
+def test_hacdipole_ramp(
+    test_context, test_volt, test_turn, test_freq, test_lag
+) -> None:
+    """
+    Test horizontal ACDipole ramp:
+    - Only px should receive the expected kick, all other coordinates should remain zero.
+    - Each test case is described in the test ID.
+    """
+    expected_kick = _calculate_ramp_kick(test_volt, test_turn)
+    assert_acdipole_kick(
+        test_context=test_context,
+        acdipole_class=xt.ACDipoleThickHorizontal,
+        test_turn=test_turn,
+        test_volt=test_volt,
+        test_freq=test_freq,
+        test_lag=test_lag,
+        kick_attr="px",
+        expected_kick=expected_kick,
+    )

--- a/tests/test_thin_acdipole.py
+++ b/tests/test_thin_acdipole.py
@@ -1,0 +1,56 @@
+import pytest
+import xpart as xp
+from xobjects.test_helpers import for_all_test_contexts
+
+import xtrack as xt
+
+
+def _create_fodo_line(test_context) -> xt.Line:
+    """Helper function to create a FODO line for testing."""
+    n = 6
+    fodo = [
+        xt.Multipole(length=0.2, knl=[0, +0.2], ksl=[0, 0]),
+        xt.Drift(length=1.0),
+        xt.Multipole(length=0.2, knl=[0, -0.2], ksl=[0, 0]),
+        xt.Drift(length=1.0),
+    ]
+    line = xt.Line(elements=n * fodo)
+    line.build_tracker(_context=test_context)
+    line.particle_ref = xp.Particles(mass0=xp.PROTON_MASS_EV, q0=1, p0c=1e9)
+    return line
+
+
+@for_all_test_contexts
+@pytest.mark.parametrize(
+    "qx_shift", [-0.015, 0.035], ids=lambda v: f"qx_shift={v}"
+)
+@pytest.mark.parametrize(
+    "qy_shift", [0.015,-0.02], ids=lambda v: f"qy_shift={v}"
+)
+def test_thin_ac_dipole(test_context, qx_shift, qy_shift):
+    """Test the effect of a thin AC dipole on the tune shift."""
+    line = _create_fodo_line(test_context)
+    base_tws = line.twiss(method="4d")
+
+    nat_qx, nat_qy = base_tws["qx"], base_tws["qy"]
+    drv_qx, drv_qy = nat_qx + qx_shift, nat_qy + qy_shift
+
+    e5_pos = line.get_s_position("e5")
+    e5_betx = base_tws.rows["e5"]["betx"].item()
+    e5_bety = base_tws.rows["e5"]["bety"].item()
+
+    # Define AC dipole elements
+    line.env.elements["e5_hacd"] = xt.ACDipoleThinHorizontal(
+        natural_qx=nat_qx, driven_qx=drv_qx, betx_at_acdipole=e5_betx
+    )
+    line.env.elements["e5_vacd"] = xt.ACDipoleThinVertical(
+        natural_qy=nat_qy, driven_qy=drv_qy, bety_at_acdipole=e5_bety
+    )
+
+    line.insert("e5_hacd", at=e5_pos)
+    line.insert("e5_vacd", at=e5_pos)
+    line.build_tracker(_context=test_context)
+    tws_both = line.twiss(method="4d")
+
+    assert tws_both["qx"] == pytest.approx(drv_qx, rel=1e-5)
+    assert tws_both["qy"] == pytest.approx(drv_qy, rel=1e-5)

--- a/xtrack/beam_elements/__init__.py
+++ b/xtrack/beam_elements/__init__.py
@@ -3,6 +3,7 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
+from .acdipole import ACDipoleThickHorizontal, ACDipoleThickVertical, ACDipoleThinHorizontal, ACDipoleThinVertical
 from .elements import *
 from .exciter import Exciter
 from .apertures import *

--- a/xtrack/beam_elements/acdipole.py
+++ b/xtrack/beam_elements/acdipole.py
@@ -1,0 +1,260 @@
+import numpy as np
+import xobjects as xo
+
+import xtrack as xt
+
+
+class ACDipoleThickVertical(xt.BeamElement):
+    """
+    ACDipoleTrack is a thin element that applies an oscillating kick to the beam in the x and y directions.
+    It is used for beam excitations in circular machines for optics measurements. The kick is
+    defined by the voltages, frequencies, and phase lags in the x and y directions.
+    The kick is applied as a function of the turn number, and it can be ramped up and down
+    to avoid emittance growth. The transverse momentum in the vertical plane is changed by
+    `(0.3 * volt/p0c) * sin(2π * freq * turn + lag)`.
+
+    Since, this acts as a kicker that has a frequency over a number of turns, it is
+    only useful when running a tracking simulation with a fixed number of turns. If
+    you need to run a twiss for a single turn, you should use the `ACDipoleThinHorizontal`
+    element instead.
+
+    Parameters
+    ----------
+    volt : list of float
+        The voltages applied in the y direction,
+    freq : list of float
+        The frequencies of the AC dipole in the y direction, in units of Hz.
+    lag : list of float
+        The phase lag of the AC dipole in the y direction, in units of radians.
+    ramp : list of int
+        The ramp settings for the AC dipole, defining the turns for ramping up and down the kick.
+        The list should contain four integers: [ramp1, ramp2, ramp3, ramp4].
+        - `ramp1`: Starting turn of amplitude ramp-up.
+        - `ramp2`: Last turn of amplitude ramp-up.
+        - `ramp3`: Starting turn of amplitude ramp-down.
+        - `ramp4`: Last turn of amplitude ramp-down.
+    """
+
+    def __init__(
+        self, *, volt=None, freq=None, lag=None, ramp=None, _xobject=None, **kwargs
+    ):
+        if _xobject is not None:
+            super().__init__(_xobject=_xobject)
+        else:
+            # The default is needed, as we wish to be able to instantiate
+            # elements without properties (empty elements can be templates).
+            if volt is None:
+                volt = 0
+            if freq is None:
+                freq = 0
+            if lag is None:
+                lag = 0
+            if ramp is None:
+                ramp = [0, 0, 0, 0]
+            elif not (
+                (isinstance(ramp, (list, tuple)) or hasattr(ramp, "__iter__"))
+                and len(ramp) == 4
+                and all(isinstance(int(x), int) for x in ramp)
+            ):
+                raise ValueError(
+                    "The ramp parameter must be a list of four integers: [ramp1, ramp2, ramp3, ramp4]."
+                )
+
+            super().__init__(
+                volt=volt, freq=freq, lag=lag, ramp=ramp, _xobject=_xobject, **kwargs
+            )
+
+    _xofields = {
+        # Voltage defines the strength of the kick
+        "volt": xo.Float64,
+        # Frequency defines strength depending on delta to tune
+        "freq": xo.Float64,
+        # Lag
+        "lag": xo.Float64,
+        # Ramping parameters
+        "ramp": xo.UInt16[:],
+    }
+
+    _extra_c_sources = [
+        "#include <beam_elements/elements_src/acdipole_vertical.h>",
+    ]
+
+
+class ACDipoleThickHorizontal(xt.BeamElement):
+    """
+    ACDipoleTrack is a thin element that applies an oscillating kick to the beam in the x and y directions.
+    It is used for beam excitations in circular machines for optics measurements. The kick is
+    defined by the voltages, frequencies, and phase lags in the x and y directions.
+    The kick is applied as a function of the turn number, and it can be ramped up and down
+    to avoid emittance growth. The transverse momentum in the horizontal plane is changed by
+    `(0.3 * volt/p0c) * sin(2π * freq * turn + lag)`.
+
+    Since, this acts as a kicker that has a frequency over a number of turns, it is
+    only useful when running a tracking simulation with a fixed number of turns. If
+    you need to run a twiss for a single turn, you should use the `ACDipoleThinHorizontal`
+    element instead.
+
+    Parameters
+    ----------
+    volt : list of float
+        The voltages applied in the x direction,
+    freq : list of float
+        The frequencies of the AC dipole in the x direction, in units of Hz.
+    lag : list of float
+        The phase lag of the AC dipole in the x direction, in units of radians.
+    ramp : list of int
+        The ramp settings for the AC dipole, defining the turns for ramping up and down the kick.
+        The list should contain four integers: [ramp1, ramp2, ramp3, ramp4].
+        - `ramp1`: Starting turn of amplitude ramp-up.
+        - `ramp2`: Last turn of amplitude ramp-up.
+        - `ramp3`: Starting turn of amplitude ramp-down.
+        - `ramp4`: Last turn of amplitude ramp-down.
+    """
+
+    def __init__(
+        self, *, volt=None, freq=None, lag=None, ramp=None, _xobject=None, **kwargs
+    ):
+        if _xobject is not None:
+            super().__init__(_xobject=_xobject)
+        else:
+            # The default is needed, as we wish to be able to instantiate
+            # elements without properties (empty elements can be templates).
+            if volt is None:
+                volt = 0
+            if freq is None:
+                freq = 0
+            if lag is None:
+                lag = 0
+            if ramp is None:
+                ramp = [0, 0, 0, 0]
+            elif not (
+                (isinstance(ramp, (list, tuple)) or hasattr(ramp, "__iter__"))
+                and len(ramp) == 4
+                and all(int(x) == x for x in ramp)
+            ):
+                raise ValueError(
+                    "The ramp parameter must be a list of four integers: [ramp1, ramp2, ramp3, ramp4]."
+                )
+
+            super().__init__(
+                volt=volt, freq=freq, lag=lag, ramp=ramp, _xobject=_xobject, **kwargs
+            )
+
+    _xofields = {
+        # Voltage defines the strength of the kick
+        "volt": xo.Float64,
+        # Frequency defines strength depending on delta to tune
+        "freq": xo.Float64,
+        # Lag
+        "lag": xo.Float64,
+        # Ramping parameters
+        "ramp": xo.UInt16[:],
+    }
+
+    _extra_c_sources = [
+        "#include <beam_elements/elements_src/acdipole_horizontal.h>",
+    ]
+
+
+class ACDipoleThinVertical(xt.BeamElement):
+    """
+    ACDipoleThinVertical is a thin element that approximates the effect of an AC dipole,
+    simulating it as a thin gradient error see Miyamoto, R., Kopp, S., Jansson, A., & Syphers, M. (2008).
+    Parametrization of the driven betatron oscillation. Phys. Rev. ST Accel. Beams, 11, 084002 for more details.
+    It applies a beta and tune shift to the beam in the vertical plane, depending on the natural and driven tunes.
+
+    If any of the parameters `natural_qy`, `driven_qy`, or `bety_at_acdipole` are not provided,
+    the effective gradient (`eff_grad`) is set to zero, meaning no kick is applied.
+
+    Parameters
+    ----------
+    natural_qy : float
+        The natural vertical tune of the machine.
+    driven_qy : float
+        The driven vertical tune desired for the AC dipole.
+    bety_at_acdipole : float
+        The beta function at the location of the AC dipole, in meters.
+    """
+
+    def __init__(
+        self,
+        *,
+        natural_qy=None,
+        driven_qy=None,
+        bety_at_acdipole=None,
+        _xobject=None,
+        **kwargs,
+    ):
+        if _xobject is not None:
+            super().__init__(_xobject=_xobject)
+        else:
+            if natural_qy is None or driven_qy is None or bety_at_acdipole is None:
+                eff_grad = 0
+            else:
+                eff_grad = (
+                    2
+                    * (np.cos(2 * np.pi * driven_qy) - np.cos(2 * np.pi * natural_qy))
+                    / (bety_at_acdipole * np.sin(2 * np.pi * natural_qy))
+                )
+            super().__init__(eff_grad=eff_grad, _xobject=_xobject, **kwargs)
+
+    _xofields = {
+        # Effective gradient of the AC dipole.
+        "eff_grad": xo.Float64,
+    }
+
+    _extra_c_sources = [
+        "#include <beam_elements/elements_src/thin_vacdipole.h>",
+    ]
+
+
+class ACDipoleThinHorizontal(xt.BeamElement):
+    """
+    ACDipoleThinHorizontal is a thin element that approximates the effect of an AC dipole,
+    simulating it as a thin gradient error see Miyamoto, R., Kopp, S., Jansson, A., & Syphers, M. (2008).
+    Parametrization of the driven betatron oscillation. Phys. Rev. ST Accel. Beams, 11, 084002 for more details.
+    It applies a beta and tune shift to the beam in the horizontal plane, depending on the natural and driven tunes.
+
+    If any of the parameters `natural_qx`, `driven_qx`, or `betx_at_acdipole` are not provided,
+    the effective gradient (`eff_grad`) is set to zero, meaning no kick is applied.
+
+    Parameters
+    ----------
+    natural_qx : float
+        The natural horizontal tune of the machine.
+    driven_qx : float
+        The driven horizontal tune desired for the AC dipole.
+    betx_at_acdipole : float
+        The beta function at the location of the AC dipole, in meters.
+    """
+
+    def __init__(
+        self,
+        *,
+        natural_qx=None,
+        driven_qx=None,
+        betx_at_acdipole=None,
+        _xobject=None,
+        **kwargs,
+    ):
+        if _xobject is not None:
+            super().__init__(_xobject=_xobject)
+        else:
+            if natural_qx is None or driven_qx is None or betx_at_acdipole is None:
+                eff_grad = 0
+            else:
+                eff_grad = (
+                    2
+                    * (np.cos(2 * np.pi * driven_qx) - np.cos(2 * np.pi * natural_qx))
+                    / (betx_at_acdipole * np.sin(2 * np.pi * natural_qx))
+                )
+            super().__init__(eff_grad=eff_grad, _xobject=_xobject, **kwargs)
+
+    _xofields = {
+        # Effective gradient of the AC dipole.
+        "eff_grad": xo.Float64,
+    }
+
+    _extra_c_sources = [
+        "#include <beam_elements/elements_src/thin_hacdipole.h>",
+    ]

--- a/xtrack/beam_elements/elements_src/acdipole_horizontal.h
+++ b/xtrack/beam_elements/elements_src/acdipole_horizontal.h
@@ -1,0 +1,40 @@
+// copyright ############################### //
+// This file is part of the Xtrack Package.  //
+// Copyright (c) CERN, 2025.                 //
+// ######################################### //
+
+#ifndef XTRACK_ACDIPOLE_HORIZONTAL_H
+#define XTRACK_ACDIPOLE_HORIZONTAL_H
+
+#include <headers/track.h>
+#include <beam_elements/elements_src/track_acdipole.h>
+
+
+GPUFUN void ACDipoleThickHorizontal_track_local_particle(
+    ACDipoleThickHorizontalData el,
+    LocalParticle* part0
+) {
+    const double vrf = ACDipoleThickHorizontalData_get_volt(el) * 300e-3;
+    const double omega = ACDipoleThickHorizontalData_get_freq(el) * 2 * PI;
+    const double phirf = ACDipoleThickHorizontalData_get_lag(el) * 2 * PI;
+    const int16_t ramp1 = ACDipoleThickHorizontalData_get_ramp(el, 0);
+    const int16_t ramp2 = ACDipoleThickHorizontalData_get_ramp(el, 1);
+    const int16_t ramp3 = ACDipoleThickHorizontalData_get_ramp(el, 2);
+    const int16_t ramp4 = ACDipoleThickHorizontalData_get_ramp(el, 3);
+    
+
+    START_PER_PARTICLE_BLOCK(part0, part);
+        track_ac_dipole_horizontal_single_particle(
+            part,
+            vrf,
+            omega,
+            phirf,
+            ramp1,
+            ramp2,
+            ramp3,
+            ramp4
+        );
+    END_PER_PARTICLE_BLOCK;
+}
+
+#endif

--- a/xtrack/beam_elements/elements_src/acdipole_vertical.h
+++ b/xtrack/beam_elements/elements_src/acdipole_vertical.h
@@ -1,0 +1,40 @@
+// copyright ############################### //
+// This file is part of the Xtrack Package.  //
+// Copyright (c) CERN, 2025.                 //
+// ######################################### //
+
+#ifndef XTRACK_ACDIPOLE_VERTICAL_H
+#define XTRACK_ACDIPOLE_VERTICAL_H
+
+#include <headers/track.h>
+#include <beam_elements/elements_src/track_acdipole.h>
+
+
+GPUFUN void ACDipoleThickVertical_track_local_particle(
+    ACDipoleThickVerticalData el,
+    LocalParticle* part0
+) {
+    const double vrf = ACDipoleThickVerticalData_get_volt(el) * 300e-3;
+    const double omega = ACDipoleThickVerticalData_get_freq(el) * 2 * PI;
+    const double phirf = ACDipoleThickVerticalData_get_lag(el) * 2 * PI;
+    const int16_t ramp1 = ACDipoleThickVerticalData_get_ramp(el, 0);
+    const int16_t ramp2 = ACDipoleThickVerticalData_get_ramp(el, 1);
+    const int16_t ramp3 = ACDipoleThickVerticalData_get_ramp(el, 2);
+    const int16_t ramp4 = ACDipoleThickVerticalData_get_ramp(el, 3);
+    
+
+    START_PER_PARTICLE_BLOCK(part0, part);
+        track_ac_dipole_vertical_single_particle(
+            part,
+            vrf,
+            omega,
+            phirf,
+            ramp1,
+            ramp2,
+            ramp3,
+            ramp4
+        );
+    END_PER_PARTICLE_BLOCK;
+}
+
+#endif

--- a/xtrack/beam_elements/elements_src/thin_hacdipole.h
+++ b/xtrack/beam_elements/elements_src/thin_hacdipole.h
@@ -1,0 +1,26 @@
+// copyright ############################### //
+// This file is part of the Xtrack Package.  //
+// Copyright (c) CERN, 2025.                 //
+// ######################################### //
+
+#ifndef XTRACK_THIN_HACDIPOLE_H
+#define XTRACK_THIN_HACDIPOLE_H
+
+#include <headers/track.h>
+#include <beam_elements/elements_src/track_acdipole.h>
+
+
+GPUFUN void ACDipoleThinHorizontal_track_local_particle(
+    ACDipoleThinHorizontalData el,
+    LocalParticle* part0
+) {
+    const double eff_grad = ACDipoleThinHorizontalData_get_eff_grad(el);
+    START_PER_PARTICLE_BLOCK(part0, part);
+        track_thin_ac_dipole_horizontal_single_particle(
+            part,
+            eff_grad
+        );
+    END_PER_PARTICLE_BLOCK;
+}
+
+#endif

--- a/xtrack/beam_elements/elements_src/thin_vacdipole.h
+++ b/xtrack/beam_elements/elements_src/thin_vacdipole.h
@@ -1,0 +1,25 @@
+// copyright ############################### //
+// This file is part of the Xtrack Package.  //
+// Copyright (c) CERN, 2025.                 //
+// ######################################### //
+
+#ifndef XTRACK_THIN_VACDIPOLE_H
+#define XTRACK_THIN_VACDIPOLE_H
+
+#include <headers/track.h>
+#include <beam_elements/elements_src/track_acdipole.h>
+
+
+GPUFUN void ACDipoleThinVertical_track_local_particle(
+    ACDipoleThinVerticalData el,
+    LocalParticle* part0
+) {
+    const double eff_grad = ACDipoleThinVerticalData_get_eff_grad(el);
+    START_PER_PARTICLE_BLOCK(part0, part);
+        track_thin_ac_dipole_vertical_single_particle(
+            part,
+            eff_grad);
+    END_PER_PARTICLE_BLOCK;
+}
+
+#endif

--- a/xtrack/beam_elements/elements_src/track_acdipole.h
+++ b/xtrack/beam_elements/elements_src/track_acdipole.h
@@ -1,0 +1,108 @@
+// copyright ############################### //
+// This file is part of the Xtrack Package.  //
+// Copyright (c) CERN, 2025.                 //
+// ######################################### //
+#ifndef XTRACK_TRACK_ACDIPOLE_H
+#define XTRACK_TRACK_ACDIPOLE_H
+
+#include <headers/track.h>
+
+GPUFUN
+void track_ac_dipole_vertical_single_particle(
+    LocalParticle* part,
+    double vrf,
+    double omega,
+    double phirf,
+    int16_t ramp1,
+    int16_t ramp2,
+    int16_t ramp3,
+    int16_t ramp4)
+{
+    double const at_turn = LocalParticle_get_at_turn(part);
+    double const p0c = LocalParticle_get_p0c(part) / 1e9; // Convert to GeV/c
+    
+    double vrf_scaled;
+    if (at_turn < ramp1)
+    { // voltage stable at zero
+        vrf_scaled = 0.0;
+    }
+    else if (at_turn < ramp2)
+    { // ramping up the voltage
+        vrf_scaled = (at_turn - ramp1) * vrf / (ramp2 - ramp1);
+    }
+    else if (at_turn < ramp3)
+    { // voltage stable at maximum
+        vrf_scaled = vrf;
+    }
+    else if (at_turn < ramp4)
+    { // ramping down the voltage
+        vrf_scaled = (ramp4 - at_turn) * vrf / (ramp4 - ramp3);
+    }
+    else
+    { // stable again at zero
+        vrf_scaled = 0.0;
+    }
+    double const kick_y = vrf_scaled / p0c * sin(phirf + omega * at_turn);
+    LocalParticle_add_to_py(part, kick_y);
+}
+
+GPUFUN
+void track_ac_dipole_horizontal_single_particle(
+    LocalParticle* part,
+    double vrf,
+    double omega,
+    double phirf,
+    int16_t ramp1,
+    int16_t ramp2,
+    int16_t ramp3,
+    int16_t ramp4)
+{
+    double const at_turn = LocalParticle_get_at_turn(part);
+    double const p0c = LocalParticle_get_p0c(part) / 1e9; // Convert to GeV/c
+
+    double vrf_scaled;
+    if (at_turn < ramp1)
+    { // voltage stable at zero
+        vrf_scaled = 0.0;
+    }
+    else if (at_turn < ramp2)
+    { // ramping up the voltage
+        vrf_scaled = (at_turn - ramp1) * vrf / (ramp2 - ramp1);
+    }
+    else if (at_turn < ramp3)
+    { // voltage stable at maximum
+        vrf_scaled = vrf;
+    }
+    else if (at_turn < ramp4)
+    { // ramping down the voltage
+        vrf_scaled = (ramp4 - at_turn) * vrf / (ramp4 - ramp3);
+    }
+    else
+    { // stable again at zero
+        vrf_scaled = 0.0;
+    }
+
+    double const kick_x = vrf_scaled / p0c * sin(phirf + omega * at_turn);
+    LocalParticle_add_to_px(part, kick_x);
+}
+
+GPUFUN
+void track_thin_ac_dipole_vertical_single_particle(
+    LocalParticle* part,
+    double eff_grad)
+{
+    double const y = LocalParticle_get_y(part);
+    LocalParticle_add_to_py(part, eff_grad * y);
+}
+
+GPUFUN
+void track_thin_ac_dipole_horizontal_single_particle(
+    LocalParticle* part,
+    double eff_grad)
+{
+    double const x = LocalParticle_get_x(part);
+    LocalParticle_add_to_px(part, eff_grad * x);
+}
+
+#endif
+


### PR DESCRIPTION
## Description
Here I implement a thick and a thin AC-dipole along with tests. 

Currently fails on personal computer due to:
```
E   NameError: name 'ThickSliceSolenoid' is not defined

python3.11/site-packages/xsuite/kernel_definitions.py:72: NameError
```

Will the documentation inside the element classes be automatically inserted? I.e. Do I need to write additional documentation? 

Also, help with how to run the GPU contexts would be nice!

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones. 
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable.
- [ ] I have tested also GPU contexts.
