### PR TITLE
implement ecollimator

### DIFF
--- a/xtrack/mad_loader.py
+++ b/xtrack/mad_loader.py
@@ -988,6 +988,7 @@ class MadLoader:
     convert_vmonitor = convert_drift_like
     convert_collimator = convert_drift_like
     convert_rcollimator = convert_drift_like
+    convert_ecollimator = convert_drift_like
     convert_elseparator = convert_drift_like
     convert_instrument = convert_drift_like
 


### PR DESCRIPTION
## Description

Previously, loading a MADX lattice with an ecollimator element would return an error:

```
ValueError: Element ecollimator not supported,
implement "add_ecollimator" or convert_ecollimator in function in MadLoader
```

This implements the convert_ecollimator function.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
