### PR TITLE
Fix tqdm notebook error in apptainer containers

### DIFF
--- a/xtrack/progress_indicator.py
+++ b/xtrack/progress_indicator.py
@@ -96,9 +96,12 @@ try:
     with warnings.catch_warnings(): # To avoid warnings from tqdm.autonotebook (experimental module)
         warnings.simplefilter("ignore")
         from tqdm.autonotebook import tqdm
-        from tqdm.notebook import tqdm_notebook
+        try:
+            from tqdm.notebook import tqdm_notebook
+        except:
+            tqdm_notebook = None
 
-    if tqdm is tqdm_notebook:  # tqdm determined we're in a notebook.
+    if tqdm_notebook is not None and tqdm is tqdm_notebook:  # tqdm determined we're in a notebook.
         class PatchedTqdm(tqdm):
             """Patched version of tqdm_notebook.
 


### PR DESCRIPTION
## Description
This PR fixes an issue that was introduced in low privilege environments (like lxplus) when using apptainer with IPython 9.13.0

The error originated from a permission issue when importing `tqdm.notebook`, which seems unnecessary if we are not running from a notebook environment. This fix changes the import logic to avoid errors in simple imports.
 
This change is important to ensure that cvmfs containers do not crash.

<details>
<summary>xtrack import error</summary>
<pre>
Traceback (most recent call last):
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/psutil/_pslinux.py", line 1593, in wrapper
    return fun(self, *args, **kwargs)
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/psutil/_common.py", line 377, in wrapper
    raise err from None
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/psutil/_common.py", line 375, in wrapper
    return fun(self)
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/psutil/_pslinux.py", line 1683, in _parse_stat_file
    data = bcat(f"{self._procfs_path}/{self.pid}/stat")
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/psutil/_common.py", line 730, in bcat
    return cat(fname, fallback=fallback, _open=open_binary)
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/psutil/_common.py", line 718, in cat
    with _open(fname) as f:
         ~~~~~^^^^^^^
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/psutil/_common.py", line 682, in open_binary
    return open(fname, "rb", buffering=FILE_READ_BUFFER_SIZE)
PermissionError: [Errno 1] Operation not permitted: '/proc/776109/stat'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/afs/cern.ch/work/e/ekatrali/private/test_container.py", line 1, in <module>
    import xtrack as xt
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/xtrack/__init__.py", line 14, in <module>
    from .tracker_data import TrackerData
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/xtrack/tracker_data.py", line 16, in <module>
    from .line import Line, mk_class_namespace, _has_backtrack
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/xtrack/line.py", line 46, in <module>
    from .mad_loader import MadLoader
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/xtrack/mad_loader.py", line 38, in <module>
    from .progress_indicator import progress
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/xtrack/progress_indicator.py", line 99, in <module>
    from tqdm.notebook import tqdm_notebook
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/tqdm/notebook.py", line 23, in <module>
    import ipywidgets
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/ipywidgets/__init__.py", line 27, in <module>
    from IPython import get_ipython
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/IPython/__init__.py", line 56, in <module>
    from .terminal.embed import embed
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/IPython/terminal/embed.py", line 16, in <module>
    from IPython.terminal.interactiveshell import TerminalInteractiveShell
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/IPython/terminal/interactiveshell.py", line 11, in <module>
    from IPython.core.kitty import (
    ...<2 lines>...
    )
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/IPython/core/kitty.py", line 36, in <module>
    supports_kitty_graphics = _supports_kitty_graphics()
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/IPython/core/kitty.py", line 30, in _supports_kitty_graphics
    while process := process.parent():
                     ~~~~~~~~~~~~~~^^
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/psutil/__init__.py", line 608, in parent
    if parent.create_time() <= proc_ctime:
       ~~~~~~~~~~~~~~~~~~^^
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/psutil/__init__.py", line 784, in create_time
    self._create_time = self._proc.create_time()
                        ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/psutil/_pslinux.py", line 1593, in wrapper
    return fun(self, *args, **kwargs)
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/psutil/_pslinux.py", line 1857, in create_time
    float(self._parse_stat_file()['create_time']) / CLOCK_TICKS
          ~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/xsuiteuser/xsuite-env/lib/python3.13/site-packages/psutil/_pslinux.py", line 1595, in wrapper
    raise AccessDenied(pid, name) from err
psutil.AccessDenied: (pid=776109)
</pre>

</details>
