### PR TITLE
Fixes in native madloader (strings in clone, aperture defaults)

### DIFF
--- a/tests/test_native_madloader.py
+++ b/tests/test_native_madloader.py
@@ -937,32 +937,18 @@ def test_repeated_element_mad_behaviour():
     assert env.seq2['ee'] == element
 
 
-@pytest.mark.parametrize('aper_config', ['attached_to_marker', 'standalone'])
-def test_apertures_on_markers(aper_config):
-    if aper_config == 'attached_to_marker':
-        sequence = """
-            ! Attached to a marker
-            m_circle: marker, apertype="circle", aperture={.2};
-            m_ellipse: marker, apertype="ellipse", aperture={.2, .1};
-            m_rectangle: marker, apertype="rectangle", aperture={.07, .05};
-            m_rectellipse: marker, apertype="rectellipse", aperture={.2, .4, .25, .45};
-            m_racetrack: marker, apertype="racetrack", aperture={.6,.4,.2,.1};
-            m_octagon: marker, apertype="octagon", aperture={.4, .5, 0.5, 1.};
-            m_polygon: marker, apertype="circle", aper_vx={+5.800e-2,+5.800e-2,-8.800e-2}, aper_vy={+3.500e-2,-3.500e-2,+0.000e+0};
-            """
-    else:
-        sequence = """
-            ! Standalone
-            m_circle: circle, aperture={.2};
-            m_ellipse: ellipse, aperture={.2, .1};
-            m_rectangle: rectangle, aperture={.07, .05};
-            m_rectellipse: rectellipse, aperture={.2, .4, .25, .45};
-            m_racetrack: racetrack, aperture={.6,.4,.2,.1};
-            m_octagon: octagon, aperture={.4, .5, 0.5, 1.};
-            m_polygon: circle, aper_vx={+5.800e-2,+5.800e-2,-8.800e-2}, aper_vy={+3.500e-2,-3.500e-2,+0.000e+0};
-            """
+def test_apertures_on_markers():
 
-    sequence += """
+    sequence = """
+        ! Attached to a marker
+        m_circle: marker, apertype="circle", aperture={.2};
+        m_ellipse: marker, apertype="ellipse", aperture={.2, .1};
+        m_rectangle: marker, apertype="rectangle", aperture={.07, .05};
+        m_rectellipse: marker, apertype="rectellipse", aperture={.2, .4, .25, .45};
+        m_racetrack: marker, apertype="racetrack", aperture={.6,.4,.2,.1};
+        m_octagon: marker, apertype="octagon", aperture={.4, .5, 0.5, 1.};
+        m_polygon: marker, apertype="circle", aper_vx={+5.800e-2,+5.800e-2,-8.800e-2}, aper_vy={+3.500e-2,-3.500e-2,+0.000e+0};
+
         line: sequence, l=1;
             m_circle, at=0;
             m_ellipse, at=0.01;
@@ -1056,14 +1042,17 @@ def test_aperture_setting():
     sequence = """
     m_ellipse: marker, apertype="ellipse", aperture={.2, .1};
     m_aper: marker, apertype="rectangle", aperture={.3, .4};
+    m_inferred: marker, aperture=.5;  ! no apertype, should infer circle
 
     line: sequence, l=1;
         m_ellipse, at=0;
         m_aper, at=0.1;
+        m_inferred, at=0.2;
     endsequence;
 
     m_ellipse, aperture={.3, .2};  ! no apertype
     m_aper, apertype="ellipse", aperture={.5, .6};  ! change apertype
+    m_inferred, aperture={.8};
     """
 
     env = xt.load(string=sequence, format='madx')
@@ -1074,6 +1063,8 @@ def test_aperture_setting():
 
     assert line['m_aper_aper'].a == .5
     assert line['m_aper_aper'].b == .6
+
+    assert line['m_inferred_aper'].a == .8
 
 
 def test_import_thick_with_apertures_and_slice():

--- a/xtrack/mad_parser/loader.py
+++ b/xtrack/mad_parser/loader.py
@@ -122,7 +122,9 @@ class MadxLoader:
         self._new_builtin("monitor", "Drift")
         self._new_builtin("hmonitor", "Drift")
         self._new_builtin("vmonitor", "Drift")
