### PR TITLE
Deprecate `Line.unfreeze` with a warning

### DIFF
--- a/tests/test_radial_steering.py
+++ b/tests/test_radial_steering.py
@@ -35,7 +35,7 @@ def test_radial_steering(test_context):
 
     dzeta = tw.circumference * df_hz / f_rf
 
-    line.unfreeze()
+    line.discard_tracker()
     line.append_element(element=xt.ZetaShift(dzeta=dzeta), name='zeta_shift')
     line.build_tracker()
 

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -3076,7 +3076,7 @@ class Line:
             track_kernel = None
 
         if inplace:
-            self.unfreeze()
+            self.discard_tracker()
             self.element_names = new_element_names
             new_line = self
         else:
@@ -4294,10 +4294,11 @@ class Line:
         self.element_names = tuple(self.element_names)
 
     def unfreeze(self):
-
-        # Unfreeze the line. This is useful if you want to modify the line
-        # after it has been frozen (most likely by calling `build_tracker`).
-
+        """See `Line.discard_tracker()`. This function is deprecated."""
+        _print(
+            '`Line.unfreeze()` is deprecated and will be removed in future '
+            'versions. Please use `Line.discard_tracker()` instead.'
+        )
         self.discard_tracker()
 
     def _frozen_check(self):

--- a/xtrack/multiline_legacy/multiline_legacy.py
+++ b/xtrack/multiline_legacy/multiline_legacy.py
@@ -479,7 +479,7 @@ class MultilineLegacy:
 
         # Trackers need to be invalidated to add elements
         for nn, ll in self.lines.items():
-            ll.unfreeze()
+            ll.discard_tracker()
 
         if clockwise_line is not None and anticlockwise_line is not None:
             circumference_cw = self.lines[clockwise_line].get_length()


### PR DESCRIPTION
## Description

See xsuite/xsuite#723.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
