### PR TITLE
Release/0.103.2

### DIFF
--- a/tests/test_madloader.py
+++ b/tests/test_madloader.py
@@ -3,8 +3,6 @@ import pathlib
 
 import numpy as np
 from cpymad.madx import Madx
-from scipy.constants import c as clight
-from scipy.special import factorial
 
 import xobjects as xo
 import xpart as xp

--- a/tests/test_native_madloader.py
+++ b/tests/test_native_madloader.py
@@ -10,8 +10,8 @@ from cpymad.madx import Madx
 from xdeps.refs import CompactFormatter
 import xtrack as xt
 from xtrack import Strategy, Uniform
-from xtrack.mad_parser.loader import MadxLoader
-from xtrack.mad_parser.parse import MadxOutputType, MadxParser
+from xtrack.mad_parser.loader import MadxLoader, MADLoaderWarning
+from xtrack.mad_parser.parse import MadxParser
 
 test_data_folder = (Path(__file__).parent / '../test_data').absolute()
 
@@ -1160,6 +1160,7 @@ def test_import_thick_with_apertures_and_slice():
     for i in range(2):
         _assert_eq(line[f'elm..{i}']._parent.rot_s_rad, 0.2)
 
+
 def test_solenoid_zero_length():
 
     mad_str = """
@@ -1187,6 +1188,7 @@ def test_solenoid_zero_length():
     xo.assert_allclose(env['sol4'].length, 0.0, rtol=0, atol=1e-12)
     xo.assert_allclose(env['sol5'].length, 0.0, rtol=0, atol=1e-12)
     xo.assert_allclose(env['sol6'].length, 0.0, rtol=0, atol=1e-12)
+
 
 def test_bend_k0_neq_h():
 
@@ -1231,3 +1233,57 @@ def test_bend_k0_neq_h():
                     lmad['b1'].edge_entry_angle_fdown, rtol=0, atol=1e-12)
     xo.assert_allclose(lenv['b1'].edge_exit_angle_fdown,
                     lmad['b1'].edge_exit_angle_fdown, rtol=0, atol=1e-12)
+
+
+def test_redefined_apertures():
+    """Check that the following MAD-X behaviour is supported, and note that in both cases MAD-X complains.
+
+    In both cases it ignores the new settings. With "ip1: omk, at = ..." we get:
+
+        ++++++ warning: implicit element re-definition ignored: ip1
+
+    With "ip, at = ..." we get:
+
+        ++++++ warning: Not possible to update attribute for element in sequence definition:  ip1
+        ++++++ warning: Not possible to update attribute for element in sequence definition:  ip1
+        ++++++ warning: Not possible to update attribute for element in sequence definition:  ip1
+
+    In both cases:
+
+        >>> m.sequence.line1.elements['ip1'].aperture
+        [0.029]
+        >>> m.sequence.line2.elements['ip1'].aperture
+        [0.029]
+    """
+
+    mad_src_clone = """
+        l.omk = 0;
+        omk: marker, l := l.omk;
+        ip1: omk, apertype = "circle", aperture := {0.029}, aper_tol := {0.011};
+        
+        line1: sequence, l = 1;
+            ip1: omk, at = 0, apertype = "circle", aperture := {42}, aper_tol := {0.87};
+        endsequence;
+    """
+
+    mad_src_place = """
+        l.omk = 0;
+        omk: marker, l := l.omk;
+        ip1: omk, apertype = "circle", aperture := {0.029}, aper_tol := {0.011};
+
+        line2: sequence, l = 1;
+            ip1: omk, at = 0, apertype = "circle", aperture := {42}, aper_tol := {0.87};
+        endsequence;
+    """
+
+    with pytest.warns(MADLoaderWarning, match='redefinition ignored'):
+        env1 = xt.load(string=mad_src_clone, format='madx')
+    aper1 = env1.line1['ip1_aper']
+    assert isinstance(aper1, xt.LimitEllipse)
+    assert np.allclose([aper1.a, aper1.b], 0.029, atol=1e-12, rtol=0)
+
+    with pytest.warns(MADLoaderWarning, match='redefinition ignored'):
+        env2 = xt.load(string=mad_src_place, format='madx')
+    aper2 = env2.line2['ip1_aper']
+    assert isinstance(aper2, xt.LimitEllipse)
+    assert np.allclose([aper2.a, aper2.b], 0.029, atol=1e-12, rtol=0)

--- a/tests/test_native_madloader_ti2.py
+++ b/tests/test_native_madloader_ti2.py
@@ -3,10 +3,14 @@ import xtrack as xt
 import xobjects as xo
 import numpy as np
 import pathlib
+import pytest
+
 
 test_data_folder = pathlib.Path(
     __file__).parent.joinpath('../test_data').absolute()
 
+
+@pytest.mark.filterwarnings('ignore::xtrack.mad_parser.loader.MADLoaderWarning')
 def test_native_madloader_ti2():
     env = xt.load([test_data_folder / 'sps_to_lhc_ti2/ti2.seq',
                    test_data_folder / 'sps_to_lhc_ti2/ti2_liu.str'])

--- a/xtrack/headers/track_local_particle_with_transformations.h
+++ b/xtrack/headers/track_local_particle_with_transformations.h
@@ -93,6 +93,9 @@
 #ifdef ALLOW_ROT_AND_SHIFT
 
 GPUFUN
+#ifdef XO_CONTEXT_CL
+    __attribute__((noinline))
+#endif
 void CONCAT(ELEMENT_NAME, _track_local_particle_with_nonzero_transformations)(
     ELEMENT_DATA el,
     LocalParticle* part0
@@ -165,6 +168,9 @@ void CONCAT(ELEMENT_NAME, _track_local_particle_with_nonzero_transformations)(
    standard local tracking function or the one that handles transformations.
 */
 GPUFUN
+#ifdef XO_CONTEXT_CL
+    __attribute__((noinline))
+#endif
 void CONCAT(ELEMENT_NAME, _track_local_particle_with_transformations)(
     ELEMENT_DATA el,
     LocalParticle* part0

--- a/xtrack/mad_loader.py
+++ b/xtrack/mad_loader.py
@@ -327,6 +327,7 @@ class ElementAssembler:
             xtel.name_associated_aperture = name_associated_aperture
         name = generate_repeated_name(line, self.name)
         line.append(name, xtel)
+        return xtel
 
 
 class ElementAssemblerWithExpr(ElementAssembler):

--- a/xtrack/mad_parser/loader.py
+++ b/xtrack/mad_parser/loader.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Dict, Optional, List, Set, Tuple, Union
 
 import numpy as np
@@ -59,8 +60,12 @@ _APERTURE_TYPES = {
 }
 
 
+class MADLoaderWarning(UserWarning):
+    pass
+
+
 def _warn(msg):
-    print(f'Warning: {msg}')
+    warnings.warn(msg, MADLoaderWarning)
 
 
 def get_params(params, parent):
@@ -624,6 +629,10 @@ class MadxLoader:
                 aper_params['x_vertices'] = aper_vx
             if (aper_vy := params.pop('aper_vy', None)):
                 aper_params['y_vertices'] = aper_vy
+
+        if not force and aper_name in self.env:
+            _warn(f'Aperture `{aper_name}` redefinition ignored for compatibility with MAD-X.')
+            return aper_name
 
         return self.env.new(aper_name, _APERTURE_TYPES[apertype], force=force,
                             **aper_params)


### PR DESCRIPTION
**Changes:**

- Enable loading redefined apertures in the native madloader, replicating the MAD-X behaviour: ignore and warn #775.
- Fix a bug in the cpymad loader where `aper_offset` was not read #775.
- Speedup OpenCL compile time by no-inlining per-element tracking functions #776.