### PR TITLE
Add deprecation info to docstrings, replace deprecated xd.Optimize calls

### DIFF
--- a/examples/fcc_ee_solenoid/004b_correction.py
+++ b/examples/fcc_ee_solenoid/004b_correction.py
@@ -46,23 +46,23 @@ opt_l = line.match(
 
 for iter in range(2):
     # Orbit alone
-    opt_l.disable_all_targets(); opt_l.disable_all_vary()
-    opt_l.enable_targets(tag='orbit'); opt_l.enable_vary(tag='corr_l'); opt_l.solve()
+    opt_l.disable(target=True); opt_l.disable(vary=True)
+    opt_l.enable(target='orbit'); opt_l.enable(vary='corr_l'); opt_l.solve()
 
     # Coupling alone
-    opt_l.disable_all_targets(); opt_l.disable_all_vary()
-    opt_l.enable_targets(tag='coupl'); opt_l.enable_vary(tag='skew_l'); opt_l.solve()
+    opt_l.disable(target=True); opt_l.disable(vary=True)
+    opt_l.enable(target='coupl'); opt_l.enable(vary='skew_l'); opt_l.solve()
 
     # phase, beta and alpha alone
-    opt_l.disable_all_targets(); opt_l.disable_all_vary()
-    opt_l.enable_vary(tag='normal_l')
-    opt_l.enable_targets(tag='mu_ip'); opt_l.solve()
-    opt_l.enable_targets(tag='bet_ip'); opt_l.solve()
-    opt_l.enable_targets(tag='alf_ip'); opt_l.solve()
+    opt_l.disable(target=True); opt_l.disable(vary=True)
+    opt_l.enable(vary='normal_l')
+    opt_l.enable(target='mu_ip'); opt_l.solve()
+    opt_l.enable(target='bet_ip'); opt_l.solve()
+    opt_l.enable(target='alf_ip'); opt_l.solve()
 
 # All together
-opt_l.enable_all_targets()
-opt_l.enable_all_vary()
+opt_l.enable(target=True)
+opt_l.enable(vary=True)
 opt_l.solve()
 
 
@@ -93,23 +93,23 @@ opt_r = line.match(
 
 for iter in range(2):
     # Orbit alone
-    opt_r.disable_all_targets(); opt_r.disable_all_vary()
-    opt_r.enable_targets(tag='orbit'); opt_r.enable_vary(tag='corr_r'); opt_r.solve()
+    opt_r.disable(target=True); opt_r.disable(vary=True)
+    opt_r.enable(target='orbit'); opt_r.enable(vary='corr_r'); opt_r.solve()
 
     # Coupling alone
-    opt_r.disable_all_targets(); opt_r.disable_all_vary()
-    opt_r.enable_targets(tag='coupl'); opt_r.enable_vary(tag='skew_r'); opt_r.solve()
+    opt_r.disable(target=True); opt_r.disable(vary=True)
+    opt_r.enable(target='coupl'); opt_r.enable(vary='skew_r'); opt_r.solve()
 
     # phase, beta and alpha alone
-    opt_r.disable_all_targets(); opt_r.disable_all_vary()
-    opt_r.enable_vary(tag='normal_r')
-    opt_r.enable_targets(tag='mu_ip'); opt_r.solve()
-    opt_r.enable_targets(tag='bet_ip'); opt_r.solve()
-    opt_r.enable_targets(tag='alf_ip'); opt_r.solve()
+    opt_r.disable(target=True); opt_r.disable(vary=True)
+    opt_r.enable(vary='normal_r')
+    opt_r.enable(target='mu_ip'); opt_r.solve()
+    opt_r.enable(target='bet_ip'); opt_r.solve()
+    opt_r.enable(target='alf_ip'); opt_r.solve()
 
 # All together
-opt_r.enable_all_targets()
-opt_r.enable_all_vary()
+opt_r.enable(target=True)
+opt_r.enable(vary=True)
 opt_r.solve()
 
 tw_local_corr = line.twiss(start='ip.4', end='_end_point', init_at='ip.1',

--- a/examples/fcc_ee_solenoid/005b_correction_thick_lattice.py
+++ b/examples/fcc_ee_solenoid/005b_correction_thick_lattice.py
@@ -46,23 +46,23 @@ opt_l = line.match(
 
 for iter in range(2):
     # Orbit alone
-    opt_l.disable_all_targets(); opt_l.disable_all_vary()
-    opt_l.enable_targets(tag='orbit'); opt_l.enable_vary(tag='corr_l'); opt_l.solve()
+    opt_l.disable(target=True); opt_l.disable(vary=True)
+    opt_l.enable(target='orbit'); opt_l.enable(vary='corr_l'); opt_l.solve()
 
     # Coupling alone
-    opt_l.disable_all_targets(); opt_l.disable_all_vary()
-    opt_l.enable_targets(tag='coupl'); opt_l.enable_vary(tag='skew_l'); opt_l.solve()
+    opt_l.disable(target=True); opt_l.disable(vary=True)
+    opt_l.enable(target='coupl'); opt_l.enable(vary='skew_l'); opt_l.solve()
 
     # phase, beta and alpha alone
-    opt_l.disable_all_targets(); opt_l.disable_all_vary()
-    opt_l.enable_vary(tag='normal_l')
-    opt_l.enable_targets(tag='mu_ip'); opt_l.solve()
-    opt_l.enable_targets(tag='bet_ip'); opt_l.solve()
-    opt_l.enable_targets(tag='alf_ip'); opt_l.solve()
+    opt_l.disable(target=True); opt_l.disable(vary=True)
+    opt_l.enable(vary='normal_l')
+    opt_l.enable(target='mu_ip'); opt_l.solve()
+    opt_l.enable(target='bet_ip'); opt_l.solve()
+    opt_l.enable(target='alf_ip'); opt_l.solve()
 
 # All together
-opt_l.enable_all_targets()
-opt_l.enable_all_vary()
+opt_l.enable(target=True)
+opt_l.enable(vary=True)
 opt_l.solve()
 
 
@@ -93,23 +93,23 @@ opt_r = line.match(
 
 for iter in range(2):
     # Orbit alone
-    opt_r.disable_all_targets(); opt_r.disable_all_vary()
-    opt_r.enable_targets(tag='orbit'); opt_r.enable_vary(tag='corr_r'); opt_r.solve()
+    opt_r.disable(target=True); opt_r.disable(vary=True)
+    opt_r.enable(target='orbit'); opt_r.enable(vary='corr_r'); opt_r.solve()
 
     # Coupling alone
-    opt_r.disable_all_targets(); opt_r.disable_all_vary()
-    opt_r.enable_targets(tag='coupl'); opt_r.enable_vary(tag='skew_r'); opt_r.solve()
+    opt_r.disable(target=True); opt_r.disable(vary=True)
+    opt_r.enable(target='coupl'); opt_r.enable(vary='skew_r'); opt_r.solve()
 
     # phase, beta and alpha alone
-    opt_r.disable_all_targets(); opt_r.disable_all_vary()
-    opt_r.enable_vary(tag='normal_r')
-    opt_r.enable_targets(tag='mu_ip'); opt_r.solve()
-    opt_r.enable_targets(tag='bet_ip'); opt_r.solve()
-    opt_r.enable_targets(tag='alf_ip'); opt_r.solve()
+    opt_r.disable(target=True); opt_r.disable(vary=True)
+    opt_r.enable(vary='normal_r')
+    opt_r.enable(target='mu_ip'); opt_r.solve()
+    opt_r.enable(target='bet_ip'); opt_r.solve()
+    opt_r.enable(target='alf_ip'); opt_r.solve()
 
 # All together
-opt_r.enable_all_targets()
-opt_r.enable_all_vary()
+opt_r.enable(target=True)
+opt_r.enable(vary=True)
 opt_r.solve()
 
 tw_local_corr = line.twiss(start='ip.4', end='_end_point', init_at='ip.1',

--- a/examples/match/001_match_interactive.py
+++ b/examples/match/001_match_interactive.py
@@ -27,8 +27,8 @@ opt.target_status()
 #  3 ON    chrom   False     -10.057     1.94297         12 'dqy', val=12, tol=0.01, weight=1)
 
 # Disable optimization of chromaticities and usage of sextupole knobs
-opt.disable_targets(tag='chrom')
-opt.disable_vary(tag='sext')
+opt.disable(target='chrom')
+opt.disable(vary='sext')
 
 opt.show()
 # prints:
@@ -59,8 +59,8 @@ opt.target_status()
 #  3 OFF   chrom   False            0     1.91882         12 'dqy', val=12, tol=0.01, weight=1)
 
 # Enable all targets and knobs
-opt.enable_all_targets()
-opt.enable_all_vary()
+opt.enable(target=True)
+opt.enable(vary=True)
 
 # Solve (for tunes and chromaticities)
 opt.solve()

--- a/examples/match_octupole_phase_knob/000_dev.py
+++ b/examples/match_octupole_phase_knob/000_dev.py
@@ -116,7 +116,7 @@ opt = line.match_knob(
 t1 = time.time()
 opt.step(30)
 
-opt.disable_targets(tag='rdt')
+opt.disable(target='rdt')
 opt.solve()
 t2 = time.time()
 print(f'Optimization time: {t2-t1:.2f} s')

--- a/examples/radiation/009a_sps_with_vertical_bump.py
+++ b/examples/radiation/009a_sps_with_vertical_bump.py
@@ -143,22 +143,22 @@ opt = line.match(
         ],
 )
 
-opt.enable_all_targets()
-opt.enable_all_vary()
-opt.disable_targets(tag='chrom')
-opt.disable_vary(tag='chrom')
+opt.enable(target=True)
+opt.enable(vary=True)
+opt.disable(target='chrom')
+opt.disable(vary='chrom')
 opt.solve()
 
 if match_chrom:
 
-    opt.disable_all_targets()
-    opt.disable_all_vary()
-    opt.enable_targets(tag='chrom')
-    opt.enable_vary(tag='chrom')
+    opt.disable(target=True)
+    opt.disable(vary=True)
+    opt.enable(target='chrom')
+    opt.enable(vary='chrom')
     opt.solve()
 
-    opt.enable_all_targets()
-    opt.enable_all_vary()
+    opt.enable(target=True)
+    opt.enable(vary=True)
     opt.solve()
 
 

--- a/examples/radiation/009c_sps_single_kicker.py
+++ b/examples/radiation/009c_sps_single_kicker.py
@@ -117,22 +117,22 @@ opt = line.match(
 opt.step(5)
 opt.target_status()
 
-# opt.enable_all_targets()
-# opt.enable_all_vary()
-# opt.disable_targets(tag='chrom')
-# opt.disable_vary(tag='chrom')
+# opt.enable(target=True)
+# opt.enable(vary=True)
+# opt.disable(target='chrom')
+# opt.disable(vary='chrom')
 # opt.solve()
 
 # if match_chrom:
 
-#     opt.disable_all_targets()
-#     opt.disable_all_vary()
-#     opt.enable_targets(tag='chrom')
-#     opt.enable_vary(tag='chrom')
+#     opt.disable(target=True)
+#     opt.disable(vary=True)
+#     opt.enable(target='chrom')
+#     opt.enable(vary='chrom')
 #     opt.solve()
 
-#     opt.enable_all_targets()
-#     opt.enable_all_vary()
+#     opt.enable(target=True)
+#     opt.enable(vary=True)
 #     opt.solve()
 
 

--- a/tests/test_fcc_ee_solenoid_correction.py
+++ b/tests/test_fcc_ee_solenoid_correction.py
@@ -262,23 +262,23 @@ def test_fcc_ee_solenoid_correction():
 
     for iter in range(2):
         # Orbit alone
-        opt_l.disable_all_targets(); opt_l.disable_all_vary()
-        opt_l.enable_targets(tag='orbit'); opt_l.enable_vary(tag='corr_l'); opt_l.solve()
+        opt_l.disable(target=True); opt_l.disable(vary=True)
+        opt_l.enable(target='orbit'); opt_l.enable(vary='corr_l'); opt_l.solve()
 
         # Coupling alone
-        opt_l.disable_all_targets(); opt_l.disable_all_vary()
-        opt_l.enable_targets(tag='coupl'); opt_l.enable_vary(tag='skew_l'); opt_l.solve()
+        opt_l.disable(target=True); opt_l.disable(vary=True)
+        opt_l.enable(target='coupl'); opt_l.enable(vary='skew_l'); opt_l.solve()
 
         # phase, beta and alpha alone
-        opt_l.disable_all_targets(); opt_l.disable_all_vary()
-        opt_l.enable_vary(tag='normal_l')
-        opt_l.enable_targets(tag='mu_ip'); opt_l.solve()
-        opt_l.enable_targets(tag='bet_ip'); opt_l.solve()
-        opt_l.enable_targets(tag='alf_ip'); opt_l.solve()
+        opt_l.disable(target=True); opt_l.disable(vary=True)
+        opt_l.enable(vary='normal_l')
+        opt_l.enable(target='mu_ip'); opt_l.solve()
+        opt_l.enable(target='bet_ip'); opt_l.solve()
+        opt_l.enable(target='alf_ip'); opt_l.solve()
 
     # All together
-    opt_l.enable_all_targets()
-    opt_l.enable_all_vary()
+    opt_l.enable(target=True)
+    opt_l.enable(vary=True)
     opt_l.solve()
 
 
@@ -309,23 +309,23 @@ def test_fcc_ee_solenoid_correction():
 
     for iter in range(2):
         # Orbit alone
-        opt_r.disable_all_targets(); opt_r.disable_all_vary()
-        opt_r.enable_targets(tag='orbit'); opt_r.enable_vary(tag='corr_r'); opt_r.solve()
+        opt_r.disable(target=True); opt_r.disable(vary=True)
+        opt_r.enable(target='orbit'); opt_r.enable(vary='corr_r'); opt_r.solve()
 
         # Coupling alone
-        opt_r.disable_all_targets(); opt_r.disable_all_vary()
-        opt_r.enable_targets(tag='coupl'); opt_r.enable_vary(tag='skew_r'); opt_r.solve()
+        opt_r.disable(target=True); opt_r.disable(vary=True)
+        opt_r.enable(target='coupl'); opt_r.enable(vary='skew_r'); opt_r.solve()
 
         # phase, beta and alpha alone
-        opt_r.disable_all_targets(); opt_r.disable_all_vary()
-        opt_r.enable_vary(tag='normal_r')
-        opt_r.enable_targets(tag='mu_ip'); opt_r.solve()
-        opt_r.enable_targets(tag='bet_ip'); opt_r.solve()
-        opt_r.enable_targets(tag='alf_ip'); opt_r.solve()
+        opt_r.disable(target=True); opt_r.disable(vary=True)
+        opt_r.enable(vary='normal_r')
+        opt_r.enable(target='mu_ip'); opt_r.solve()
+        opt_r.enable(target='bet_ip'); opt_r.solve()
+        opt_r.enable(target='alf_ip'); opt_r.solve()
 
     # All together
-    opt_r.enable_all_targets()
-    opt_r.enable_all_vary()
+    opt_r.enable(target=True)
+    opt_r.enable(vary=True)
     opt_r.solve()
 
     line.to_json(fname + '_with_sol_corrected.json')

--- a/tests/test_match_optics_and_ip_knob.py
+++ b/tests/test_match_optics_and_ip_knob.py
@@ -177,7 +177,7 @@ def test_ip_knob_matching(test_context):
     init_mcbx_plus = collider.varval['acbxh1.l8_from_on_x8h']
 
     # First round of optimization without changing mcbx
-    opt.disable_vary(tag='mcbx')
+    opt.disable(vary='mcbx')
     vtags = [vv.tag for vv in opt.vary]
     assert np.all(np.array(vtags) == np.array(
         ['', '', '', '', '', '', '', '', 'mcbx', 'mcbx', 'mcbx', 'mcbx', 'mcbx', 'mcbx']))
@@ -287,7 +287,7 @@ def test_ip_knob_matching(test_context):
     collider.vars['acbxh3.r8_from_on_sep8h'] = acbx_sep_ir8 * sep_match / 2e-3
 
     # First round of optimization without changing mcbx
-    opt.disable_vary(tag='mcbx')
+    opt.disable(vary='mcbx')
     opt.step(10) # perform 10 steps without checking for convergence
 
     # Enable first mcbx knob (which controls the others)
@@ -491,12 +491,12 @@ def test_match_ir8_optics(test_context):
     opt.clear_log()
     assert opt.log()['tol_met', 0] == 'nnnnnnnnnnnnnn'
 
-    opt.disable_targets(tag=['stage1', 'stage2'])
+    opt.disable(target=['stage1', 'stage2'])
     opt.tag()
     assert opt.log()['target_active', -1] == 'yyyyyynnnnnnyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyyyyyyyyyyyy'
 
-    opt.disable_vary(tag=['stage1', 'stage2'])
+    opt.disable(vary=['stage1', 'stage2'])
     opt.tag()
     assert opt.log()['target_active', -1] == 'yyyyyynnnnnnyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyynnnnnnnnnnnn'
@@ -506,12 +506,12 @@ def test_match_ir8_optics(test_context):
     assert opt.log()['target_active', -1] == 'yyyyyynnnnnnyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyynnnnnnnnnnnn'
 
-    opt.enable_vary(tag='stage1')
+    opt.enable(vary='stage1')
     opt.tag()
     assert opt.log()['target_active', -1] == 'yyyyyynnnnnnyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyynnnnnnnnnn'
 
-    opt.enable_targets(tag='stage1')
+    opt.enable(target='stage1')
     opt.tag()
     assert opt.log()['target_active', -1] == 'yyyyyynnnnnnyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyynnnnnnnnnn'
@@ -521,13 +521,13 @@ def test_match_ir8_optics(test_context):
     assert opt.log()['target_active', -1] == 'yyyyyynnnnnnyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyynnnnnnnnnn'
 
-    opt.enable_targets(tag='stage2')
+    opt.enable(target='stage2')
     opt.tag()
     assert opt.log()['target_active', -1] == 'yyyyyyyyyyyyyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyynnnnnnnnnn'
     assert opt.log()['tol_met', -1] != 'yyyyyyyyyyyyyy'
 
-    opt.enable_vary(tag='stage2')
+    opt.enable(vary='stage2')
     opt.tag()
     assert opt.log()['target_active', -1] == 'yyyyyyyyyyyyyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyyyyyyyyyyyy'
@@ -631,12 +631,12 @@ def test_match_ir8_optics(test_context):
     opt.clear_log()
     assert opt.log()['tol_met', 0] == 'nnnnnnnnnnnnnn'
 
-    opt.disable_targets(tag=['stage1', 'stage2'])
+    opt.disable(target=['stage1', 'stage2'])
     opt.tag()
     assert opt.log()['target_active', -1] == 'yyyyyynnnnnnyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyyyyyyyyyyyy'
 
-    opt.disable_vary(tag=['stage1', 'stage2'])
+    opt.disable(vary=['stage1', 'stage2'])
     opt.tag()
     assert opt.log()['target_active', -1] == 'yyyyyynnnnnnyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyynnnnnnnnnnnn'
@@ -674,12 +674,12 @@ def test_match_ir8_optics(test_context):
 
     ##### Done checking reloading features #####
 
-    opt.enable_vary(tag='stage1')
+    opt.enable(vary='stage1')
     opt.tag()
     assert opt.log()['target_active', -1] == 'yyyyyynnnnnnyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyynnnnnnnnnn'
 
-    opt.enable_targets(tag='stage1')
+    opt.enable(target='stage1')
     opt.tag()
     assert opt.log()['target_active', -1] == 'yyyyyynnnnnnyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyynnnnnnnnnn'
@@ -689,13 +689,13 @@ def test_match_ir8_optics(test_context):
     assert opt.log()['target_active', -1] == 'yyyyyynnnnnnyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyynnnnnnnnnn'
 
-    opt.enable_targets(tag='stage2')
+    opt.enable(target='stage2')
     opt.tag()
     assert opt.log()['target_active', -1] == 'yyyyyyyyyyyyyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyynnnnnnnnnn'
     assert opt.log()['tol_met', -1] != 'yyyyyyyyyyyyyy'
 
-    opt.enable_vary(tag='stage2')
+    opt.enable(vary='stage2')
     opt.tag()
     assert opt.log()['target_active', -1] == 'yyyyyyyyyyyyyy'
     assert opt.log()['vary_active', -1] == 'yyyyyyyyyyyyyyyyyyyy'

--- a/xtrack/_temp/lhc_match/lhc_match.py
+++ b/xtrack/_temp/lhc_match/lhc_match.py
@@ -412,18 +412,18 @@ def rematch_ir2(collider, line_name,
 
     if solve:
         if staged_match:
-            opt.disable_all_vary()
-            opt.disable_all_targets()
+            opt.disable(vary=True)
+            opt.disable(target=True)
 
-            opt.enable_vary(tag='stage0')
-            opt.enable_targets(tag='stage0')
+            opt.enable(vary='stage0')
+            opt.enable(target='stage0')
             opt.solve()
 
-            opt.enable_vary(tag='stage1')
+            opt.enable(vary='stage1')
             opt.solve()
 
-            opt.enable_vary(tag='stage2')
-            opt.enable_targets(tag='stage2')
+            opt.enable(vary='stage2')
+            opt.enable(target='stage2')
             opt.solve()
         else:
             opt.solve()
@@ -468,9 +468,9 @@ def rematch_ir3(collider, line_name,
 
     if solve:
         if staged_match:
-            opt.disable_targets(tag='stage1')
+            opt.disable(target='stage1')
             opt.solve()
-            opt.enable_targets(tag='stage1')
+            opt.enable(target='stage1')
             opt.solve()
         else:
             opt.solve()
@@ -516,9 +516,9 @@ def rematch_ir4(collider, line_name,
 
     if solve:
         if staged_match:
-            opt.disable_targets(tag='stage1')
+            opt.disable(target='stage1')
             opt.solve()
-            opt.enable_targets(tag='stage1')
+            opt.enable(target='stage1')
             opt.solve()
         else:
             opt.solve()
@@ -610,9 +610,9 @@ def rematch_ir7(collider, line_name,
 
     if solve:
         if staged_match:
-            opt.disable_targets(tag='stage1')
+            opt.disable(target='stage1')
             opt.solve()
-            opt.enable_targets(tag='stage1')
+            opt.enable(target='stage1')
             opt.solve()
         else:
             opt.solve()
@@ -663,16 +663,16 @@ def rematch_ir8(collider, line_name,
 
     if solve:
         if staged_match:
-            opt.disable_targets(tag=['stage1', 'stage2'])
-            opt.disable_vary(tag=['stage1', 'stage2'])
+            opt.disable(target=['stage1', 'stage2'])
+            opt.disable(vary=['stage1', 'stage2'])
             opt.solve()
 
-            opt.enable_vary(tag='stage1')
+            opt.enable(vary='stage1')
             opt.solve()
 
-            opt.enable_targets(tag='stage1')
-            opt.enable_targets(tag='stage2')
-            opt.enable_vary(tag='stage2')
+            opt.enable(target='stage1')
+            opt.enable(target='stage2')
+            opt.enable(vary='stage2')
             opt.solve()
         else:
             opt.solve()
@@ -900,7 +900,7 @@ def match_orbit_knobs_ip2_ip8(collider):
         collider.vars[f'acbxh{icorr}.l2_from_on_x2h'] = acbx_xing_ir2
         collider.vars[f'acbxh{icorr}.r2_from_on_x2h'] = -acbx_xing_ir2
     # Match other correctors with fixed mcbx and generate knob
-    opt_x2h.disable_vary(tag='mcbx')
+    opt_x2h.disable(vary='mcbx')
     opt_x2h.solve()
     opt_x2h.generate_knob()
 
@@ -924,7 +924,7 @@ def match_orbit_knobs_ip2_ip8(collider):
         collider.vars[f'acbxv{icorr}.l2_from_on_x2v'] = acbx_xing_ir2
         collider.vars[f'acbxv{icorr}.r2_from_on_x2v'] = -acbx_xing_ir2
     # Match other correctors with fixed mcbx and generate knob
-    opt_x2v.disable_vary(tag='mcbx')
+    opt_x2v.disable(vary='mcbx')
     opt_x2v.solve()
     opt_x2v.generate_knob()
 
@@ -956,7 +956,7 @@ def match_orbit_knobs_ip2_ip8(collider):
     #   collider.vars[f'acbxh{icorr}.r8_from_on_x8h'] = -acbx_xing_ir8 * angle_match_ip8 / 170e-6 * 0.1
 
     # First round of optimization without changing mcbx
-    opt_x8h.disable_vary(tag='mcbx')
+    opt_x8h.disable(vary='mcbx')
     opt_x8h.step(3) # perform 3 steps without checking for convergence
 
     # Link all mcbx strengths to the first one
@@ -997,11 +997,11 @@ def match_orbit_knobs_ip2_ip8(collider):
         collider.vars[f'acbxv{icorr}.r8_from_on_x8v'] = -acbx_xing_ir8 * angle_match_ip8 / 170e-6
 
     # First round of optimization without changing mcbx
-    opt_x8v.disable_vary(tag='mcbx')
+    opt_x8v.disable(vary='mcbx')
     opt_x8v.step(3) # perform 3 steps without checking for convergence
 
     # Solve with all vary active and generate knob
-    opt_x8v.enable_vary(tag='mcbx')
+    opt_x8v.enable(vary='mcbx')
     opt_x8v.solve()
     opt_x8v.generate_knob()
 
@@ -1034,7 +1034,7 @@ def match_orbit_knobs_ip2_ip8(collider):
         collider.vars[f'acbxh{icorr}.r2_from_on_sep2h'] = acbx_sep_ir2
 
     # Match other correctors with fixed mcbx and generate knob
-    opt_sep2h.disable_vary(tag='mcbx')
+    opt_sep2h.disable(vary='mcbx')
     opt_sep2h.solve()
     opt_sep2h.generate_knob()
 
@@ -1061,7 +1061,7 @@ def match_orbit_knobs_ip2_ip8(collider):
         collider.vars[f'acbxv{icorr}.r2_from_on_sep2v'] = acbx_sep_ir2
 
     # Match other correctors with fixed mcbx and generate knob
-    opt_sep2v.disable_vary(tag='mcbx')
+    opt_sep2v.disable(vary='mcbx')
     opt_sep2v.solve()
     opt_sep2v.generate_knob()
 
@@ -1088,7 +1088,7 @@ def match_orbit_knobs_ip2_ip8(collider):
         collider.vars[f'acbxh{icorr}.r8_from_on_sep8h'] = acbx_sep_ir8 * sep_match / 2e-3
 
     # Match other correctors with fixed mcbx and generate knob
-    opt_sep8h.disable_vary(tag='mcbx')
+    opt_sep8h.disable(vary='mcbx')
     opt_sep8h.solve()
     opt_sep8h.generate_knob()
 
@@ -1115,7 +1115,7 @@ def match_orbit_knobs_ip2_ip8(collider):
         collider.vars[f'acbxv{icorr}.r8_from_on_sep8v'] = acbx_sep_ir8 * sep_match / 2e-3
 
     # Match other correctors with fixed mcbx and generate knob
-    opt_sep8v.disable_vary(tag='mcbx')
+    opt_sep8v.disable(vary='mcbx')
     opt_sep8v.solve()
     opt_sep8v.generate_knob()
 

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -2732,6 +2732,8 @@ class TempRF(_HasKnlKsl, _HasModelRF, _HasIntegrator, BeamElement):
 class Solenoid(_HasKnlKsl, BeamElement):
     """Solenoid element.
 
+    .. warning:: The Solenoid element is deprecated, use VariableSolenoid or UniformSolenoid instead.
+
     Parameters
     ----------
     length : float

--- a/xtrack/environment.py
+++ b/xtrack/environment.py
@@ -445,6 +445,14 @@ class Environment:
             Length of the line to be built by the builder. Can be an expression.
             If not specified, the length will be the minimum length that can
             fit all the components.
+        mirror : bool, optional
+            Whether the line should be mirrored after creation.
+        compose : bool, optional
+            Whether to instantiate the line in ``compose`` mode, which allows
+            the components to be added to the line after creation.
+        s_tol : float, optional
+            Difference between two s positions below which they should be
+            treated as the same location.
 
         Returns
         -------
@@ -465,7 +473,7 @@ class Environment:
                 env.new('mymark', xt.Marker, at=10.0),  # Create a marker at s=10
                 env.new('mq1_clone', 'mq1', k1='2a'),   # Clone 'mq1' with a different k1
                 env.place('mq2', at=20.0, from='mymark'),  # Place 'mq2' at s=20
-                ])
+            ])
         """
 
         if isinstance(components, str):
@@ -1035,13 +1043,11 @@ class Environment:
                     ] + object.__dir__(self)
 
     def set_multipolar_errors(env, errors):
+        """Deprecated: set multipolar errors for specified elements of the environment.
 
-        '''
-        !DEPRECATED!: This function is deprecated and will be removed in a future version.
-        Please use the attributes `knl_rel` and `ksl_rel` of the elements
-        to set relative multipolar errors directly on the elements.
-
-        Set multipolar errors for specified elements of the environment.
+        .. warning:: This function is deprecated and will be removed in a future
+           version. Please use the attributes `knl_rel` and `ksl_rel` of the elements
+           to set relative multipolar errors directly on the elements.
 
         Parameters
         ----------
@@ -1078,13 +1084,11 @@ class Environment:
                 'mb': {'rel_knl': [2e-6, 3e-5, 4e-4],
                        'rel_ksl': [5e-6, 6e-5, 7e-4]},
                 })
-
-        '''
-
+        """
         warn('The function `set_multipolar_errors` is deprecated and will be removed '
-             'in a future version. Please use the attributes `knl_rel` and `ksl_rel` ' \
+             'in a future version. Please use the attributes `knl_rel` and `ksl_rel` '
              'of the elements to set relative multipolar errors directly on the elements.',
-                FutureWarning)
+             FutureWarning)
 
         for ele_name in progress(errors.keys(), desc='Setting multipolar errors'):
 
@@ -2283,6 +2287,7 @@ class EnvVars:
         self.default_to_zero = old_default_to_zero  # restore (in case changed by loader)
 
     def load_json(self, filename):
+        """Deprecated: use `load` instead."""
         warn(
             '`EnvVars.load_json` is deprecated, use `load`, optionally with `format="json"` instead.',
             FutureWarning

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -116,11 +116,31 @@ class Line:
             used for building particles distributions, computing twiss parameters
             and matching.
         energy_program: EnergyProgram
-            (optional) Energy program used to update the reference energy during the tracking.
+            (optional) Energy program used to update the reference energy during
+            the tracking.
         env : Environment
             Environment object to which the line belongs. If not provided, a new
             environment is created.
-
+        compose : bool, optional
+            Whether to instantiate the line in ``compose`` mode, which allows
+            the components to be added to the line after creation.
+        components : list, optional
+            List of components to be added to the line. It can include strings,
+            place objects, and lines. Can only be given if ``compose`` is true.
+        length : float | str, optional
+            Length of the line to be built by the builder. Can be an expression.
+            If not specified, the length will be the minimum length that can
+            fit all the components. Can only be given if ``compose`` is true.
+        refer : str, optional
+            Specifies which part of the component the ``at`` position will refer
+            to. Allowed values are ``start``, ``center`` (default; also allowed
+            is ``centre```), and ``end``. Can only be given if ``compose`` is true.
+        mirror : bool, optional
+            Whether the line should be mirrored after creation. Can only be given
+            if ``compose`` is true.
+        s_tol : float, optional
+            Difference between two s positions below which they should be
+            treated as the same location. Can only be given if ``compose`` is true.
         """
 
         self.config = xt.tracker.TrackerConfig()
@@ -206,8 +226,8 @@ class Line:
             self.element_names = list(element_names).copy()
         else:
             self.composer = xt.Builder(env, mirror=mirror, length=length,
-                                        refer=refer, s_tol=s_tol or 1e-6,
-                                        components=components)
+                                       refer=refer, s_tol=s_tol or 1e-6,
+                                       components=components)
             self.element_names = element_names
 
         self._particle_ref = particle_ref
@@ -1534,8 +1554,7 @@ class Line:
         ele_stop='__discontinued__',
         ele_init='__discontinued__',
         twiss_init='__discontinued__'
-        ):
-
+    ):
         if not self._has_valid_tracker():
             self.build_tracker()
 
@@ -2895,11 +2914,9 @@ class Line:
     # To be deprecated in favor of Line.insert
     def insert_element(self, name, element=None, at=None, index=None, at_s=None,
                        s_tol=1e-6):
+        """Insert an element in the line.
 
-        """
-        NOTE: This method is deprecated. Use `Line.insert` instead.
-
-        Insert an element in the line.
+        .. warning:: This method is deprecated. Use :meth:`Line.insert` instead.
 
         Parameters
         ----------
@@ -2909,9 +2926,9 @@ class Line:
             Element to be inserted. If not given, the element of the given name
             already present in the line is used.
         at: int or string, optional
-            Index or name of the element in the line. If `index` is provided, `at_s` must be None.
+            Index or name of the element in the line. If ``index`` is provided, ``at_s`` must be None.
         at_s: float, optional
-            Position of the element in the line in meters. If `at_s` is provided, `index`
+            Position of the element in the line in meters. If ``at_s`` is provided, ``index``
             must be None.
         s_tol: float, optional
             Tolerance for the position of the element in the line in meters.
@@ -3003,11 +3020,9 @@ class Line:
         return self
 
     def append_element(self, element, name):
+        """Append element to the end of the lattice
 
-        """
-        NOTE: This method is deprecated. Use `Line.append` instead.
-
-        Append element to the end of the lattice
+        .. warning:: This method is deprecated. Use :meth:`Line.append` instead.
 
         Parameters
         ----------
@@ -4390,7 +4405,10 @@ class Line:
         self.element_names = tuple(self.element_names)
 
     def unfreeze(self):
-        """See `Line.discard_tracker()`. This function is deprecated."""
+        """Use :meth:`Line.discard_tracker` instead.
+
+        .. warning:: This function is deprecated.
+        """
         warn(
             '`Line.unfreeze()` is deprecated and will be removed in future '
             'versions. Please use `Line.discard_tracker()` instead.',

--- a/xtrack/multiline.py
+++ b/xtrack/multiline.py
@@ -4,6 +4,7 @@ from .environment import Environment
 
 # For backward compatibility
 class Multiline(Environment):
+    """Multiline is deprecated, use :class:`Environment` instead."""
 
     def __init__(self, *args, **kwargs):
         warn('Multiline is deprecated, use Environment instead', FutureWarning)

--- a/xtrack/pipeline/multitracker.py
+++ b/xtrack/pipeline/multitracker.py
@@ -4,7 +4,17 @@ import xtrack as xt
 
 class PipelineBranch:
     def __init__(self, line=None, particles=None, tracker=None):
+        """Create a new pipeline branch.
 
+        Parameters
+        ----------
+        line : Line
+            Line of the branch.
+        particles : Particles
+            Particles to be passed to the branch.
+        tracker : Tracker
+            Deprecated: use `line` instead.
+        """
         if tracker is not None:
             warn('The argument tracker is deprecated. Please use line instead.', FutureWarning)
             assert line is None
@@ -65,8 +75,7 @@ class PipelineMultiTracker:
                             f"by element {branch.line.tracker._part_names[branch.pipeline_status.data['ipp']]} "
                             f"with info: {branch.pipeline_status.data['status_from_element'].info}")
 
-                    branch.pipeline_status = branch.line.tracker.resume(
-                                                        branch.pipeline_status)
+                    branch.pipeline_status = branch.line.tracker.resume(branch.pipeline_status)
                     need_resume = True
 
 


### PR DESCRIPTION
## Description

Add deprecation warnings in docstrings, which will be displayed nicely in readthedocs.

Remove the use of functions deprecated in https://github.com/xsuite/xdeps/pull/121.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