+        self._new_builtin("imonitor", "Drift")
         self._new_builtin("placeholder", "Drift")
+        self._new_builtin("wire", "Drift")
         self._new_builtin("sbend", "Bend")
         self._new_builtin("rbend", "RBend")
         self._new_builtin("quadrupole", "Quadrupole")
@@ -138,9 +140,6 @@ class MadxLoader:
         self._new_builtin("srotation", "SRotation")
         self._new_builtin("translation", "XYShift")
         self._new_builtin("dipedge", "DipoleEdge")
-
-        for mad_apertype in _APERTURE_TYPES:
-            self._new_builtin(mad_apertype, 'Marker')
 
     def load_file(self, file):
         """Load a MAD-X file and generate/update the environment."""
@@ -519,14 +518,22 @@ class MadxLoader:
             apertype = 'polygon'
             aperture = None
         else:
-            apertype = params.pop('apertype', None) or self._mad_base_type(name)
+            apertype = params.pop('apertype', 'circle')
             aperture = params.pop('aperture', None)
+
+        if 'apertype' not in self._parameter_cache[name]:
+            # Save the aperture type, as it might have been inferred (polygon, circle)
+            self._parameter_cache[name]['apertype'] = apertype
 
         if apertype not in _APERTURE_TYPES:
             raise ValueError(
                 f'The aperture type for the element `{name}` (inferred to be '
                 f'`{apertype}`) is not recognised.'
             )
+
+        if aperture is not None and not isinstance(aperture, list):
+            # Ensure if defined, aperture is a list
+            aperture = [aperture]
 
         aper_offsets = params.pop('aper_offset', (0, 0))
         if len(aper_offsets) == 1:

--- a/xtrack/mad_parser/madx.lark
+++ b/xtrack/mad_parser/madx.lark
@@ -15,9 +15,9 @@ start:  stmt*
 
 ?sequence: _sequence_body _ENDSEQUENCE ";"
 
-_sequence_body: NAME ":" _SEQUENCE command_arglist ";" (clone | command_stmt)*
+_sequence_body: name_or_string ":" _SEQUENCE command_arglist ";" (clone | command_stmt)*
 
-?line: NAME ":" _LINE "=" anonymous_line ";"
+?line: name_or_string ":" _LINE "=" anonymous_line ";"
 
 anonymous_line: "(" line_elements ")"
 
@@ -25,17 +25,17 @@ modifiers: /-/? ( NUMBER "*" )?
 
 ?line_elements: line_element ("," line_element)*    -> build_list
 
-?line_element: modifiers (NAME | anonymous_line)
+?line_element: modifiers (name_or_string | anonymous_line)
 
 ?seqedit: _seqedit_body _ENDEDIT ";"
 
 _seqedit_body: _SEQEDIT command_arglist ";" command_stmt*
 
-?clone: NAME ":" _command
+?clone: name_or_string ":" _command
 
 ?command_stmt: _command
 
-_command: NAME command_arglist ";"
+_command: name_or_string command_arglist ";"
 
 command_arglist: ( "," ( equal_scalar | defer_scalar | equal_array | defer_array | equal_string | flag | equal_token ) )*
 
