### PR TITLE
Added x to MAD-NG get_jacobian for arbitrary jacobian calculation

### DIFF
--- a/tests/test_madnginterface.py
+++ b/tests/test_madnginterface.py
@@ -586,3 +586,11 @@ def test_madng_orbit_bump():
     opt.solve()
 
     assert opt._err.call_counter < 7
+
+    # check for arbitrary x argument that x is persisted in optimization object
+    x_sol = opt._err._get_x()
+    jac_sol = opt._err.get_jacobian(x_sol)
+    x_probe = x_sol + 1e-4
+    jac_probe = opt._err.get_jacobian(x_probe)
+    xo.assert_allclose(opt._err._get_x(), x_probe, rtol=0, atol=1e-12)
+    assert not np.allclose(jac_probe, jac_sol, rtol=1e-6, atol=1e-6)

--- a/tests/test_madnginterface.py
+++ b/tests/test_madnginterface.py
@@ -594,3 +594,66 @@ def test_madng_orbit_bump():
     jac_probe = opt._err.get_jacobian(x_probe)
     xo.assert_allclose(opt._err._get_x(), x_probe, rtol=0, atol=1e-12)
     assert not np.allclose(jac_probe, jac_sol, rtol=1e-6, atol=1e-6)
+
+def test_madng_tpsa_optics_with_nonzero_initial_orbit():
+    # Regression test: TPSA optical functions (beta/alpha) must be correct for a
+    # non-zero initial orbit. The initial orbit used to be written into the
+    # damap with `map1.x = value`, which wiped the A-matrix built by bet2map and
+    # corrupted the optics; the fix sets only the constant part (`map1.x:set0`).
+    env = xt.Environment()
+    env.particle_ref = xt.Particles(p0c=7e12, mass0=xt.PROTON_MASS_EV)
+    env.vars.default_to_zero = True
+    env['kqf'] = 0.30
+    env['kqd'] = -0.32
+    qkw = dict(length=0.5, model='mat-kick-mat', integrator='uniform',
+               num_multipole_kicks=1, edge_entry_active=False,
+               edge_exit_active=False)
+    env.new('d1', xt.Drift, length=1.0, model='exact')
+    env.new('qf', xt.Quadrupole, k1='kqf', **qkw)
+    env.new('d2', xt.Drift, length=1.0, model='exact')
+    env.new('mb', xt.Bend, angle=0.05, length=2.0, k1=0.0,
+            model='bend-kick-bend', integrator='uniform', num_multipole_kicks=1,
+            edge_entry_active=False, edge_exit_active=False)
+    env.new('d3', xt.Drift, length=1.0, model='exact')
+    env.new('qd', xt.Quadrupole, k1='kqd', **qkw)
+    env.new('d4', xt.Drift, length=1.0, model='exact')
+    env.new('end', xt.Marker)
+    line = env.new_line(components=['d1', 'qf', 'd2', 'mb', 'd3', 'qd', 'd4', 'end'])
+    line.particle_ref = env.particle_ref
+
+    # Non-trivial initial Twiss with a non-zero initial orbit (the trigger).
+    init = dict(betx=3.0, alfx=-1.0, bety=5.0, alfy=2.0,
+                dx=0.0, dpx=0.0, dy=0.0, dpy=0.0,
+                x=1e-3, px=1.5e-3, y=0.5e-3, py=-0.8e-3, delta=1e-3)
+    quants = ['betx', 'alfx', 'bety', 'alfy']
+
+    tw_nom = line.twiss(**init)
+
+    # Reachable targets: beta/alpha at a known working point (so a solution
+    # exists), then reset the knobs to start the match away from it.
+    line['kqf'], line['kqd'] = 0.34, -0.30
+    tw_wp = line.twiss(**init)
+    target = {q: tw_wp[q, 'end'] for q in quants}
+    line['kqf'], line['kqd'] = 0.30, -0.32
+
+    opt = line.match(
+        solve=False, use_tpsa=True, assert_within_tol=False,
+        vary=xt.VaryList(['kqf', 'kqd'], step=1e-7),
+        targets=[xt.TargetSet(at='end', tol=1e-3, **target)],
+        **init)
+
+    # Forward check: the TPSA optical functions (last_res_values) at the nominal
+    # knobs must match xtrack twiss - corrupted by the bug for a non-zero orbit.
+    opt._err.show_call_counter = False
+    opt._err(opt._err._get_x())
+    tpsa = dict(zip([t.tar[0] for t in opt.targets], opt._err.last_res_values))
+    for q in quants:
+        xo.assert_allclose(tpsa[q], tw_nom[q, 'end'], rtol=5e-3, atol=1e-4)
+
+    # Solve the match (its Jacobian is also corrupted by the bug) and verify the
+    # matched optics hit the targets, cross-checked with an independent xtrack
+    # twiss. With the bug the TPSA optics/Jacobian are wrong, so this fails.
+    opt.solve()
+    tw_sol = line.twiss(**init)
+    for q in quants:
+        xo.assert_allclose(tw_sol[q, 'end'], target[q], rtol=2e-4, atol=1e-5)

