### PR TITLE
Fix fringe symplecticity

### DIFF
--- a/tests/test_quadrupole_fringe_ptc.py
+++ b/tests/test_quadrupole_fringe_ptc.py
@@ -9,17 +9,23 @@ def test_quadrupole_fringe_ptc():
     b1 = 0
     length=1e-20
 
+    # Initial conditions
     x0 = 0.07
     px0 = 0.03
     y0 = 0.08
     py0 = 0.06
+    zeta0 = 0.04
+    delta0=0.1
+    beta0=0.1
 
+    p0 = xt.Particles(x=x0,px=px0,y=y0,py=py0,delta=delta0,zeta=zeta0,beta0=beta0)
+    
+    ptau0 = float(p0.ptau)
+    tau0 = zeta0/beta0
+    
     # XSuite
     quadrupole = xt.Bend(length=length, k0=b1, k1=b2, edge_entry_model='1', edge_exit_model='1')  # 1 with quadrupole fringe
     line = xt.Line(elements=[ quadrupole])
-
-    p0 = xt.Particles(x=x0,px=px0,y=y0,py=py0)
-
     line.discard_tracker()
     line.build_tracker()
     line.track(p0)
@@ -29,10 +35,11 @@ def test_quadrupole_fringe_ptc():
     
     assert np.isclose(det, 1.0)
 
+    # PTC
     madx_sequence = line.to_madx_sequence('quadrupole_fringes')
 
     madx = Madx()
-    madx.beam()
+    madx.beam(particle='proton', beta=beta0)
     madx.input(madx_sequence)
     madx.use('quadrupole_fringes')
     
@@ -40,8 +47,8 @@ def test_quadrupole_fringe_ptc():
                ptc_create_universe;
                ptc_create_layout, exact=true;
                ptc_setswitch, fringe=true;
-               ptc_start, x={x0}, px={px0}, y={y0}, py={py0}, t=0.0, pt=0.0;
-               ptc_track, TURNS=1;
+               ptc_start, x={x0}, px={px0}, y={y0}, py={py0}, t={tau0}, pt={ptau0};
+               ptc_track, icase=6, TURNS=1;
                ptc_track_end;
                ptc_end;
                stop;
@@ -50,7 +57,10 @@ def test_quadrupole_fringe_ptc():
     
     df = madx.table.tracksumm.dframe()
     
+    
     assert np.isclose(p0.x, df.x[-1])
     assert np.isclose(p0.px, df.px[-1])
     assert np.isclose(p0.y, df.y[-1])
     assert np.isclose(p0.py, df.py[-1])
+    assert np.isclose(p0.ptau, df.pt[-1])
+    assert np.isclose(p0.zeta/p0.beta0, df.t[-1])

--- a/tests/test_quadrupole_fringe_ptc.py
+++ b/tests/test_quadrupole_fringe_ptc.py
@@ -1,35 +1,37 @@
 # Checks entrance fringe for very strong quadrupole against values of PTC
 
 import xtrack as xt
+import numpy as np
 
-angle = 0
-b2 = 100
-b1 = 0
-length=1e-20
+def test_quadrupole_fringe_ptc():
+    angle = 0
+    b2 = 100
+    b1 = 0
+    length=1e-20
 
-x0 = 0.1
-px0 = 0.1
-y0 = 0.1
-py0 = 0
-t0 = 0.0
-pt0 = 0.0  # Convert to xsuite if nonzero
+    x0 = 0.1
+    px0 = 0.1
+    y0 = 0.1
+    py0 = 0
+    t0 = 0.0
+    pt0 = 0.0  # Convert to xsuite if nonzero
 
-# XSuite
-quadrupole = xt.Bend(length=length, k0=b1, k1=b2, edge_entry_angle=angle, edge_entry_model='1', edge_exit_model='-1')  # 1 with quadrupole fringe
-line = xt.Line(elements=[ quadrupole])
+    # XSuite
+    quadrupole = xt.Bend(length=length, k0=b1, k1=b2, edge_entry_angle=angle, edge_entry_model='1', edge_exit_model='-1')  # 1 with quadrupole fringe
+    line = xt.Line(elements=[ quadrupole])
 
