### PR TITLE
Fix bug in get_total_knl_ksl on CuPy

### DIFF
--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -373,12 +373,14 @@ class _HasKnlKsl:
 
         knl = np.zeros(nn, dtype=np.float64)
         ksl = np.zeros(nn, dtype=np.float64)
-        knl[: len(self.knl)] += self.knl
-        ksl[: len(self.ksl)] += self.ksl
+        knl[: len(self.knl)] += self._context.nparray_from_context_array(self.knl)
+        ksl[: len(self.ksl)] += self._context.nparray_from_context_array(self.ksl)
 
         if 'knl_rel' in self._xo_fnames:
-            knl[: len(self.knl_rel)] += self.main_strength * self.knl_rel
-            ksl[: len(self.ksl_rel)] += self.main_strength * self.ksl_rel
+            knl[: len(self.knl_rel)] += self._context.nparray_from_context_array(
+                self.main_strength * self.knl_rel)
+            ksl[: len(self.ksl_rel)] += self._context.nparray_from_context_array(
+                self.main_strength * self.ksl_rel)
 
         if 'k0' in self._xo_fnames:
             if hasattr(self, '_k0'): # To bypass k0 = from_angle


### PR DESCRIPTION
## Description

Fix a bug that made `get_total_knl_ksl` incompatible with CUDA.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
