### PR TITLE
BUG: Fix the particle conversion in MAD-NG

### DIFF
--- a/xtrack/madng_interface.py
+++ b/xtrack/madng_interface.py
@@ -424,7 +424,7 @@ def line_to_madng(line, sequence_name='seq', temp_fname=None, keep_files=False,
 
         mng[sequence_name] = mng.MADX[sequence_name] # this ensures that the file has been read
         mng[sequence_name].beam = mng.beam(particle="'custom'",
-                        mass=line.particle_ref.mass0 * 1e9,
+                        mass=line.particle_ref.mass0 / 1e9, # xsuite mass eV -> ng mass GeV.
                         charge=line.particle_ref.q0,
                         betgam=line.particle_ref.beta0[0] * line.particle_ref.gamma0[0])
 


### PR DESCRIPTION
## Description
Please double check this, but I was was finding the particle pc was 1e18 too high for a specific test. I assumed the mass was in eV based on the documentation. 

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