--- a/xtrack/madng_interface.py
+++ b/xtrack/madng_interface.py
@@ -802,9 +802,14 @@ class ActionTwissMadngTPSA(Action):
             init_coord[4] = init['zeta', start_loc] / beta0
             init_coord[5] = init['ptau', start_loc] # ptau corresponds to pt
 
-        # Build small Lua snippet: map1.x = val ...
+        # Build small Lua snippet setting the initial orbit, e.g.
+        # ``map1.x:set0(val) ...``.  We must use ``:set0`` (set the 0th-order /
+        # constant part) and NOT ``map1.x = val``: to preserve TPSA.
+        # Otherwise TPSA is replaced which corrputs the A-matrix row and
+        # the optical functions for non-zero orbit.
+
         coord_assign = " ".join(
-            f"map1.{p} = {v}"
+            f"map1.{p}:set0({v})"
             for p, v in zip(['x','px','y','py','t','pt'], init_coord)
             if abs(v) > 1e-12
         )

--- a/xtrack/madng_interface.py
+++ b/xtrack/madng_interface.py
@@ -805,7 +805,7 @@ class ActionTwissMadngTPSA(Action):
         # Build small Lua snippet setting the initial orbit, e.g.
         # ``map1.x:set0(val) ...``.  We must use ``:set0`` (set the 0th-order /
         # constant part) and NOT ``map1.x = val``: to preserve TPSA.
-        # Otherwise TPSA is replaced which corrputs the A-matrix row and
+        # Otherwise TPSA is replaced which corrupts the A-matrix row and
         # the optical functions for non-zero orbit.
 
         coord_assign = " ".join(

--- a/xtrack/match.py
+++ b/xtrack/match.py
@@ -839,11 +839,11 @@ class MeritFunctionLine(xd.MeritFunctionForMatch):
 
     def get_jacobian(self, x=None, f0=None):
         if self.use_tpsa:
-            return self.get_jacobian_tpsa()
+            return self.get_jacobian_tpsa(x)
         else:
             return super().get_jacobian(x, f0=f0)
 
-    def get_jacobian_tpsa(self):
+    def get_jacobian_tpsa(self, x=None):
         from .madng_interface import ActionTwissMadngTPSA
         action = None
         for a in self.actions:
@@ -853,7 +853,11 @@ class MeritFunctionLine(xd.MeritFunctionForMatch):
         if action is None:
             raise RuntimeError('No ActionTwissMadngTPSA found in actions for TPSA jacobian computation')
 
-
+        # acquire_jacobian() reads the Jacobian as the linear part of the
+        # differential-algebra map from the last MAD-NG track.
+        # Re-track only if different point requested, to avoid redundant MAD-NG calls: self(x) re-tracks at x
+        if x is not None and not np.allclose(x, self._get_x(), rtol=1e-12, atol=0):
+            self(x)
 
         jacobian = action.acquire_jacobian()
 


### PR DESCRIPTION
## Description

Bugfix: Fixed bug when initializing coordinates with non-zero orbit for TPSA optimization.
Added possibility for get_jacobian_tpsa to use an x to calculate jacobian for any x and not only for current map. Put a little addendum to the orbit_bump test to verify this.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description