-p0 = xt.Particles(x=x0,px=px0,y=y0,py=py0)
+    p0 = xt.Particles(x=x0,px=px0,y=y0,py=py0)
 
-line.discard_tracker()
-line.build_tracker(use_prebuilt_kernels=False)
-line.track(p0)
+    line.discard_tracker()
+    line.build_tracker(use_prebuilt_kernels=False)
+    line.track(p0)
 
-x_ptc = 0.13333333333333336
-px_ptc = 5.0000000000000003e-002
-y_ptc = 6.6666666666666666e-002
-py_ptc = -5.0000000000000003e-002
+    x_ptc = 0.13333333333333336
+    px_ptc = 5.0000000000000003e-002
+    y_ptc = 6.6666666666666666e-002
+    py_ptc = -5.0000000000000003e-002
 
-assert np.isclose(p0.x, x_ptc)
-assert np.isclose(p0.px, px_ptc)
-assert np.isclose(p0.y, y_ptc)
-assert np.isclose(p0.py, py_ptc)
+    assert np.isclose(p0.x, x_ptc)
+    assert np.isclose(p0.px, px_ptc)
+    assert np.isclose(p0.y, y_ptc)
+    assert np.isclose(p0.py, py_ptc)

--- a/tests/test_quadrupole_fringe_ptc.py
+++ b/tests/test_quadrupole_fringe_ptc.py
@@ -2,36 +2,55 @@
 
 import xtrack as xt
 import numpy as np
+from cpymad.madx import Madx
 
 def test_quadrupole_fringe_ptc():
-    angle = 0
     b2 = 100
     b1 = 0
     length=1e-20
 
-    x0 = 0.1
-    px0 = 0.1
-    y0 = 0.1
-    py0 = 0
-    t0 = 0.0
-    pt0 = 0.0  # Convert to xsuite if nonzero
+    x0 = 0.07
+    px0 = 0.03
+    y0 = 0.08
+    py0 = 0.06
 
     # XSuite
-    quadrupole = xt.Bend(length=length, k0=b1, k1=b2, edge_entry_angle=angle, edge_entry_model='1', edge_exit_model='-1')  # 1 with quadrupole fringe
+    quadrupole = xt.Bend(length=length, k0=b1, k1=b2, edge_entry_model='1', edge_exit_model='1')  # 1 with quadrupole fringe
     line = xt.Line(elements=[ quadrupole])
 
     p0 = xt.Particles(x=x0,px=px0,y=y0,py=py0)
 
     line.discard_tracker()
-    line.build_tracker(use_prebuilt_kernels=False)
+    line.build_tracker()
     line.track(p0)
+    
+    mat = line.compute_one_turn_matrix_finite_differences(p0)['R_matrix']
+    det = np.linalg.det(mat)
+    
+    assert np.isclose(det, 1.0)
 
-    x_ptc = 0.13333333333333336
-    px_ptc = 5.0000000000000003e-002
-    y_ptc = 6.6666666666666666e-002
-    py_ptc = -5.0000000000000003e-002
+    madx_sequence = line.to_madx_sequence('quadrupole_fringes')
 
-    assert np.isclose(p0.x, x_ptc)
-    assert np.isclose(p0.px, px_ptc)
-    assert np.isclose(p0.y, y_ptc)
-    assert np.isclose(p0.py, py_ptc)
+    madx = Madx()
+    madx.beam()
+    madx.input(madx_sequence)
+    madx.use('quadrupole_fringes')
+    
+    madx.input(f"""
+               ptc_create_universe;
+               ptc_create_layout, exact=true;
+               ptc_setswitch, fringe=true;
+               ptc_start, x={x0}, px={px0}, y={y0}, py={py0}, t=0.0, pt=0.0;
+               ptc_track, TURNS=1;
+               ptc_track_end;
+               ptc_end;
+               stop;
+               """
+               )
+    
+    df = madx.table.tracksumm.dframe()
+    
+    assert np.isclose(p0.x, df.x[-1])
+    assert np.isclose(p0.px, df.px[-1])
+    assert np.isclose(p0.y, df.y[-1])
+    assert np.isclose(p0.py, df.py[-1])

