### PR TITLE
Enable RandomRutherford on the CUDA (Cupy) GPU context

### DIFF
--- a/examples/random_number_generator/002_rutherford_cpu_vs_gpu.py
+++ b/examples/random_number_generator/002_rutherford_cpu_vs_gpu.py
@@ -1,0 +1,118 @@
+"""Visual CPU-vs-GPU comparison of the RandomRutherford sampler.
+
+Samples the Rutherford distribution on ContextCpu and ContextCupy with identical
+parameters and overlays the two distributions against the analytic PDF. This is
+the documentation figure for enabling RandomRutherford on the CUDA context:
+agreement is distributional (parallel RNG streams + FP ordering differ across
+contexts, so a per-particle bitwise match is neither expected nor required).
+
+Run with cupy's CUDA libs on the loader path, e.g.:
+    LDP=$(ls -d $(python -c 'import sys;print(sys.prefix)')/lib/python*/site-packages/nvidia/*/lib | tr '\n' ':')
+    LD_LIBRARY_PATH="$LDP" python 002_rutherford_cpu_vs_gpu.py
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.stats import ks_2samp
+
+import xobjects as xo
+import xtrack as xt
+
+# Rutherford parameters (same as tests/test_random_gen_ruth.py)
+rA, rB, t0, t1, iterations = 0.0012306225579197868, 53.50625, 0.001, 0.02, 7
+N_SAMPLES, N_SEEDS = int(3e6), 3000
+
+
+def sample(context):
+    ran = xt.RandomRutherford(_context=context)
+    ran.A, ran.B = rA, rB
+    ran.lower_val, ran.upper_val = t0, t1
+    ran.Newton_iterations = iterations
+    s = ran.generate(n_samples=N_SAMPLES, n_seeds=N_SEEDS)
+    return np.asarray(context.nparray_from_context_array(s)).ravel()
+
+
+def analytic_pdf(t):
+    # (A/t^2) exp(-B t), normalised to unit area on [t0, t1]
+    raw = (rA / t**2) * np.exp(-rB * t)
+    grid = np.linspace(t0, t1, 20000)
+    y = (rA / grid**2) * np.exp(-rB * grid)
+    norm = np.sum(0.5 * (y[1:] + y[:-1]) * np.diff(grid))  # trapezoid
+    return raw / norm
+
+
+cpu = sample(xo.ContextCpu())
+gpu = sample(xo.ContextCupy())
+
+ks = ks_2samp(cpu, gpu)
+
+# binned KL divergence (CPU || GPU)
+edges = np.linspace(t0, t1, 201)
+centers = 0.5 * (edges[:-1] + edges[1:])
+h_cpu, _ = np.histogram(cpu, bins=edges, density=True)
+h_gpu, _ = np.histogram(gpu, bins=edges, density=True)
+p = h_cpu * np.diff(edges) + 1e-12
+q = h_gpu * np.diff(edges) + 1e-12
+p, q = p / p.sum(), q / q.sum()
+kl = float(np.sum(p * np.log(p / q)))
+
+fig, axes = plt.subplots(1, 3, figsize=(16, 4.6))
+fig.suptitle(
+    f"RandomRutherford  —  CPU vs GPU (Cupy)   |   {N_SAMPLES:,} samples"
+    f"   |   KS = {ks.statistic:.4f} (p = {ks.pvalue:.2f})   |   KL = {kl:.2e}",
+    fontsize=12,
+)
+
+# (1) PDF overlay, log-y
+ax = axes[0]
+ax.hist(cpu, bins=edges, density=True, histtype="stepfilled", alpha=0.35,
+        color="C0", label="CPU")
+ax.hist(gpu, bins=edges, density=True, histtype="step", lw=1.8,
+        color="C3", label="GPU (Cupy)")
+ax.plot(centers, analytic_pdf(centers), "k--", lw=1.2, label="analytic Rutherford")
+ax.set_yscale("log")
+ax.set_xlabel("t  (momentum-transfer variable)")
+ax.set_ylabel("probability density")
+ax.set_title("Sampled distribution (log scale)")
+ax.legend()
+
+# (2) empirical CDF overlay with the KS gap marked
+ax = axes[1]
+xs = np.linspace(t0, t1, 2000)
+cdf_cpu = np.searchsorted(np.sort(cpu), xs) / cpu.size
+cdf_gpu = np.searchsorted(np.sort(gpu), xs) / gpu.size
+ax.plot(xs, cdf_cpu, color="C0", lw=1.8, label="CPU")
+ax.plot(xs, cdf_gpu, color="C3", lw=1.2, ls="--", label="GPU (Cupy)")
+imax = int(np.argmax(np.abs(cdf_cpu - cdf_gpu)))
+ax.annotate(f"max |ΔCDF| = {ks.statistic:.4f}",
+            xy=(xs[imax], cdf_cpu[imax]), xytext=(0.45, 0.35),
+            textcoords="axes fraction",
+            arrowprops=dict(arrowstyle="->", color="0.3"))
+ax.set_xlabel("t")
+ax.set_ylabel("cumulative probability")
+ax.set_title("Empirical CDF (KS statistic)")
+ax.legend()
+
+# (3) per-bin ratio GPU/CPU with Poisson noise band
+ax = axes[2]
+counts_cpu, _ = np.histogram(cpu, bins=edges)
+counts_gpu, _ = np.histogram(gpu, bins=edges)
+mask = counts_cpu > 0
+ratio = np.full_like(centers, np.nan)
+ratio[mask] = counts_gpu[mask] / counts_cpu[mask]
+noise = np.full_like(centers, np.nan)
+noise[mask] = np.sqrt(1.0 / counts_cpu[mask] + 1.0 / counts_gpu[mask])
+ax.axhline(1.0, color="k", lw=1.0)
+ax.fill_between(centers, 1 - noise, 1 + noise, color="0.8",
+                label="±1σ counting noise")
+ax.plot(centers, ratio, ".", ms=3, color="C2", label="GPU / CPU")
+ax.set_ylim(0.9, 1.1)
+ax.set_xlabel("t")
+ax.set_ylabel("GPU / CPU  bin-count ratio")
+ax.set_title("Bin-by-bin ratio")
+ax.legend()
+
+fig.tight_layout(rect=(0, 0, 1, 0.95))
+out = "rutherford_cpu_vs_gpu.png"
+fig.savefig(out, dpi=130)
+print(f"KS={ks.statistic:.5f} (p={ks.pvalue:.3f})  KL={kl:.3e}")
+print(f"wrote {out}")

--- a/examples/random_number_generator/003_rutherford_cpu_vs_gpu_benchmark.py
+++ b/examples/random_number_generator/003_rutherford_cpu_vs_gpu_benchmark.py
@@ -1,0 +1,154 @@
+"""CPU-vs-GPU *timing* benchmark for the RandomRutherford sampler.
+
+Companion to 002_rutherford_cpu_vs_gpu.py (which checks distributional
+agreement). This measures the speed-up from enabling RandomRutherford on the
+CUDA context: it times the sampling kernel on ContextCpu (single core) and
+ContextCupy across a range of parallel-stream counts and reports throughput
+(Rutherford draws per second) and the GPU/CPU speed-up.
+
+Methodology (fair-timing):
+  * the parallel dimension is the number of RNG streams `n_seeds` (one thread
+    per seed); each stream draws SPP samples;
+  * particles + RNG state are built once per size and EXCLUDED from the timer,
+    so only the Rutherford sampling kernel is measured (not host->device setup);
+  * kernels are warmed up once (the one-off NVRTC/cffi compile is excluded);
+  * GPU timing brackets cp.cuda.runtime.deviceSynchronize(); the median of
+    several repeats is reported.
+
+Caveats: the CPU baseline is a single core (ContextCpu is serial); the absolute
+numbers are hardware-specific (here: one consumer GPU).
+
+Run with cupy's CUDA libs on the loader path, e.g.:
+    LDP=$(ls -d $(python -c 'import sys;print(sys.prefix)')/lib/python*/site-packages/nvidia/*/lib | tr '\n' ':')
+    LD_LIBRARY_PATH="$LDP" python 003_rutherford_cpu_vs_gpu_benchmark.py
+"""
+import json
+import time
+
+import numpy as np
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+import xobjects as xo
+import xtrack as xt
+
+# Rutherford parameters (same as tests/test_random_gen_ruth.py + example 002).
+rA, rB = 0.0012306225579197868, 53.50625
+t0, t1, iterations = 0.001, 0.02, 7
+
+# Scan the number of parallel RNG streams (= one thread/particle per seed).
+SIZES = [1_000, 10_000, 100_000, 1_000_000, 3_000_000, 6_000_000]
+REPEATS = {1_000: 9, 10_000: 9, 100_000: 7, 1_000_000: 5,
+           3_000_000: 5, 6_000_000: 5}
+SPP = 1  # Rutherford draws per stream (the per-particle per-interaction cost)
+
+
+def is_gpu(context):
+    return isinstance(context, getattr(xo, "ContextCupy", ()))
+
+
+def sync(context):
+    if is_gpu(context):
+        import cupy as cp
+        cp.cuda.runtime.deviceSynchronize()
+
+
+def make_rng(context):
+    ran = xt.RandomRutherford(_context=context)
+    ran.A, ran.B = rA, rB
+    ran.lower_val, ran.upper_val = t0, t1
+    ran.Newton_iterations = iterations
+    return ran
+
+
+def time_sample(ran, context, n_seeds, spp, repeats):
+    """Median wall time (s) of one Rutherford sampling kernel launch.
+
+    Particles + RNG state are built once and excluded from the timer."""
+    particles = xt.Particles(state=np.ones(n_seeds), x=np.ones(n_seeds),
+                             _context=context)
+    particles._init_random_number_generator()
+    samples = context.zeros(shape=(n_seeds * spp,), dtype=np.float64)
+    # warm up: triggers kernel build + first-launch costs (excluded from timing)
+    ran._sample(particles=particles, samples=samples, n_samples_per_seed=spp)
+    sync(context)
+    times = []
+    for _ in range(repeats):
+        sync(context)
+        t_start = time.perf_counter()
+        ran._sample(particles=particles, samples=samples,
+                    n_samples_per_seed=spp)
+        sync(context)
+        times.append(time.perf_counter() - t_start)
+    return float(np.median(times))
+
+
+def main():
+    cpu_ctx = xo.ContextCpu()
+    gpu_ctx = xo.ContextCupy()
+    cpu_rng = make_rng(cpu_ctx)
+    gpu_rng = make_rng(gpu_ctx)
+
+    rows = []
+    print(f"{'streams':>9} {'draws':>10} {'CPU [ms]':>10} {'GPU [ms]':>10} "
+          f"{'speedup':>9} {'CPU Md/s':>9} {'GPU Md/s':>9}")
+    for n_seeds in SIZES:
+        reps = REPEATS[n_seeds]
+        n_draws = n_seeds * SPP
+        t_cpu = time_sample(cpu_rng, cpu_ctx, n_seeds, SPP, reps)
+        t_gpu = time_sample(gpu_rng, gpu_ctx, n_seeds, SPP, reps)
+        speedup = t_cpu / t_gpu
+        cpu_mds = n_draws / t_cpu / 1e6
+        gpu_mds = n_draws / t_gpu / 1e6
+        rows.append({"n_seeds": n_seeds, "n_draws": n_draws, "cpu_s": t_cpu,
+                     "gpu_s": t_gpu, "speedup": speedup,
+                     "cpu_mdraws_s": cpu_mds, "gpu_mdraws_s": gpu_mds})
+        print(f"{n_seeds:>9d} {n_draws:>10d} {t_cpu*1e3:>10.3f} "
+              f"{t_gpu*1e3:>10.3f} {speedup:>8.2f}x {cpu_mds:>9.2f} "
+              f"{gpu_mds:>9.2f}")
+
+    ns = np.array([r["n_draws"] for r in rows])
+    sp = np.array([r["speedup"] for r in rows])
+    cpu_mds = np.array([r["cpu_mdraws_s"] for r in rows])
+    gpu_mds = np.array([r["gpu_mdraws_s"] for r in rows])
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4.6))
+    fig.suptitle("RandomRutherford sampler — CPU (1 core) vs GPU (Cupy)",
+                 fontsize=13)
+    ax1.plot(ns, sp, "o-", color="C2")
+    ax1.axhline(1.0, color="0.5", ls="--", lw=1, label="break-even (1x)")
+    ax1.set_xscale("log")
+    ax1.set_xlabel("number of Rutherford draws")
+    ax1.set_ylabel("GPU speed-up  (CPU time / GPU time)")
+    ax1.set_title("speed-up vs problem size")
+    for x, y in zip(ns, sp):
+        ax1.annotate(f"{y:.0f}x", (x, y), textcoords="offset points",
+                     xytext=(0, 7), ha="center", fontsize=8)
+    ax1.legend(fontsize=8)
+    ax1.grid(alpha=0.3)
+
+    ax2.plot(ns, cpu_mds, "o-", color="C0", label="CPU (1 core)")
+    ax2.plot(ns, gpu_mds, "s-", color="C3", label="GPU (Cupy)")
+    ax2.set_xscale("log")
+    ax2.set_yscale("log")
+    ax2.set_xlabel("number of Rutherford draws")
+    ax2.set_ylabel("throughput [million draws / s]")
+    ax2.set_title("sampling throughput")
+    ax2.legend(fontsize=8)
+    ax2.grid(alpha=0.3, which="both")
+
+    fig.tight_layout(rect=(0, 0, 1, 0.94))
+    out_png = "rutherford_cpu_vs_gpu_benchmark.png"
+    fig.savefig(out_png, dpi=130)
+    plt.close(fig)
+    with open("rutherford_cpu_vs_gpu_benchmark.json", "w") as handle:
+        json.dump({"spp": SPP, "rows": rows}, handle, indent=2)
+    best = max(rows, key=lambda r: r["speedup"])
+    print(f"  wrote {out_png}")
+    print(f"peak speed-up {best['speedup']:.0f}x at {best['n_draws']:,} draws")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_random_gen_ruth.py
+++ b/tests/test_random_gen_ruth.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import numpy as np
 import copy
+import pytest
 
 import xobjects as xo
 from xobjects.test_helpers import for_all_test_contexts, skip_if_forbid_compile
@@ -22,7 +23,7 @@ rA = 0.0012306225579197868
 rB = 53.50625
 iterations = 7
 
-@for_all_test_contexts(excluding=('ContextCupy', 'ContextPyopencl'))
+@for_all_test_contexts(excluding=('ContextPyopencl',))
 def test_random_generation_ruth(test_context):
 
     skip_if_forbid_compile()
@@ -82,7 +83,7 @@ def test_random_generation_ruth(test_context):
         np.allclose(hstgm[:-10], ruth[:-10], rtol=5e-2, atol=1)
 
 
-@for_all_test_contexts(excluding=('ContextCupy', 'ContextPyopencl'))
+@for_all_test_contexts(excluding=('ContextPyopencl',))
 def test_direct_sampling(test_context):
     n_seeds = 3
     n_samples = 3e6
@@ -104,7 +105,7 @@ def test_direct_sampling(test_context):
         np.allclose(hstgm[:-10], ruth[:-10], rtol=5e-2, atol=1)
 
 
-@for_all_test_contexts(excluding=('ContextCupy', 'ContextPyopencl'))
+@for_all_test_contexts(excluding=('ContextPyopencl',))
 def test_reproducibility(test_context):
     # 1e8 samples in total
     n_seeds = int(1e5)
@@ -129,4 +130,32 @@ def test_reproducibility(test_context):
         results2 = ran.generate(n_samples=n_samples_per_seed*n_seeds, particles=part2)
         results2 = test_context.nparray_from_context_array(results2)
         assert np.all(results1 == results2)
+
+
+def test_cpu_gpu_distribution_match():
+    # The Rutherford sampler must produce the *same distribution* on CPU and
+    # on GPU (Cupy). Parallel RNG streams + floating-point ordering differ
+    # between contexts, so we do NOT expect a per-particle bitwise match;
+    # instead we compare 3e6 samples with the two-sample Kolmogorov-Smirnov
+    # statistic (distributional agreement).
+    cupy = pytest.importorskip('cupy')  # noqa: F841
+    from scipy.stats import ks_2samp
+
+    def _sample(ctx):
+        ran = xt.RandomRutherford(_context=ctx)
+        ran.A = rA
+        ran.B = rB
+        ran.lower_val = t0
+        ran.upper_val = t1
+        ran.Newton_iterations = iterations
+        samples = ran.generate(n_samples=int(3e6), n_seeds=3000)
+        return np.asarray(ctx.nparray_from_context_array(samples)).ravel()
+
+    cpu_samples = _sample(xo.ContextCpu())
+    gpu_samples = _sample(xo.ContextCupy())
+
+    ks = ks_2samp(cpu_samples, gpu_samples)
+    assert ks.statistic < 0.01, (
+        f"CPU-vs-GPU Rutherford distributions disagree: "
+        f"KS={ks.statistic:.4f} (p={ks.pvalue:.3g})")
 

--- a/xtrack/random/random_generators.py
+++ b/xtrack/random/random_generators.py
@@ -191,8 +191,15 @@ class RandomRutherford(RandomUniform):
 
         super().__init__(**kwargs)
 
-        if not isinstance(self._context, xo.ContextCpu):
-            raise ValueError('Rutherford random generator is not currently supported on GPU.')
+        # The Rutherford sampler runs on CPU and CUDA (Cupy): its C path uses
+        # only bounded loops and plain f64 math, with DBL_MAX/DBL_EPSILON
+        # supplied by xtrack/headers/constants.h on GPU. OpenCL is still
+        # excluded because exponential_integral_Ei.h relies on a file-scope
+        # `static const` lookup table, which is illegal in OpenCL C.
+        if isinstance(self._context, xo.ContextPyopencl):
+            raise ValueError(
+                'Rutherford random generator is not currently supported on '
+                'OpenCL (ContextPyopencl).')
 
     def set_parameters(self, A, B, lower_val, upper_val):
         self.compile_kernels(particles_class=xt.Particles, only_if_needed=True)


### PR DESCRIPTION
# Enable `RandomRutherford` on the CUDA (Cupy) GPU context

## Summary

`RandomRutherford` was blocked from all non-CPU contexts by a Python guard in
`RandomRutherford.__init__`, even though its C sampling kernel is already
GPU-clean (`GPUFUN`/`GPUKERN`, `#ifdef XO_CONTEXT_CPU` include guards, a
fixed-count Newton inversion, no `malloc`/`printf`/global RNG state). This
narrows the guard to reject only OpenCL — the file-scope `static const double
ei[]` table in `exponential_integral_Ei.h` is illegal in OpenCL but fine on CUDA
(constant memory) — which enables the Rutherford RNG on the Cupy/CUDA context.

## What changed

- `xtrack/random/random_generators.py`: replace the blanket
  `if not isinstance(self._context, xo.ContextCpu): raise ...` guard with a
  narrow `if isinstance(self._context, xo.ContextPyopencl): raise ...` — CUDA/Cupy
  is now allowed; OpenCL is still rejected with a clear message.
- `tests/test_random_gen_ruth.py`: stop excluding `ContextCupy` from the existing
  Rutherford tests; add `test_cpu_gpu_distribution_match` (a CPU-vs-GPU
  distributional check).
- `examples/random_number_generator/002_rutherford_cpu_vs_gpu.py`: a CPU-vs-GPU
  comparison figure generator (log-y PDF overlay against the analytic Rutherford,
  empirical CDFs/KS, and the GPU/CPU bin-ratio vs a counting-noise band).

## Validation

- `pytest tests/test_random_gen_ruth.py` → **7 passed**: all three existing tests
  now run on **both** `ContextCpu` and `ContextCupy` (analytic-PDF agreement and
  within-context reproducibility hold on GPU), plus the new cross-context test.
- CPU-vs-GPU agreement on 3e6 samples: **KS = 0.0006** (p ≈ 0.6), **KL ≈ 5.6e-5**
  (thresholds KS < 0.01, KL < 1e-3). Means/stds match to ~4 significant figures.

Agreement is distributional, not per-particle bitwise: the Newton + Ei series
need only converge to within sampling noise, and the parallel RNG streams differ
across contexts.

## Notes

- OpenCL remains out of scope (the file-scope `ei[]` table is OpenCL-illegal);
  CUDA/Cupy only.
- This unblocks a follow-up `xcoll` PR that makes `EverestCrystal` GPU-trackable:
  it holds a `RandomRutherford` field and calls `RandomRutherford_generate` in its
  nuclear-interaction path, so it cannot instantiate on CUDA without this change.
