### PR TITLE
Fix GPU compile error about ambiguous tgamma call

### DIFF
--- a/xtrack/headers/factorial.h
+++ b/xtrack/headers/factorial.h
@@ -30,7 +30,7 @@ double one_over_factorial(int n){
     } else if (n < 20){
         return ONE_OVER_FACT[n];
     } else {
-        return 1 / tgamma(n+1);
+        return 1. / tgamma((double)(n + 1));
     }
 }
 


### PR DESCRIPTION
## Description

Fix failing code on GPUs related to the ambiguous call to the `tgamma` function.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
