### PR TITLE
Noinline the track local particle per-element functions

### DIFF
--- a/xtrack/headers/track_local_particle_with_transformations.h
+++ b/xtrack/headers/track_local_particle_with_transformations.h
@@ -93,6 +93,9 @@
 #ifdef ALLOW_ROT_AND_SHIFT
 
 GPUFUN
+#ifdef XO_CONTEXT_CL
+    __attribute__((noinline))
+#endif
 void CONCAT(ELEMENT_NAME, _track_local_particle_with_nonzero_transformations)(
     ELEMENT_DATA el,
     LocalParticle* part0
@@ -165,6 +168,9 @@ void CONCAT(ELEMENT_NAME, _track_local_particle_with_nonzero_transformations)(
    standard local tracking function or the one that handles transformations.
 */
 GPUFUN
+#ifdef XO_CONTEXT_CL
+    __attribute__((noinline))
+#endif
 void CONCAT(ELEMENT_NAME, _track_local_particle_with_transformations)(
     ELEMENT_DATA el,
     LocalParticle* part0


### PR DESCRIPTION
## Description

Add a `noinline` annotation to the `*_track_local_particle_with_*_transformations` on the OpenCL context only.

In general, this annotation speeds up compilation on the AMD OpenCL by almost 4x. No tangible gain observed on other contexts and platforms. The tracking slowdown is ~5% on CUDA and CPU, negligible on OpenCL, hence the annotation is only applied on OpenCL.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
