### PR TITLE
remove duplicate import in example

### DIFF
--- a/examples/psb/000a_all_xsuite_import_model.py
+++ b/examples/psb/000a_all_xsuite_import_model.py
@@ -5,8 +5,6 @@ import xtrack as xt
 
 import matplotlib.pyplot as plt
 
-from cpymad.madx import Madx
-
 mad = Madx()
 
 # Load mad model and apply element shifts


### PR DESCRIPTION
## Description
Removes duplicate import of cpymad in example used in the documentation

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
