### PR TITLE
Fix bug in `test_elements_thick.py::test_solenoid_against_madx_native`

### DIFF
--- a/tests/test_elements_thick.py
+++ b/tests/test_elements_thick.py
@@ -1830,6 +1830,7 @@ def test_solenoid_against_madx_native(test_context, ks, ksi, length):
     line_thick = env['ss']
 
     line_thick.configure_drift_model('exact')  # to be consistent with madx
+    line_thick.build_tracker(_context=test_context)
 
     mad = Madx(stdout=False)
     mad.input(mad_src)


### PR DESCRIPTION
## Description

Fix bug in `test_elements_thick.py::test_solenoid_against_madx_native` where the line was not put on the correct context of the test.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
