### PR TITLE
adding support of gz from url

### DIFF
--- a/xtrack/general.py
+++ b/xtrack/general.py
@@ -7,6 +7,7 @@ from enum import Enum
 from pathlib import Path
 from xobjects.general import _print  # noqa: F401
 import requests
+import gzip
 
 _pkg_root = Path(__file__).parent.absolute()
 
@@ -29,6 +30,9 @@ def read_url(url, timeout=0.1):
     try:
         response = requests.get(url, timeout=timeout)
         response.raise_for_status()  # Raise an error for bad responses
-        return response.text
+        if url.endswith('.gz'):
+            return gzip.decompress(response.content).decode("utf-8")
+        else:
+            return response.text
     except requests.exceptions.RequestException as e:
         raise RuntimeError(f"Failed to read from URL {url}: {e}")


### PR DESCRIPTION
## Description
Supports:

 xt.load("https://acc-models.web.cern.ch/acc-models/lhc/hl16/xsuite/lhc.json.gz")

## Checklist

Mandatory: 

- [X] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
