### PR TITLE
Feature/sol shift

### DIFF
--- a/examples/solenoid/004_solenoid_shift.py
+++ b/examples/solenoid/004_solenoid_shift.py
@@ -1,5 +1,6 @@
 import xtrack as xt
 import numpy as np
+import xobjects as xo
 
 # TODO:
 # - field for radiation and spin
@@ -7,11 +8,21 @@ import numpy as np
 env = xt.Environment()
 env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)
 
-line = env.new_line(components=[
-    env.new('sol',xt.UniformSolenoid, length=3, ks=0.2, x0=0.1, y0=0.2),
+line_ref = env.new_line(components=[
+    env.new('sol_ref',xt.UniformSolenoid, length=3, ks=0.2),
     ])
+line_ref.cut_at_s(np.linspace(0, 3, 5))
+tw_ref = line_ref.twiss(x=0.1, y=0.2, betx=1, bety=1)
 
-line.cut_at_s(np.linspace(0, 3, 5))
 
-tw = line.twiss(x=0.1, y=0.2, betx=1, bety=1)
+x0 = 0.05
+y0 = 0.15
+line_test = env.new_line(components=[
+    env.new('solt_test', xt.UniformSolenoid, length=3, ks=0.2, x0=x0, y0=y0),
+    ])
+line_test.cut_at_s(np.linspace(0, 3, 5))
+tw_test = line_test.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
+
+xo.assert_near(tw_test.x, tw_ref.x + x0, rtol=0, atol=1e-14)
+
 

--- a/examples/solenoid/004_solenoid_shift.py
+++ b/examples/solenoid/004_solenoid_shift.py
@@ -59,3 +59,31 @@ for ttest, tref in zip([tw_ref_back, tw_test_back, tw_ref_thick_back, tw_test_th
     xo.assert_allclose(ttest.py, tref.py, rtol=0, atol=1e-14)
     xo.assert_allclose(ttest.kin_px, tref.kin_px, rtol=0, atol=1e-14)
     xo.assert_allclose(ttest.kin_py, tref.kin_py, rtol=0, atol=1e-14)
+
+
+line_ref.configure_radiation(model='mean')
+line_test.configure_radiation(model='mean')
+line_ref_thick.configure_radiation(model='mean')
+line_test_thick.configure_radiation(model='mean')
+
+tw_ref_rad = line_ref.twiss(x=0.1, y=0.2, betx=1, bety=1)
+tw_test_rad = line_test.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
+tw_ref_thick_rad = line_ref_thick.twiss(x=0.1, y=0.2, betx=1, bety=1)
+tw_test_thick_rad = line_test_thick.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
+
+assert tw_test_rad.delta[-1] < -5e-6
+xo.assert_allclose(tw_test_rad.x, tw_ref_rad.x + x0, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_rad.y, tw_ref_rad.y + y0, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_rad.px, tw_ref_rad.px, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_rad.py, tw_ref_rad.py, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_rad.kin_px, tw_ref_rad.kin_px, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_rad.kin_py, tw_ref_rad.kin_py, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_rad.delta, tw_ref_rad.delta, rtol=0, atol=1e-14)
+
+xo.assert_allclose(tw_test_thick_rad.x, tw_ref_thick_rad.x + x0, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick_rad.y, tw_ref_thick_rad.y + y0, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick_rad.px, tw_ref_thick_rad.px, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick_rad.py, tw_ref_thick_rad.py, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick_rad.kin_px, tw_ref_thick_rad.kin_px, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick_rad.kin_py, tw_ref_thick_rad.kin_py, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick_rad.delta, tw_ref_thick_rad.delta, rtol=0, atol=1e-14)

--- a/examples/solenoid/004_solenoid_shift.py
+++ b/examples/solenoid/004_solenoid_shift.py
@@ -4,12 +4,15 @@ import xobjects as xo
 
 # TODO:
 # - field for radiation and spin
+# - check backtrack
+# - check variable solenoid
 
 env = xt.Environment()
 env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)
 
 line_ref = env.new_line(components=[
     env.new('sol_ref',xt.UniformSolenoid, length=3, ks=0.2),
+    env.new('end', xt.Marker)
     ])
 line_ref_thick = line_ref.copy(shallow=True)
 line_ref.cut_at_s(np.linspace(0, 3, 5))
@@ -20,6 +23,7 @@ x0 = 0.05
 y0 = 0.15
 line_test = env.new_line(components=[
     env.new('solt_test', xt.UniformSolenoid, length=3, ks=0.2, x0=x0, y0=y0),
+    env.place('end')
     ])
 line_test_thick = line_test.copy(shallow=True)
 line_test.cut_at_s(np.linspace(0, 3, 5))
@@ -46,3 +50,17 @@ xo.assert_allclose(tw_test_thick.px[-1], tw_test.px[-1], rtol=0, atol=1e-14)
 xo.assert_allclose(tw_test_thick.py[-1], tw_test.py[-1], rtol=0, atol=1e-14)
 xo.assert_allclose(tw_test_thick.kin_px[-1], tw_test.kin_px[-1], rtol=0, atol=1e-14)
 xo.assert_allclose(tw_test_thick.kin_py[-1], tw_test.kin_py[-1], rtol=0, atol=1e-14)
+
+tw_ref_back = line_ref.twiss(init=tw_ref, init_at='end')
+tw_test_back = line_test.twiss(init=tw_test, init_at='end')
+tw_ref_thick_back = line_ref_thick.twiss(init=tw_ref_thick, init_at='end')
+tw_test_thick_back = line_test_thick.twiss(init=tw_test_thick, init_at='end')
+
+for ttest, tref in zip([tw_ref_back, tw_test_back, tw_ref_thick_back, tw_test_thick_back],
+                       [tw_ref, tw_test, tw_ref_thick, tw_test_thick]):
+    xo.assert_allclose(ttest.x, tref.x, rtol=0, atol=1e-14)
+    xo.assert_allclose(ttest.y, tref.y, rtol=0, atol=1e-14)
+    xo.assert_allclose(ttest.px, tref.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(ttest.py, tref.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(ttest.kin_px, tref.kin_px, rtol=0, atol=1e-14)
+    xo.assert_allclose(ttest.kin_py, tref.kin_py, rtol=0, atol=1e-14)

--- a/examples/solenoid/004_solenoid_shift.py
+++ b/examples/solenoid/004_solenoid_shift.py
@@ -11,18 +11,38 @@ env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)
 line_ref = env.new_line(components=[
     env.new('sol_ref',xt.UniformSolenoid, length=3, ks=0.2),
     ])
+line_ref_thick = line_ref.copy(shallow=True)
 line_ref.cut_at_s(np.linspace(0, 3, 5))
 tw_ref = line_ref.twiss(x=0.1, y=0.2, betx=1, bety=1)
-
+tw_ref_thick = line_ref_thick.twiss(x=0.1, y=0.2, betx=1, bety=1)
 
 x0 = 0.05
 y0 = 0.15
 line_test = env.new_line(components=[
     env.new('solt_test', xt.UniformSolenoid, length=3, ks=0.2, x0=x0, y0=y0),
     ])
+line_test_thick = line_test.copy(shallow=True)
 line_test.cut_at_s(np.linspace(0, 3, 5))
 tw_test = line_test.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
+tw_test_thick = line_test_thick.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
 
-xo.assert_near(tw_test.x, tw_ref.x + x0, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test.x, tw_ref.x + x0, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test.y, tw_ref.y + y0, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test.px, tw_ref.px, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test.py, tw_ref.py, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test.kin_px, tw_ref.kin_px, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test.kin_py, tw_ref.kin_py, rtol=0, atol=1e-14)
 
+xo.assert_allclose(tw_ref_thick.x[-1], tw_ref.x[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_ref_thick.y[-1], tw_ref.y[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_ref_thick.px[-1], tw_ref.px[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_ref_thick.py[-1], tw_ref.py[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_ref_thick.kin_px[-1], tw_ref.kin_px[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_ref_thick.kin_py[-1], tw_ref.kin_py[-1], rtol=0, atol=1e-14)
 
+xo.assert_allclose(tw_test_thick.x[-1], tw_test.x[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick.y[-1], tw_test.y[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick.px[-1], tw_test.px[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick.py[-1], tw_test.py[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick.kin_px[-1], tw_test.kin_px[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick.kin_py[-1], tw_test.kin_py[-1], rtol=0, atol=1e-14)

--- a/examples/solenoid/004_solenoid_shift.py
+++ b/examples/solenoid/004_solenoid_shift.py
@@ -2,11 +2,6 @@ import xtrack as xt
 import numpy as np
 import xobjects as xo
 
-# TODO:
-# - field for radiation and spin
-# - check backtrack
-# - check variable solenoid
-
 env = xt.Environment()
 env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)
 

--- a/examples/solenoid/004_solenoid_shift.py
+++ b/examples/solenoid/004_solenoid_shift.py
@@ -1,0 +1,17 @@
+import xtrack as xt
+import numpy as np
+
+# TODO:
+# - field for radiation and spin
+
+env = xt.Environment()
+env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)
+
+line = env.new_line(components=[
+    env.new('sol',xt.UniformSolenoid, length=3, ks=0.2)
+    ])
+
+line.cut_at_s(np.linspace(0, 3, 5))
+
+tw = line.twiss(x=0.1, y=0.2, betx=1, bety=1)
+

--- a/examples/solenoid/004_solenoid_shift.py
+++ b/examples/solenoid/004_solenoid_shift.py
@@ -8,7 +8,7 @@ env = xt.Environment()
 env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)
 
 line = env.new_line(components=[
-    env.new('sol',xt.UniformSolenoid, length=3, ks=0.2)
+    env.new('sol',xt.UniformSolenoid, length=3, ks=0.2, x0=0.1, y0=0.2),
     ])
 
 line.cut_at_s(np.linspace(0, 3, 5))

--- a/examples/solenoid/004b_variable_solenoid_shift.py
+++ b/examples/solenoid/004b_variable_solenoid_shift.py
@@ -16,9 +16,7 @@ line_ref = env.new_line(components=[
     env.new('sol_ref2', xt.VariableSolenoid, length=3, ks_profile=[0.3, 0.]),
     env.new('end', xt.Marker)
     ])
-line_ref_thick = line_ref.copy(shallow=True)
 tw_ref = line_ref.twiss(x=0.1, y=0.2, betx=1, bety=1)
-tw_ref_thick = line_ref_thick.twiss(x=0.1, y=0.2, betx=1, bety=1)
 
 x0 = 0.05
 y0 = 0.15
@@ -28,9 +26,7 @@ line_test = env.new_line(components=[
     env.new('solt_test2', xt.VariableSolenoid, length=3, ks_profile=[0.3, 0.], x0=x0, y0=y0),
     env.place('end')
     ])
-line_test_thick = line_test.copy(shallow=True)
 tw_test = line_test.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
-tw_test_thick = line_test_thick.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
 
 xo.assert_allclose(tw_test.x, tw_ref.x + x0, rtol=0, atol=1e-14)
 xo.assert_allclose(tw_test.y, tw_ref.y + y0, rtol=0, atol=1e-14)
@@ -39,27 +35,11 @@ xo.assert_allclose(tw_test.py, tw_ref.py, rtol=0, atol=1e-14)
 xo.assert_allclose(tw_test.kin_px, tw_ref.kin_px, rtol=0, atol=1e-14)
 xo.assert_allclose(tw_test.kin_py, tw_ref.kin_py, rtol=0, atol=1e-14)
 
-xo.assert_allclose(tw_ref_thick.x[-1], tw_ref.x[-1], rtol=0, atol=1e-14)
-xo.assert_allclose(tw_ref_thick.y[-1], tw_ref.y[-1], rtol=0, atol=1e-14)
-xo.assert_allclose(tw_ref_thick.px[-1], tw_ref.px[-1], rtol=0, atol=1e-14)
-xo.assert_allclose(tw_ref_thick.py[-1], tw_ref.py[-1], rtol=0, atol=1e-14)
-xo.assert_allclose(tw_ref_thick.kin_px[-1], tw_ref.kin_px[-1], rtol=0, atol=1e-14)
-xo.assert_allclose(tw_ref_thick.kin_py[-1], tw_ref.kin_py[-1], rtol=0, atol=1e-14)
-
-xo.assert_allclose(tw_test_thick.x[-1], tw_test.x[-1], rtol=0, atol=1e-14)
-xo.assert_allclose(tw_test_thick.y[-1], tw_test.y[-1], rtol=0, atol=1e-14)
-xo.assert_allclose(tw_test_thick.px[-1], tw_test.px[-1], rtol=0, atol=1e-14)
-xo.assert_allclose(tw_test_thick.py[-1], tw_test.py[-1], rtol=0, atol=1e-14)
-xo.assert_allclose(tw_test_thick.kin_px[-1], tw_test.kin_px[-1], rtol=0, atol=1e-14)
-xo.assert_allclose(tw_test_thick.kin_py[-1], tw_test.kin_py[-1], rtol=0, atol=1e-14)
-
 tw_ref_back = line_ref.twiss(init=tw_ref, init_at='end')
 tw_test_back = line_test.twiss(init=tw_test, init_at='end')
-tw_ref_thick_back = line_ref_thick.twiss(init=tw_ref_thick, init_at='end')
-tw_test_thick_back = line_test_thick.twiss(init=tw_test_thick, init_at='end')
 
-for ttest, tref in zip([tw_ref_back, tw_test_back, tw_ref_thick_back, tw_test_thick_back],
-                       [tw_ref, tw_test, tw_ref_thick, tw_test_thick]):
+for ttest, tref in zip([tw_ref_back, tw_test_back],
+                       [tw_ref, tw_test]):
     xo.assert_allclose(ttest.x, tref.x, rtol=0, atol=1e-14)
     xo.assert_allclose(ttest.y, tref.y, rtol=0, atol=1e-14)
     xo.assert_allclose(ttest.px, tref.px, rtol=0, atol=1e-14)

--- a/examples/solenoid/004b_variable_solenoid_shift.py
+++ b/examples/solenoid/004b_variable_solenoid_shift.py
@@ -46,3 +46,18 @@ for ttest, tref in zip([tw_ref_back, tw_test_back],
     xo.assert_allclose(ttest.py, tref.py, rtol=0, atol=1e-14)
     xo.assert_allclose(ttest.kin_px, tref.kin_px, rtol=0, atol=1e-14)
     xo.assert_allclose(ttest.kin_py, tref.kin_py, rtol=0, atol=1e-14)
+
+line_ref.configure_radiation(model='mean')
+line_test.configure_radiation(model='mean')
+
+tw_ref_rad = line_ref.twiss(x=0.1, y=0.2, betx=1, bety=1)
+tw_test_rad = line_test.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
+
+assert tw_test_rad.delta[-1] < -5e-5
+xo.assert_allclose(tw_test_rad.x, tw_ref_rad.x + x0, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_rad.y, tw_ref_rad.y + y0, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_rad.px, tw_ref_rad.px, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_rad.py, tw_ref_rad.py, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_rad.kin_px, tw_ref_rad.kin_px, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_rad.kin_py, tw_ref_rad.kin_py, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_rad.delta, tw_ref_rad.delta, rtol=0, atol=1e-14)

--- a/examples/solenoid/004b_variable_solenoid_shift.py
+++ b/examples/solenoid/004b_variable_solenoid_shift.py
@@ -1,0 +1,64 @@
+import xtrack as xt
+import numpy as np
+import xobjects as xo
+
+# TODO:
+# - field for radiation and spin
+# - check backtrack
+# - check variable solenoid
+
+env = xt.Environment()
+env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)
+
+line_ref = env.new_line(components=[
+    env.new('sol_ref', xt.VariableSolenoid, length=3, ks_profile=[0.1, 0.3]),
+    env.new('end', xt.Marker)
+    ])
+line_ref_thick = line_ref.copy(shallow=True)
+tw_ref = line_ref.twiss(x=0.1, y=0.2, betx=1, bety=1)
+tw_ref_thick = line_ref_thick.twiss(x=0.1, y=0.2, betx=1, bety=1)
+
+x0 = 0.05
+y0 = 0.15
+line_test = env.new_line(components=[
+    env.new('solt_test', xt.VariableSolenoid, length=3, ks_profile=[0.1, 0.3], x0=x0, y0=y0),
+    env.place('end')
+    ])
+line_test_thick = line_test.copy(shallow=True)
+tw_test = line_test.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
+tw_test_thick = line_test_thick.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
+
+xo.assert_allclose(tw_test.x, tw_ref.x + x0, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test.y, tw_ref.y + y0, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test.px, tw_ref.px, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test.py, tw_ref.py, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test.kin_px, tw_ref.kin_px, rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test.kin_py, tw_ref.kin_py, rtol=0, atol=1e-14)
+
+xo.assert_allclose(tw_ref_thick.x[-1], tw_ref.x[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_ref_thick.y[-1], tw_ref.y[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_ref_thick.px[-1], tw_ref.px[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_ref_thick.py[-1], tw_ref.py[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_ref_thick.kin_px[-1], tw_ref.kin_px[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_ref_thick.kin_py[-1], tw_ref.kin_py[-1], rtol=0, atol=1e-14)
+
+xo.assert_allclose(tw_test_thick.x[-1], tw_test.x[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick.y[-1], tw_test.y[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick.px[-1], tw_test.px[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick.py[-1], tw_test.py[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick.kin_px[-1], tw_test.kin_px[-1], rtol=0, atol=1e-14)
+xo.assert_allclose(tw_test_thick.kin_py[-1], tw_test.kin_py[-1], rtol=0, atol=1e-14)
+
+tw_ref_back = line_ref.twiss(init=tw_ref, init_at='end')
+tw_test_back = line_test.twiss(init=tw_test, init_at='end')
+tw_ref_thick_back = line_ref_thick.twiss(init=tw_ref_thick, init_at='end')
+tw_test_thick_back = line_test_thick.twiss(init=tw_test_thick, init_at='end')
+
+for ttest, tref in zip([tw_ref_back, tw_test_back, tw_ref_thick_back, tw_test_thick_back],
+                       [tw_ref, tw_test, tw_ref_thick, tw_test_thick]):
+    xo.assert_allclose(ttest.x, tref.x, rtol=0, atol=1e-14)
+    xo.assert_allclose(ttest.y, tref.y, rtol=0, atol=1e-14)
+    xo.assert_allclose(ttest.px, tref.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(ttest.py, tref.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(ttest.kin_px, tref.kin_px, rtol=0, atol=1e-14)
+    xo.assert_allclose(ttest.kin_py, tref.kin_py, rtol=0, atol=1e-14)

--- a/examples/solenoid/004b_variable_solenoid_shift.py
+++ b/examples/solenoid/004b_variable_solenoid_shift.py
@@ -2,11 +2,6 @@ import xtrack as xt
 import numpy as np
 import xobjects as xo
 
-# TODO:
-# - field for radiation and spin
-# - check backtrack
-# - check variable solenoid
-
 env = xt.Environment()
 env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)
 

--- a/examples/solenoid/004b_variable_solenoid_shift.py
+++ b/examples/solenoid/004b_variable_solenoid_shift.py
@@ -11,7 +11,9 @@ env = xt.Environment()
 env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)
 
 line_ref = env.new_line(components=[
-    env.new('sol_ref', xt.VariableSolenoid, length=3, ks_profile=[0.1, 0.3]),
+    env.new('sol_ref0', xt.VariableSolenoid, length=3, ks_profile=[0., 0.1]),
+    env.new('sol_ref1', xt.VariableSolenoid, length=3, ks_profile=[0.1, 0.3]),
+    env.new('sol_ref2', xt.VariableSolenoid, length=3, ks_profile=[0.3, 0.]),
     env.new('end', xt.Marker)
     ])
 line_ref_thick = line_ref.copy(shallow=True)
@@ -21,7 +23,9 @@ tw_ref_thick = line_ref_thick.twiss(x=0.1, y=0.2, betx=1, bety=1)
 x0 = 0.05
 y0 = 0.15
 line_test = env.new_line(components=[
-    env.new('solt_test', xt.VariableSolenoid, length=3, ks_profile=[0.1, 0.3], x0=x0, y0=y0),
+    env.new('solt_test0', xt.VariableSolenoid, length=3, ks_profile=[0., 0.1], x0=x0, y0=y0),
+    env.new('solt_test1', xt.VariableSolenoid, length=3, ks_profile=[0.1, 0.3], x0=x0, y0=y0),
+    env.new('solt_test2', xt.VariableSolenoid, length=3, ks_profile=[0.3, 0.], x0=x0, y0=y0),
     env.place('end')
     ])
 line_test_thick = line_test.copy(shallow=True)

--- a/tests/test_elements_thick.py
+++ b/tests/test_elements_thick.py
@@ -2362,3 +2362,92 @@ def test_uniform_solenoid_with_slices(test_context, reference):
                     rtol=0, atol=1e-10)
     xo.assert_allclose(tw_back.rows[:'e0..0'].ay, tw['ay', 'e0..0'],
                     rtol=0, atol=1e-10)
+
+
+def test_uniform_solienoid_x0y0():
+
+    env = xt.Environment()
+    env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)
+
+    line_ref = env.new_line(components=[
+        env.new('sol_ref',xt.UniformSolenoid, length=3, ks=0.2),
+        env.new('end', xt.Marker)
+        ])
+    line_ref_thick = line_ref.copy(shallow=True)
+    line_ref.cut_at_s(np.linspace(0, 3, 5))
+    tw_ref = line_ref.twiss(x=0.1, y=0.2, betx=1, bety=1)
+    tw_ref_thick = line_ref_thick.twiss(x=0.1, y=0.2, betx=1, bety=1)
+
+    x0 = 0.05
+    y0 = 0.15
+    line_test = env.new_line(components=[
+        env.new('solt_test', xt.UniformSolenoid, length=3, ks=0.2, x0=x0, y0=y0),
+        env.place('end')
+        ])
+    line_test_thick = line_test.copy(shallow=True)
+    line_test.cut_at_s(np.linspace(0, 3, 5))
+    tw_test = line_test.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
+    tw_test_thick = line_test_thick.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
+
+    xo.assert_allclose(tw_test.x, tw_ref.x + x0, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test.y, tw_ref.y + y0, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test.px, tw_ref.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test.py, tw_ref.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test.kin_px, tw_ref.kin_px, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test.kin_py, tw_ref.kin_py, rtol=0, atol=1e-14)
+
+    xo.assert_allclose(tw_ref_thick.x[-1], tw_ref.x[-1], rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_ref_thick.y[-1], tw_ref.y[-1], rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_ref_thick.px[-1], tw_ref.px[-1], rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_ref_thick.py[-1], tw_ref.py[-1], rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_ref_thick.kin_px[-1], tw_ref.kin_px[-1], rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_ref_thick.kin_py[-1], tw_ref.kin_py[-1], rtol=0, atol=1e-14)
+
+    xo.assert_allclose(tw_test_thick.x[-1], tw_test.x[-1], rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_thick.y[-1], tw_test.y[-1], rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_thick.px[-1], tw_test.px[-1], rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_thick.py[-1], tw_test.py[-1], rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_thick.kin_px[-1], tw_test.kin_px[-1], rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_thick.kin_py[-1], tw_test.kin_py[-1], rtol=0, atol=1e-14)
+
+    tw_ref_back = line_ref.twiss(init=tw_ref, init_at='end')
+    tw_test_back = line_test.twiss(init=tw_test, init_at='end')
+    tw_ref_thick_back = line_ref_thick.twiss(init=tw_ref_thick, init_at='end')
+    tw_test_thick_back = line_test_thick.twiss(init=tw_test_thick, init_at='end')
+
+    for ttest, tref in zip([tw_ref_back, tw_test_back, tw_ref_thick_back, tw_test_thick_back],
+                        [tw_ref, tw_test, tw_ref_thick, tw_test_thick]):
+        xo.assert_allclose(ttest.x, tref.x, rtol=0, atol=1e-14)
+        xo.assert_allclose(ttest.y, tref.y, rtol=0, atol=1e-14)
+        xo.assert_allclose(ttest.px, tref.px, rtol=0, atol=1e-14)
+        xo.assert_allclose(ttest.py, tref.py, rtol=0, atol=1e-14)
+        xo.assert_allclose(ttest.kin_px, tref.kin_px, rtol=0, atol=1e-14)
+        xo.assert_allclose(ttest.kin_py, tref.kin_py, rtol=0, atol=1e-14)
+
+
+    line_ref.configure_radiation(model='mean')
+    line_test.configure_radiation(model='mean')
+    line_ref_thick.configure_radiation(model='mean')
+    line_test_thick.configure_radiation(model='mean')
+
+    tw_ref_rad = line_ref.twiss(x=0.1, y=0.2, betx=1, bety=1)
+    tw_test_rad = line_test.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
+    tw_ref_thick_rad = line_ref_thick.twiss(x=0.1, y=0.2, betx=1, bety=1)
+    tw_test_thick_rad = line_test_thick.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
+
+    assert tw_test_rad.delta[-1] < -5e-6
+    xo.assert_allclose(tw_test_rad.x, tw_ref_rad.x + x0, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_rad.y, tw_ref_rad.y + y0, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_rad.px, tw_ref_rad.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_rad.py, tw_ref_rad.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_rad.kin_px, tw_ref_rad.kin_px, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_rad.kin_py, tw_ref_rad.kin_py, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_rad.delta, tw_ref_rad.delta, rtol=0, atol=1e-14)
+
+    xo.assert_allclose(tw_test_thick_rad.x, tw_ref_thick_rad.x + x0, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_thick_rad.y, tw_ref_thick_rad.y + y0, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_thick_rad.px, tw_ref_thick_rad.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_thick_rad.py, tw_ref_thick_rad.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_thick_rad.kin_px, tw_ref_thick_rad.kin_px, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_thick_rad.kin_py, tw_ref_thick_rad.kin_py, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_thick_rad.delta, tw_ref_thick_rad.delta, rtol=0, atol=1e-14)

--- a/tests/test_elements_thick.py
+++ b/tests/test_elements_thick.py
@@ -2426,6 +2426,10 @@ def test_uniform_solienoid_x0y0(test_context):
         xo.assert_allclose(ttest.kin_px, tref.kin_px, rtol=0, atol=1e-14)
         xo.assert_allclose(ttest.kin_py, tref.kin_py, rtol=0, atol=1e-14)
 
+    line_test.discard_tracker()
+    line_test_thick.discard_tracker()
+    line_test.build_tracker(xo.context_default)
+    line_test_thick.build_tracker(xo.context_default)
 
     line_ref.configure_radiation(model='mean')
     line_test.configure_radiation(model='mean')
@@ -2500,6 +2504,9 @@ def test_variable_solenoid_x0y0(test_context):
 
     line_ref.configure_radiation(model='mean')
     line_test.configure_radiation(model='mean')
+
+    line_test.discard_tracker()
+    line_test.build_tracker(xo.context_default)
 
     tw_ref_rad = line_ref.twiss(x=0.1, y=0.2, betx=1, bety=1)
     tw_test_rad = line_test.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)

--- a/tests/test_elements_thick.py
+++ b/tests/test_elements_thick.py
@@ -2363,7 +2363,8 @@ def test_uniform_solenoid_with_slices(test_context, reference):
     xo.assert_allclose(tw_back.rows[:'e0..0'].ay, tw['ay', 'e0..0'],
                     rtol=0, atol=1e-10)
 
-def test_uniform_solienoid_x0y0():
+@for_all_test_contexts
+def test_uniform_solienoid_x0y0(test_context):
 
     env = xt.Environment()
     env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)
@@ -2384,7 +2385,9 @@ def test_uniform_solienoid_x0y0():
         env.place('end')
         ])
     line_test_thick = line_test.copy(shallow=True)
+    line_test.build_tracker(test_context)
     line_test.cut_at_s(np.linspace(0, 3, 5))
+    line_test_thick.build_tracker(test_context)
     tw_test = line_test.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
     tw_test_thick = line_test_thick.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
 
@@ -2451,7 +2454,8 @@ def test_uniform_solienoid_x0y0():
     xo.assert_allclose(tw_test_thick_rad.kin_py, tw_ref_thick_rad.kin_py, rtol=0, atol=1e-14)
     xo.assert_allclose(tw_test_thick_rad.delta, tw_ref_thick_rad.delta, rtol=0, atol=1e-14)
 
-def test_variable_solenoid_x0y0():
+@for_all_test_contexts
+def test_variable_solenoid_x0y0(test_context):
 
     env = xt.Environment()
     env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)
@@ -2472,6 +2476,7 @@ def test_variable_solenoid_x0y0():
         env.new('solt_test2', xt.VariableSolenoid, length=3, ks_profile=[0.3, 0.], x0=x0, y0=y0),
         env.place('end')
         ])
+    line_test.build_tracker(test_context)
     tw_test = line_test.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
 
     xo.assert_allclose(tw_test.x, tw_ref.x + x0, rtol=0, atol=1e-14)

--- a/tests/test_elements_thick.py
+++ b/tests/test_elements_thick.py
@@ -2363,7 +2363,6 @@ def test_uniform_solenoid_with_slices(test_context, reference):
     xo.assert_allclose(tw_back.rows[:'e0..0'].ay, tw['ay', 'e0..0'],
                     rtol=0, atol=1e-10)
 
-
 def test_uniform_solienoid_x0y0():
 
     env = xt.Environment()
@@ -2451,3 +2450,60 @@ def test_uniform_solienoid_x0y0():
     xo.assert_allclose(tw_test_thick_rad.kin_px, tw_ref_thick_rad.kin_px, rtol=0, atol=1e-14)
     xo.assert_allclose(tw_test_thick_rad.kin_py, tw_ref_thick_rad.kin_py, rtol=0, atol=1e-14)
     xo.assert_allclose(tw_test_thick_rad.delta, tw_ref_thick_rad.delta, rtol=0, atol=1e-14)
+
+def test_variable_solenoid_x0y0():
+
+    env = xt.Environment()
+    env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)
+
+    line_ref = env.new_line(components=[
+        env.new('sol_ref0', xt.VariableSolenoid, length=3, ks_profile=[0., 0.1]),
+        env.new('sol_ref1', xt.VariableSolenoid, length=3, ks_profile=[0.1, 0.3]),
+        env.new('sol_ref2', xt.VariableSolenoid, length=3, ks_profile=[0.3, 0.]),
+        env.new('end', xt.Marker)
+        ])
+    tw_ref = line_ref.twiss(x=0.1, y=0.2, betx=1, bety=1)
+
+    x0 = 0.05
+    y0 = 0.15
+    line_test = env.new_line(components=[
+        env.new('solt_test0', xt.VariableSolenoid, length=3, ks_profile=[0., 0.1], x0=x0, y0=y0),
+        env.new('solt_test1', xt.VariableSolenoid, length=3, ks_profile=[0.1, 0.3], x0=x0, y0=y0),
+        env.new('solt_test2', xt.VariableSolenoid, length=3, ks_profile=[0.3, 0.], x0=x0, y0=y0),
+        env.place('end')
+        ])
+    tw_test = line_test.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
+
+    xo.assert_allclose(tw_test.x, tw_ref.x + x0, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test.y, tw_ref.y + y0, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test.px, tw_ref.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test.py, tw_ref.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test.kin_px, tw_ref.kin_px, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test.kin_py, tw_ref.kin_py, rtol=0, atol=1e-14)
+
+    tw_ref_back = line_ref.twiss(init=tw_ref, init_at='end')
+    tw_test_back = line_test.twiss(init=tw_test, init_at='end')
+
+    for ttest, tref in zip([tw_ref_back, tw_test_back],
+                        [tw_ref, tw_test]):
+        xo.assert_allclose(ttest.x, tref.x, rtol=0, atol=1e-14)
+        xo.assert_allclose(ttest.y, tref.y, rtol=0, atol=1e-14)
+        xo.assert_allclose(ttest.px, tref.px, rtol=0, atol=1e-14)
+        xo.assert_allclose(ttest.py, tref.py, rtol=0, atol=1e-14)
+        xo.assert_allclose(ttest.kin_px, tref.kin_px, rtol=0, atol=1e-14)
+        xo.assert_allclose(ttest.kin_py, tref.kin_py, rtol=0, atol=1e-14)
+
+    line_ref.configure_radiation(model='mean')
+    line_test.configure_radiation(model='mean')
+
+    tw_ref_rad = line_ref.twiss(x=0.1, y=0.2, betx=1, bety=1)
+    tw_test_rad = line_test.twiss(x=x0 + 0.1, y=y0 + 0.2, betx=1, bety=1)
+
+    assert tw_test_rad.delta[-1] < -5e-5
+    xo.assert_allclose(tw_test_rad.x, tw_ref_rad.x + x0, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_rad.y, tw_ref_rad.y + y0, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_rad.px, tw_ref_rad.px, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_rad.py, tw_ref_rad.py, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_rad.kin_px, tw_ref_rad.kin_px, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_rad.kin_py, tw_ref_rad.kin_py, rtol=0, atol=1e-14)
+    xo.assert_allclose(tw_test_rad.delta, tw_ref_rad.delta, rtol=0, atol=1e-14)

--- a/tests/test_elements_thick.py
+++ b/tests/test_elements_thick.py
@@ -2364,7 +2364,7 @@ def test_uniform_solenoid_with_slices(test_context, reference):
                     rtol=0, atol=1e-10)
 
 @for_all_test_contexts
-def test_uniform_solienoid_x0y0(test_context):
+def test_uniform_solenoid_x0y0(test_context):
 
     env = xt.Environment()
     env.particle_ref = xt.Particles(mass0=xt.ELECTRON_MASS_EV, p0c=20e9)

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -1939,6 +1939,10 @@ class UniformSolenoid(BeamElement):
         Strength of the solenoid component.
     length : float
         Length of the element in meters along the reference trajectory.
+    x0 : float, optional
+        Horizontal offset of the solenoid center in meters. Defaults to 0.
+    y0 : float, optional
+        Vertical offset of the solenoid center in meters. Defaults to 0.
     order : int, optional
         Maximum order of multipole expansion for this magnet. Defaults to 5.
     knl : list of floats, optional
@@ -1967,6 +1971,8 @@ class UniformSolenoid(BeamElement):
     _xofields={
         'ks': xo.Float64,
         'length': xo.Float64,
+        'x0': xo.Float64,
+        'y0': xo.Float64,
         'order': xo.Int64,
         'inv_factorial_order': xo.Float64,
         'knl': xo.Float64[:],

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -2099,6 +2099,8 @@ class VariableSolenoid(BeamElement):
     _xofields={
         'ks_profile': xo.Float64[2],
         'length': xo.Float64,
+        'x0': xo.Float64,
+        'y0': xo.Float64,
         'order': xo.Int64,
         'inv_factorial_order': xo.Float64,
         'knl': xo.Float64[:],

--- a/xtrack/beam_elements/elements_src/bend.h
+++ b/xtrack/beam_elements/elements_src/bend.h
@@ -46,6 +46,8 @@ void Bend_track_local_particle(
         /*ks*/                    0.,
         /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_shift*/           0.,
         /*body_active*/           1,
         /*edge_entry_active*/     BendData_get_edge_entry_active(el),

--- a/xtrack/beam_elements/elements_src/bend.h
+++ b/xtrack/beam_elements/elements_src/bend.h
@@ -45,9 +45,9 @@ void Bend_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
-        /*rbend_model*/           -1, // not rbend
         /*x0_solenoid*/           0.,
         /*y0_solenoid*/           0.,
+        /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,
         /*edge_entry_active*/     BendData_get_edge_entry_active(el),

--- a/xtrack/beam_elements/elements_src/magnet.h
+++ b/xtrack/beam_elements/elements_src/magnet.h
@@ -46,6 +46,8 @@ void Magnet_track_local_particle(
         /*k3s*/                   MagnetData_get_k3s(el),
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/magnet_edge.h
+++ b/xtrack/beam_elements/elements_src/magnet_edge.h
@@ -46,6 +46,8 @@ void MagnetEdge_track_local_particle(MagnetEdgeData el, LocalParticle* part0)
         /* factor_knl_ksl */ 1,
         kl_order,
         ks,
+        0., // x0_solenoid
+        0., // y0_solenoid
         length,
         face_angle,
         face_angle_feed_down,

--- a/xtrack/beam_elements/elements_src/multipole.h
+++ b/xtrack/beam_elements/elements_src/multipole.h
@@ -48,6 +48,8 @@ void Multipole_track_local_particle(MultipoleData el, LocalParticle* part0){
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/octupole.h
+++ b/xtrack/beam_elements/elements_src/octupole.h
@@ -45,6 +45,8 @@ void Octupole_track_local_particle(
         /*k3s*/                   OctupoleData_get_k3s(el),
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/quadrupole.h
+++ b/xtrack/beam_elements/elements_src/quadrupole.h
@@ -44,6 +44,8 @@ void Quadrupole_track_local_particle(
         /*k2s*/                   0.,
         /*k3s*/                   0.,
         /*ks*/                    0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,

--- a/xtrack/beam_elements/elements_src/quadrupole.h
+++ b/xtrack/beam_elements/elements_src/quadrupole.h
@@ -44,9 +44,9 @@ void Quadrupole_track_local_particle(
         /*k2s*/                   0.,
         /*k3s*/                   0.,
         /*ks*/                    0.,
+        /*dks_ds*/                0.,
         /*x0_solenoid*/           0.,
         /*y0_solenoid*/           0.,
-        /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/rbend.h
+++ b/xtrack/beam_elements/elements_src/rbend.h
@@ -45,6 +45,8 @@ void RBend_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           RBendData_get_rbend_model(el),
         /*rbend_shift*/           RBendData_get_rbend_shift(el),
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/sextupole.h
+++ b/xtrack/beam_elements/elements_src/sextupole.h
@@ -45,6 +45,8 @@ void Sextupole_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/slnd.h
+++ b/xtrack/beam_elements/elements_src/slnd.h
@@ -45,8 +45,8 @@ void UniformSolenoid_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    UniformSolenoidData_get_ks(el),
         /*dks_ds*/                0.,
-        /*x0_solenoid*/           0.,
-        /*y0_solenoid*/           0.,
+        /*x0_solenoid*/           UniformSolenoidData_get_x0(el),
+        /*y0_solenoid*/           UniformSolenoidData_get_y0(el),
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/slnd.h
+++ b/xtrack/beam_elements/elements_src/slnd.h
@@ -45,6 +45,8 @@ void UniformSolenoid_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    UniformSolenoidData_get_ks(el),
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/thick_slice_bend.h
+++ b/xtrack/beam_elements/elements_src/thick_slice_bend.h
@@ -48,9 +48,9 @@ void ThickSliceBend_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
-        /*rbend_model*/           -1, // not rbend
         /*x0_solenoid*/           0.,
         /*y0_solenoid*/           0.,
+        /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,
         /*edge_entry_active*/     0,

--- a/xtrack/beam_elements/elements_src/thick_slice_bend.h
+++ b/xtrack/beam_elements/elements_src/thick_slice_bend.h
@@ -49,6 +49,8 @@ void ThickSliceBend_track_local_particle(
         /*ks*/                    0.,
         /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_shift*/           0.,
         /*body_active*/           1,
         /*edge_entry_active*/     0,

--- a/xtrack/beam_elements/elements_src/thick_slice_octupole.h
+++ b/xtrack/beam_elements/elements_src/thick_slice_octupole.h
@@ -48,6 +48,8 @@ void ThickSliceOctupole_track_local_particle(
         /*k3s*/                   ThickSliceOctupoleData_get__parent_k3s(el),
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/thick_slice_quadrupole.h
+++ b/xtrack/beam_elements/elements_src/thick_slice_quadrupole.h
@@ -47,9 +47,9 @@ void ThickSliceQuadrupole_track_local_particle(
         /*k2s*/                   0.,
         /*k3s*/                   0.,
         /*ks*/                    0.,
+        /*dks_ds*/                0.,
         /*x0_solenoid*/           0.,
         /*y0_solenoid*/           0.,
-        /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/thick_slice_quadrupole.h
+++ b/xtrack/beam_elements/elements_src/thick_slice_quadrupole.h
@@ -47,6 +47,8 @@ void ThickSliceQuadrupole_track_local_particle(
         /*k2s*/                   0.,
         /*k3s*/                   0.,
         /*ks*/                    0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,

--- a/xtrack/beam_elements/elements_src/thick_slice_rbend.h
+++ b/xtrack/beam_elements/elements_src/thick_slice_rbend.h
@@ -48,6 +48,8 @@ void ThickSliceRBend_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           ThickSliceRBendData_get__parent_rbend_model(el),
         /*rbend_shift*/           ThickSliceRBendData_get__parent_rbend_shift(el),
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/thick_slice_sextupole.h
+++ b/xtrack/beam_elements/elements_src/thick_slice_sextupole.h
@@ -48,6 +48,8 @@ void ThickSliceSextupole_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/thick_slice_uniform_solenoid.h
+++ b/xtrack/beam_elements/elements_src/thick_slice_uniform_solenoid.h
@@ -48,8 +48,8 @@ void ThickSliceUniformSolenoid_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    ThickSliceUniformSolenoidData_get__parent_ks(el),
         /*dks_ds*/                0.,
-        /*x0_solenoid*/           0.,
-        /*y0_solenoid*/           0.,
+        /*x0_solenoid*/           ThickSliceUniformSolenoidData_get__parent_x0(el),
+        /*y0_solenoid*/           ThickSliceUniformSolenoidData_get__parent_y0(el),
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/thick_slice_uniform_solenoid.h
+++ b/xtrack/beam_elements/elements_src/thick_slice_uniform_solenoid.h
@@ -48,6 +48,8 @@ void ThickSliceUniformSolenoid_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    ThickSliceUniformSolenoidData_get__parent_ks(el),
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/thin_slice_bend.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_bend.h
@@ -48,9 +48,9 @@ void ThinSliceBend_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
-        /*rbend_model*/           -1, // not rbend
         /*x0_solenoid*/           0.,
         /*y0_solenoid*/           0.,
+        /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,
         /*edge_entry_active*/     0,

--- a/xtrack/beam_elements/elements_src/thin_slice_bend.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_bend.h
@@ -49,6 +49,8 @@ void ThinSliceBend_track_local_particle(
         /*ks*/                    0.,
         /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_shift*/           0.,
         /*body_active*/           1,
         /*edge_entry_active*/     0,

--- a/xtrack/beam_elements/elements_src/thin_slice_bend_entry.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_bend_entry.h
@@ -49,6 +49,8 @@ void ThinSliceBendEntry_track_local_particle(
         /*ks*/                    0.,
         /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled
         /*edge_entry_active*/     ThinSliceBendEntryData_get__parent_edge_entry_active(el),

--- a/xtrack/beam_elements/elements_src/thin_slice_bend_entry.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_bend_entry.h
@@ -48,9 +48,9 @@ void ThinSliceBendEntry_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
-        /*rbend_model*/           -1, // not rbend
         /*x0_solenoid*/           0.,
         /*y0_solenoid*/           0.,
+        /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled
         /*edge_entry_active*/     ThinSliceBendEntryData_get__parent_edge_entry_active(el),

--- a/xtrack/beam_elements/elements_src/thin_slice_bend_exit.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_bend_exit.h
@@ -49,6 +49,8 @@ void ThinSliceBendExit_track_local_particle(
         /*ks*/                    0.,
         /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled
         /*edge_entry_active*/     0,

--- a/xtrack/beam_elements/elements_src/thin_slice_bend_exit.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_bend_exit.h
@@ -48,9 +48,9 @@ void ThinSliceBendExit_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
-        /*rbend_model*/           -1, // not rbend
         /*x0_solenoid*/           0.,
         /*y0_solenoid*/           0.,
+        /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled
         /*edge_entry_active*/     0,

--- a/xtrack/beam_elements/elements_src/thin_slice_octupole.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_octupole.h
@@ -48,6 +48,8 @@ void ThinSliceOctupole_track_local_particle(
         /*k3s*/                   ThinSliceOctupoleData_get__parent_k3s(el),
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/thin_slice_octupole_entry.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_octupole_entry.h
@@ -48,6 +48,8 @@ void ThinSliceOctupoleEntry_track_local_particle(
         /*k3s*/                   ThinSliceOctupoleEntryData_get__parent_k3s(el),
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled

--- a/xtrack/beam_elements/elements_src/thin_slice_octupole_exit.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_octupole_exit.h
@@ -48,6 +48,8 @@ void ThinSliceOctupoleExit_track_local_particle(
         /*k3s*/                   ThinSliceOctupoleExitData_get__parent_k3s(el),
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled

--- a/xtrack/beam_elements/elements_src/thin_slice_quadrupole.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_quadrupole.h
@@ -47,6 +47,8 @@ void ThinSliceQuadrupole_track_local_particle(
         /*k2s*/                   0.,
         /*k3s*/                   0.,
         /*ks*/                    0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,

--- a/xtrack/beam_elements/elements_src/thin_slice_quadrupole.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_quadrupole.h
@@ -47,9 +47,9 @@ void ThinSliceQuadrupole_track_local_particle(
         /*k2s*/                   0.,
         /*k3s*/                   0.,
         /*ks*/                    0.,
+        /*dks_ds*/                0.,
         /*x0_solenoid*/           0.,
         /*y0_solenoid*/           0.,
-        /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/thin_slice_quadrupole_entry.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_quadrupole_entry.h
@@ -47,6 +47,8 @@ void ThinSliceQuadrupoleEntry_track_local_particle(
         /*k2s*/                   0.,
         /*k3s*/                   0.,
         /*ks*/                    0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,

--- a/xtrack/beam_elements/elements_src/thin_slice_quadrupole_entry.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_quadrupole_entry.h
@@ -47,9 +47,9 @@ void ThinSliceQuadrupoleEntry_track_local_particle(
         /*k2s*/                   0.,
         /*k3s*/                   0.,
         /*ks*/                    0.,
+        /*dks_ds*/                0.,
         /*x0_solenoid*/           0.,
         /*y0_solenoid*/           0.,
-        /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled

--- a/xtrack/beam_elements/elements_src/thin_slice_quadrupole_exit.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_quadrupole_exit.h
@@ -47,6 +47,8 @@ void ThinSliceQuadrupoleExit_track_local_particle(
         /*k2s*/                   0.,
         /*k3s*/                   0.,
         /*ks*/                    0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,

--- a/xtrack/beam_elements/elements_src/thin_slice_quadrupole_exit.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_quadrupole_exit.h
@@ -47,9 +47,9 @@ void ThinSliceQuadrupoleExit_track_local_particle(
         /*k2s*/                   0.,
         /*k3s*/                   0.,
         /*ks*/                    0.,
+        /*dks_ds*/                0.,
         /*x0_solenoid*/           0.,
         /*y0_solenoid*/           0.,
-        /*dks_ds*/                0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled

--- a/xtrack/beam_elements/elements_src/thin_slice_rbend.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_rbend.h
@@ -48,6 +48,8 @@ void ThinSliceRBend_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           ThinSliceRBendData_get__parent_rbend_model(el),
         /*rbend_shift*/           ThinSliceRBendData_get__parent_rbend_shift(el),
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/thin_slice_rbend_entry.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_rbend_entry.h
@@ -48,6 +48,8 @@ void ThinSliceRBendEntry_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           ThinSliceRBendEntryData_get__parent_rbend_model(el),
         /*rbend_shift*/           ThinSliceRBendEntryData_get__parent_rbend_shift(el),
         /*body_active*/           0, // disabled

--- a/xtrack/beam_elements/elements_src/thin_slice_rbend_exit.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_rbend_exit.h
@@ -48,6 +48,8 @@ void ThinSliceRBendExit_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           ThinSliceRBendExitData_get__parent_rbend_model(el),
         /*rbend_shift*/           ThinSliceRBendExitData_get__parent_rbend_shift(el),
         /*body_active*/           0, // disabled

--- a/xtrack/beam_elements/elements_src/thin_slice_sextupole.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_sextupole.h
@@ -48,6 +48,8 @@ void ThinSliceSextupole_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/thin_slice_sextupole_entry.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_sextupole_entry.h
@@ -48,6 +48,8 @@ void ThinSliceSextupoleEntry_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled

--- a/xtrack/beam_elements/elements_src/thin_slice_sextupole_exit.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_sextupole_exit.h
@@ -48,6 +48,8 @@ void ThinSliceSextupoleExit_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    0.,
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled

--- a/xtrack/beam_elements/elements_src/thin_slice_uniform_solenoid_entry.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_uniform_solenoid_entry.h
@@ -48,8 +48,8 @@ void ThinSliceUniformSolenoidEntry_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    ThinSliceUniformSolenoidEntryData_get__parent_ks(el),
         /*dks_ds*/                0.,
-        /*x0_solenoid*/           0.,
-        /*y0_solenoid*/           0.,
+        /*x0_solenoid*/           ThinSliceUniformSolenoidEntryData_get__parent_x0(el),
+        /*y0_solenoid*/           ThinSliceUniformSolenoidEntryData_get__parent_y0(el),
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled

--- a/xtrack/beam_elements/elements_src/thin_slice_uniform_solenoid_entry.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_uniform_solenoid_entry.h
@@ -48,6 +48,8 @@ void ThinSliceUniformSolenoidEntry_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    ThinSliceUniformSolenoidEntryData_get__parent_ks(el),
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled

--- a/xtrack/beam_elements/elements_src/thin_slice_uniform_solenoid_exit.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_uniform_solenoid_exit.h
@@ -48,8 +48,8 @@ void ThinSliceUniformSolenoidExit_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    ThinSliceUniformSolenoidExitData_get__parent_ks(el),
         /*dks_ds*/                0.,
-        /*x0_solenoid*/           0.,
-        /*y0_solenoid*/           0.,
+        /*x0_solenoid*/           ThinSliceUniformSolenoidExitData_get__parent_x0(el),
+        /*y0_solenoid*/           ThinSliceUniformSolenoidExitData_get__parent_y0(el),
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled

--- a/xtrack/beam_elements/elements_src/thin_slice_uniform_solenoid_exit.h
+++ b/xtrack/beam_elements/elements_src/thin_slice_uniform_solenoid_exit.h
@@ -48,6 +48,8 @@ void ThinSliceUniformSolenoidExit_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    ThinSliceUniformSolenoidExitData_get__parent_ks(el),
         /*dks_ds*/                0.,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           0, // disabled

--- a/xtrack/beam_elements/elements_src/track_magnet.h
+++ b/xtrack/beam_elements/elements_src/track_magnet.h
@@ -274,6 +274,8 @@ void track_magnet_body_single_particle(
                     k3s, \
                     ks_drift, \
                     dks_ds, \
+                    x0_solenoid, \
+                    y0_solenoid, \
                     &Bx_T, \
                     &By_T, \
                     &Bz_T \

--- a/xtrack/beam_elements/elements_src/track_magnet.h
+++ b/xtrack/beam_elements/elements_src/track_magnet.h
@@ -201,6 +201,8 @@ void track_magnet_body_single_particle(
     const double k2s,
     const double k3s,
     const double dks_ds,
+    const double x0_solenoid,
+    const double y0_solenoid,
     const int64_t radiation_flag,
     const int64_t spin_flag,
     SynchrotronRadiationRecordData radiation_record,
@@ -219,7 +221,8 @@ void track_magnet_body_single_particle(
 
     #define MAGNET_DRIFT(part, dlength) \
         track_magnet_drift_single_particle(\
-            part, (dlength), k0_drift, k1_drift, ks_drift, h_drift, drift_model\
+            part, (dlength), k0_drift, k1_drift, ks_drift, h_drift,\
+            x0_solenoid, y0_solenoid, drift_model\
         )
 
     #ifdef XTRACK_MULTIPOLE_NO_SYNRAD
@@ -436,6 +439,8 @@ void track_magnet_particles(
     double k3s,
     double ks,
     double dks_ds,
+    double x0_solenoid,
+    double y0_solenoid,
     int64_t rbend_model, // -1: not used, 0: auto, 1: curved body, 2: straight body
     double rbend_shift,
     int64_t body_active,
@@ -582,6 +587,8 @@ void track_magnet_particles(
             factor_knl_ksl_edge,
             order,
             ks,
+            x0_solenoid,
+            y0_solenoid,
             length,
             edge_entry_angle,
             edge_entry_angle_fdown,
@@ -659,6 +666,7 @@ void track_magnet_particles(
                 k0_h_correction, k1_h_correction,
                 k2, k3, k0s, k1s, k2s, k3s,
                 dks_ds,
+                x0_solenoid, y0_solenoid,
                 radiation_flag,
                 1, // spin_flag
                 radiation_record,
@@ -693,6 +701,8 @@ void track_magnet_particles(
             factor_knl_ksl_edge,
             order,
             ks,
+            x0_solenoid,
+            y0_solenoid,
             length,
             edge_exit_angle,
             edge_exit_angle_fdown,

--- a/xtrack/beam_elements/elements_src/track_magnet_drift.h
+++ b/xtrack/beam_elements/elements_src/track_magnet_drift.h
@@ -319,7 +319,9 @@ GPUFUN
 void track_solenoid_single_particle(
     LocalParticle* part,
     double length,
-    double ks
+    double ks,
+    double x0_solenoid,
+    double y0_solenoid
 ) {
     const double sk = ks / 2;
 
@@ -337,9 +339,9 @@ void track_solenoid_single_particle(
     const double skl = sk * length;
 
     // Particle coordinates
-    const double x = LocalParticle_get_x(part);
+    const double x = LocalParticle_get_x(part) - x0_solenoid;
     const double px = LocalParticle_get_px(part);
-    const double y = LocalParticle_get_y(part);
+    const double y = LocalParticle_get_y(part) - y0_solenoid;
     const double py = LocalParticle_get_py(part);
     const double delta = LocalParticle_get_delta(part);
     const double rvv = LocalParticle_get_rvv(part);
@@ -371,9 +373,9 @@ void track_solenoid_single_particle(
     double const new_ax = -0.5 * ks * new_y;
     double const new_ay = 0.5 * ks * new_x;
 
-    LocalParticle_set_x(part, new_x);
+    LocalParticle_set_x(part, new_x + x0_solenoid);
     LocalParticle_set_px(part, new_px);
-    LocalParticle_set_y(part, new_y);
+    LocalParticle_set_y(part, new_y + y0_solenoid);
     LocalParticle_set_py(part, new_py);
     LocalParticle_add_to_zeta(part, add_to_zeta);
     LocalParticle_add_to_s(part, length);
@@ -392,6 +394,8 @@ void track_magnet_drift_single_particle(
     const double k1,      // normal quadrupole strength
     const double ks,      // solenoid strength
     const double h,       // curvature
+    const double x0_solenoid,
+    const double y0_solenoid,
     const int64_t drift_model      // drift model
 ) {
 
@@ -430,7 +434,7 @@ void track_magnet_drift_single_particle(
             track_straight_exact_bend_single_particle(part, length, k0);
             break;
         case 6:
-            track_solenoid_single_particle(part, length, ks);
+            track_solenoid_single_particle(part, length, ks, x0_solenoid, y0_solenoid);
             break;
         default:
             break;

--- a/xtrack/beam_elements/elements_src/track_magnet_edge.h
+++ b/xtrack/beam_elements/elements_src/track_magnet_edge.h
@@ -27,6 +27,8 @@ void track_magnet_edge_particles(
     const double factor_knl_ksl,
     const int64_t kl_order,
     const double ksol,
+    const double x0_solenoid,
+    const double y0_solenoid,
     const double length,
     const double face_angle,
     const double face_angle_feed_down,
@@ -46,8 +48,8 @@ void track_magnet_edge_particles(
     }
     else {
         START_PER_PARTICLE_BLOCK(part0, part);
-            LocalParticle_set_ax(part, -0.5 * ksol * LocalParticle_get_y(part));
-            LocalParticle_set_ay(part, 0.5 * ksol * LocalParticle_get_x(part));
+            LocalParticle_set_ax(part, -0.5 * ksol * (LocalParticle_get_y(part) - y0_solenoid));
+            LocalParticle_set_ay(part, 0.5 * ksol * (LocalParticle_get_x(part) - x0_solenoid));
         END_PER_PARTICLE_BLOCK;
     }
 

--- a/xtrack/beam_elements/elements_src/track_magnet_kick.h
+++ b/xtrack/beam_elements/elements_src/track_magnet_kick.h
@@ -254,6 +254,8 @@ void evaluate_field_from_strengths(
     double k3s,
     double ks,
     double dks_ds,
+    double x0_solenoid,
+    double y0_solenoid,
     double *Bx_T,
     double *By_T,
     double *Bz_T
@@ -312,8 +314,8 @@ void evaluate_field_from_strengths(
     double const brho_0 = p0c / C_LIGHT / q0; // [T m]
 
 
-    *Bx_T = dpy * brho_0 / length - 0.5 * dks_ds * brho_0 * x; // [T]
-    *By_T = -dpx * brho_0 / length - 0.5 * dks_ds * brho_0 * y; // [T]
+    *Bx_T = dpy * brho_0 / length - 0.5 * dks_ds * brho_0 * (x - x0_solenoid); // [T]
+    *By_T = -dpx * brho_0 / length - 0.5 * dks_ds * brho_0 * (y - y0_solenoid); // [T]
     *Bz_T = ks * brho_0; // [T]
 
 }

--- a/xtrack/beam_elements/elements_src/variable_solenoid.h
+++ b/xtrack/beam_elements/elements_src/variable_solenoid.h
@@ -93,8 +93,8 @@ void VariableSolenoid_track_local_particle(
 
     START_PER_PARTICLE_BLOCK(part0, part);
         // Update ax and ay (Wolsky Eq. 3.114 and Eq. 2.74)
-        double const new_ax = -0.5 * ks_exit * LocalParticle_get_y(part);
-        double const new_ay = 0.5 * ks_exit * LocalParticle_get_x(part);
+        double const new_ax = -0.5 * ks_exit * (LocalParticle_get_y(part) - y0);
+        double const new_ay = 0.5 * ks_exit * (LocalParticle_get_x(part) - x0);
         LocalParticle_set_ax(part, new_ax);
         LocalParticle_set_ay(part, new_ay);
     END_PER_PARTICLE_BLOCK;

--- a/xtrack/beam_elements/elements_src/variable_solenoid.h
+++ b/xtrack/beam_elements/elements_src/variable_solenoid.h
@@ -70,6 +70,8 @@ void VariableSolenoid_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    ks,
         /*dks_ds*/                dks_ds,
+        /*x0_solenoid*/           0.,
+        /*y0_solenoid*/           0.,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/beam_elements/elements_src/variable_solenoid.h
+++ b/xtrack/beam_elements/elements_src/variable_solenoid.h
@@ -18,6 +18,8 @@ void VariableSolenoid_track_local_particle(
     double ks_entry = VariableSolenoidData_get_ks_profile(el, 0);
     double ks_exit = VariableSolenoidData_get_ks_profile(el, 1);
     double const length = VariableSolenoidData_get_length(el);
+    double const x0 = VariableSolenoidData_get_x0(el);
+    double const y0 = VariableSolenoidData_get_y0(el);
 
     #ifdef XSUITE_BACKTRACK
         VSWAP(ks_entry, ks_exit);
@@ -35,8 +37,8 @@ void VariableSolenoid_track_local_particle(
 
     START_PER_PARTICLE_BLOCK(part0, part);
         // Update ax and ay (Wolsky Eq. 3.114 and Eq. 2.74)
-        double const new_ax = -0.5 * ks_entry * LocalParticle_get_y(part);
-        double const new_ay = 0.5 * ks_entry * LocalParticle_get_x(part);
+        double const new_ax = -0.5 * ks_entry * (LocalParticle_get_y(part) - y0);
+        double const new_ay = 0.5 * ks_entry * (LocalParticle_get_x(part) - x0);
         LocalParticle_set_ax(part, new_ax);
         LocalParticle_set_ay(part, new_ay);
     END_PER_PARTICLE_BLOCK;
@@ -70,8 +72,8 @@ void VariableSolenoid_track_local_particle(
         /*k3s*/                   0.,
         /*ks*/                    ks,
         /*dks_ds*/                dks_ds,
-        /*x0_solenoid*/           0.,
-        /*y0_solenoid*/           0.,
+        /*x0_solenoid*/           x0,
+        /*y0_solenoid*/           y0,
         /*rbend_model*/           -1, // not rbend
         /*rbend_shift*/           0.,
         /*body_active*/           1,

--- a/xtrack/twiss.py
+++ b/xtrack/twiss.py
@@ -1000,6 +1000,8 @@ def _twiss_open(
             zeta  = [0] + list(W_matrix[4, :] * -scale_eigen) + list(W_matrix[4, :] * scale_eigen),
             pzeta = [0] + list(W_matrix[5, :] * -scale_eigen) + list(W_matrix[5, :] * scale_eigen),
             )
+        part_for_twiss.ax = particle_on_co.ax[0]
+        part_for_twiss.ay = particle_on_co.ay[0]
         if spin:
             part_for_twiss.spin_x = particle_on_co.spin_x[0]
             part_for_twiss.spin_y = particle_on_co.spin_y[0]
@@ -3293,6 +3295,8 @@ class TwissTable(Table):
         part.zeta[:] = self.zeta[at_element]
         part.ptau[:] = self.ptau[at_element]
         part.s[:] = self.s[at_element]
+        part.ax[:] = part.px[:] - self.kin_px[at_element]
+        part.ay[:] = part.py[:] - self.kin_py[at_element]
         part.at_element[:] = -1
 
         W = self.W_matrix[at_element]


### PR DESCRIPTION
**Changes:**
 - `UniformSolenoid` and `VariableSolenoid` support arbitrary shift of the solenoid axis (x0, y0). Multipolar components remain centered in (0,0).
 - Handle initial condition on kinetic momenta in `Line.twiss(...)`