### PR TITLE
Remove test_lhc_match_phase_15 from the GPU test suite

### DIFF
--- a/tests/test_lhc_match_phase_15.py
+++ b/tests/test_lhc_match_phase_15.py
@@ -17,9 +17,9 @@ test_data_folder = pathlib.Path(
     'config',
     ['noshift', 'shift']
 )
-@for_all_test_contexts
 @fix_random_seed(2836475)
-def test_lhc_match_phase_15(test_context, config):
+def test_lhc_match_phase_15(config):
+    test_context = xo.ContextCpu()
 
     if config == 'noshift':
         d_mux_15_b1 = 0


### PR DESCRIPTION
## Description

This removes the `test_lhc_match_phase_15` as it's not necessary and takes a very long time to run.

## Checklist

Mandatory: 

- [-] I have added tests to cover my changes
- [-] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [-] I have updated the docs in relation to my changes, if applicable
- [-] I have tested also GPU contexts
