### PR TITLE
Fix k0 property to return actual value from h

### DIFF
--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -1428,10 +1428,10 @@ class _BendCommon(_HasKnlKsl, _HasIntegrator, _HasModelCurved):
         self._length = value
         if self.length != 0:
             self._h = self.angle / self.length
-            if self.k0_from_h:
-                self._k0 = self.h
         else:
             self._h = 0.0
+        if self.k0_from_h:
+            self._k0 = self.h
 
     @property
     def h(self):


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

In recent versions, [`Bend.k0`](https://github.com/xsuite/xtrack/blob/fe5788f99cd76619659a86224a38f43c0d28eb7d/xtrack/beam_elements/elements.py#L1446) may return `"from_h"` as a string. Getting a string where a float is expected likely breaks a lot of code, and requires users to always check for this special string to get the actual value. It's also not necessary, given that [`Bend.k0_from_h`](https://github.com/xsuite/xtrack/blob/fe5788f99cd76619659a86224a38f43c0d28eb7d/xtrack/beam_elements/elements.py#L1464) exists and can be used to determine if `k0` is set manually or determined by `h`.

Not sure what the rationale behind returning a special string here was, but I propose returning the actual value (the value of `h`) in such cases.

Also fixes a missing assignment of k0 if h is set to zero

Related: https://github.com/xsuite/xplt/commit/31581073a41d5f617f6bb03c4d466bb04182d65d

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