--- a/tests/test_quadrupole_fringe_ptc.py
+++ b/tests/test_quadrupole_fringe_ptc.py
@@ -1,0 +1,35 @@
+# Checks entrance fringe for very strong quadrupole against values of PTC
+
+import xtrack as xt
+
+angle = 0
+b2 = 100
+b1 = 0
+length=1e-20
+
+x0 = 0.1
+px0 = 0.1
+y0 = 0.1
+py0 = 0
+t0 = 0.0
+pt0 = 0.0  # Convert to xsuite if nonzero
+
+# XSuite
+quadrupole = xt.Bend(length=length, k0=b1, k1=b2, edge_entry_angle=angle, edge_entry_model='1', edge_exit_model='-1')  # 1 with quadrupole fringe
+line = xt.Line(elements=[ quadrupole])
+
+p0 = xt.Particles(x=x0,px=px0,y=y0,py=py0)
+
+line.discard_tracker()
+line.build_tracker(use_prebuilt_kernels=False)
+line.track(p0)
+
+x_ptc = 0.13333333333333336
+px_ptc = 5.0000000000000003e-002
+y_ptc = 6.6666666666666666e-002
+py_ptc = -5.0000000000000003e-002
+
+assert np.isclose(p0.x, x_ptc)
+assert np.isclose(p0.px, px_ptc)
+assert np.isclose(p0.y, y_ptc)
+assert np.isclose(p0.py, py_ptc)

--- a/xtrack/beam_elements/elements_src/track_mult_fringe.h
+++ b/xtrack/beam_elements/elements_src/track_mult_fringe.h
@@ -41,8 +41,7 @@ void MultFringe_track_single_particle(
     const double t = LocalParticle_get_zeta(part) / beta0;
     const double pt = LocalParticle_get_ptau(part);
 
-    const double one_plus_delta = LocalParticle_get_delta(part) + 1.0;
-    const double pz = sqrt(POW2(one_plus_delta) - POW2(px) - POW2(py));
+    const double rpp = LocalParticle_get_rpp(part);
 
     double rx = 1;
     double ix = 0;
@@ -112,18 +111,18 @@ void MultFringe_track_single_particle(
 
     }
 
-    double a = 1 - fxx / pz;
-    double b = -fyx / pz;
-    double c = -fxy / pz;
-    double d = 1 - fyy / pz;
+    double a = 1 - fxx * rpp;
+    double b = -fyx * rpp;
+    double c = -fxy * rpp;
+    double d = 1 - fyy * rpp;
     double det = 1 / (a * d - b * c);
 
     double new_px = (d * px - b * py) / det;
     double new_py = (a * py - c * px) / det;
-    double delta_t = (1 / beta0 + pt) * (new_px * fx + new_py * fy) / POW3(pz);
+    double delta_t = (1 / beta0 + pt) * (new_px * fx + new_py * fy) * POW3(rpp);
 
-    LocalParticle_add_to_x(part, -fx / pz);
-    LocalParticle_add_to_y(part, -fy / pz);
+    LocalParticle_add_to_x(part, -fx * rpp);
+    LocalParticle_add_to_y(part, -fy * rpp);
     LocalParticle_set_px(part, new_px);
     LocalParticle_set_py(part, new_py);
     LocalParticle_set_zeta(part, (t + delta_t) * beta0);

--- a/xtrack/beam_elements/elements_src/track_mult_fringe.h
+++ b/xtrack/beam_elements/elements_src/track_mult_fringe.h
@@ -115,7 +115,7 @@ void MultFringe_track_single_particle(
     double b = -fyx * rpp;
     double c = -fxy * rpp;
     double d = 1 - fyy * rpp;
-    double det = 1 / (a * d - b * c);
+    double det = (a * d - b * c);
 
     double new_px = (d * px - b * py) / det;
     double new_py = (a * py - c * px) / det;


### PR DESCRIPTION
## Description

Replacing pz with 1+delta in multipole fringe fields, needed for symplecticity of the map. Added test for entrance quadrupole fringe compared to values of PTC, which now agree exactly. The determinant of line.compute_one_turn_matrix_finite_differences(p0)['R_matrix'] does not seem sensitive enough to capture the difference in symplecticity.

## Checklist

Mandatory: 

- [X] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