@@ -52,9 +52,9 @@ command_arglist: ( "," ( equal_scalar | defer_scalar | equal_array | defer_array
 
 ?equal_string: NAME "=" string_literal -> assign_value
 
-?equal_token: REFER "=" special_token -> assign_value
-    | FROM "=" special_token -> assign_value
-    | APERTYPE "=" special_token  -> assign_value
+?equal_token: REFER "=" name_or_string -> assign_value
+    | FROM "=" name_or_string -> assign_value
+    | APERTYPE "=" name_or_string  -> assign_value
 
 array: "{" sum ( "," sum )* "}"  -> build_list
 
@@ -86,18 +86,19 @@ array: "{" sum ( "," sum )* "}"  -> build_list
 
 !function: NAME
 
-?special_token: STRING -> string_literal  // MAD-X accepts both `"circle"`...
+?name_or_string: STRING -> string_literal  // MAD-X accepts both `"circle"`...
     | NAME -> special_token_name  // ...and `circle` for `apertype`.
 
 string_literal: STRING
 
-ignored: if | return | select | remove | beam
+ignored: if | return | select | remove | beam | assign
 
 !if: "if"i /[^\n]+/
 !return: "return"i /[^\n]+/
 !select: "select"i /[^\n]+/
 !remove: "remove"i /[^\n]+/
 !beam: "beam"i /[^;]*;/
+!assign: "assign"i /[^\n]+/
 
 _SEQUENCE: "sequence"i
 _ENDSEQUENCE: "endsequence"i
@@ -112,7 +113,7 @@ APERTYPE: "apertype"i
 _COMMENT: "!" /[^\n]*/
        | "//" /[^\n]*/
        | "/*" /.*?/s "*/"
-_NEWLINE: ( /\r?\n[\t ]*/ )+
+_NEWLINE: ( /&?\r?\n[\t ]*/ )+  // include line continuations with '&'
 
 %import common.NUMBER
 %import common.WS_INLINE

--- a/xtrack/mad_parser/parse.py
+++ b/xtrack/mad_parser/parse.py
@@ -125,8 +125,8 @@ class MadxTransformer(Transformer):
         field = name_token.value.lower()
         return self.functions[field]
 
-    def command(self, name_token, arglist):
-        command = name_token.value
+    def command(self, name, arglist):
+        command = name.value
         arglist = arglist if isinstance(arglist, list) else [arglist]
         return command.lower(), arglist
 
@@ -140,8 +140,8 @@ class MadxTransformer(Transformer):
     def reset_flag(self, name_token):
         return name_token.value.lower(), False
 
-    def sequence(self, name_token, arglist, *clones) -> Tuple[str, LineType]:
-        return name_token.value.lower(), {
+    def sequence(self, name, arglist, *clones) -> Tuple[str, LineType]:
+        return name.lower(), {
             'parent': 'sequence',
             **dict(arglist),
             'elements': list(clones),
@@ -172,11 +172,11 @@ class MadxTransformer(Transformer):
         name, body = sequence
         self.lines[name] = body
 
-    def clone(self, name_token, command_token, arglist) -> Tuple[str, ElementType]:
+    def clone(self, name, command, arglist) -> Tuple[str, ElementType]:
         args = dict(arglist)
-        parent = command_token.value.lower()
+        parent = command.lower()
 
-        return name_token.value.lower(), {
+        return name.lower(), {
             'parent': parent,
             **args,
         }
@@ -185,8 +185,8 @@ class MadxTransformer(Transformer):
         name, body = clone
         self.elements[name] = body
 
-    def command_stmt(self, command_token, arglist):
-        return command_token.value.lower(), dict(arglist)
+    def command_stmt(self, command, arglist):
+        return command.lower(), dict(arglist)
 
     def top_level_command(self, command):
         name, arglist = command
@@ -211,8 +211,8 @@ class MadxTransformer(Transformer):
     def line_element(self, modifiers, line_item) -> Tuple[str, ElementType]:
         name = None
         body = modifiers.to_dict()
-        if isinstance(line_item, Token):
-            name = line_item.value.lower()
+        if isinstance(line_item, str):
+            name = line_item.lower()
         elif isinstance(line_item, dict):
             body.update(line_item)
         else:
@@ -225,8 +225,8 @@ class MadxTransformer(Transformer):
             'elements': elements,
         }
 
-    def line(self, name_token, anonymous_line) -> Tuple[str, LineType]:
-        return name_token.value.lower(), anonymous_line
+    def line(self, name, anonymous_line) -> Tuple[str, LineType]:
+        return name.lower(), anonymous_line
 
     def top_level_line(self, line):
         name, body = line


### PR DESCRIPTION
## Description

- support string syntax in element names, etc., which is a lesser-known MAD-X alternative used in some sequences: e.g. `"myelem": "marker";`
- Remove support for standalone marker elements, as it was an invented feature in the native madloader not actually supported by MAD-X, e.g. ~`ap: circle, aperture=3`~
- Apertures: support scalar as `aperture` parameter, default to `circle` for `apertype` if unspecified (unless `polygon` is more appropriate)
- Add as drifts some elements supported in MAD-X

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
