### PR TITLE
Enable prebuilding kernels on OpenMP

### DIFF
--- a/tests/test_prebuild_kernels.py
+++ b/tests/test_prebuild_kernels.py
@@ -2,6 +2,7 @@
 # This file is part of the Xtrack Package.    #
 # Copyright (c) CERN, 2024.                   #
 # ########################################### #
+import json
 import os
 
 import cffi
@@ -92,15 +93,15 @@ def test_prebuild_kernels(mocker, tmp_path, temp_context_default_func, capsys, w
     regenerate_kernels(kernels=['111_test_module', '000_test_module'], location=tmp_path)
 
     # Check if the expected files were created
-    so_file0, = tmp_path.glob('000_test_module.*.so')
+    so_file0, = tmp_path.glob('000_test_module_cpu_serial.*.so')
     assert so_file0.exists()
-    assert (tmp_path / '000_test_module.c').exists()
-    assert (tmp_path / '000_test_module.json').exists()
+    assert (tmp_path / '000_test_module_cpu_serial.c').exists()
+    assert (tmp_path / '000_test_module_cpu_serial.json').exists()
 
-    so_file1, = tmp_path.glob('111_test_module.*.so')
+    so_file1, = tmp_path.glob('111_test_module_cpu_serial.*.so')
     assert so_file1.exists()
-    assert (tmp_path / '111_test_module.c').exists()
-    assert (tmp_path / '111_test_module.json').exists()
+    assert (tmp_path / '111_test_module_cpu_serial.c').exists()
+    assert (tmp_path / '111_test_module_cpu_serial.json').exists()
 
     # Test that reloading the kernel works, and it's the right one
     cffi_compile = mocker.patch.object(cffi.FFI, 'compile')
@@ -118,7 +119,7 @@ def test_prebuild_kernels(mocker, tmp_path, temp_context_default_func, capsys, w
     cffi_compile.assert_not_called()
 
     captured = capsys.readouterr()
-    assert 'Found suitable prebuilt kernel `111_test_module`' in captured.out
+    assert 'Found suitable prebuilt kernel `111_test_module_cpu_serial`' in captured.out
 
 def test_per_element_prebuild_kernels(mocker, tmp_path, temp_context_default_func):
 
@@ -175,15 +176,15 @@ def test_per_element_prebuild_kernels(mocker, tmp_path, temp_context_default_fun
     # Check if the expected files were created
     so_file_exists = False
     for path in tmp_path.iterdir():
-        if not path.name.startswith('test_module.'):
+        if not path.name.startswith('test_module_cpu_serial.'):
             continue
         if path.suffix not in ('.so', '.dll', '.dylib', '.pyd'):
             continue
         so_file_exists = True
     assert so_file_exists
 
-    assert (tmp_path / 'test_module.c').exists()
-    assert (tmp_path / 'test_module.json').exists()
+    assert (tmp_path / 'test_module_cpu_serial.c').exists()
+    assert (tmp_path / 'test_module_cpu_serial.json').exists()
 
     # Test that reloading the kernel works
     cffi_compile = mocker.patch.object(cffi.FFI, 'compile')
@@ -202,3 +203,83 @@ def test_per_element_prebuild_kernels(mocker, tmp_path, temp_context_default_fun
     assert len(samples) == n_samples
 
     cffi_compile.assert_not_called()
+
+
+def test_context_specific_prebuilt_kernel_selection(mocker, tmp_path):
+
+    kernel_defs = [
+        ('test_module', {'config': {}, 'classes': [xt.Drift], 'extra_classes': [xt.Particles]}),
+    ]
+    drift_tracker_class = xt.Drift._XoStruct
+    name_class_map = {
+        drift_tracker_class._DressingClass.__name__: drift_tracker_class,
+        xt.Particles.__name__: xt.Particles,
+    }
+
+    mocker.patch('xsuite.kernel_definitions.kernel_definitions', kernel_defs)
+    mocker.patch('xsuite.prebuild_kernels.kernel_definitions', kernel_defs)
+    mocker.patch('xsuite.kernel_definitions.NAME_CLASS_MAP', name_class_map)
+    mocker.patch('xsuite.prebuild_kernels.NAME_CLASS_MAP', name_class_map)
+    mocker.patch('xsuite.prebuild_kernels.XSK_PREBUILT_KERNELS_LOCATION', tmp_path)
+    mocker.patch('xsuite.XSK_PREBUILT_KERNELS_LOCATION', tmp_path)
+
+    versions = {
+        'xtrack': xt.__version__,
+        'xfields': __import__('xfields').__version__,
+        'xcoll': __import__('xcoll').__version__,
+        'xobjects': xo.__version__,
+    }
+    metadata_template = {
+        'base_module_name': 'test_module',
+        'config': {},
+        'tracker_element_classes': [drift_tracker_class._DressingClass.__name__],
+        'classes': ['Particles'],
+        'versions': versions,
+    }
+
+    with (tmp_path / 'test_module_cpu_serial.json').open('w') as fd:
+        json.dump({**metadata_template, 'context': 'serial'}, fd)
+    with (tmp_path / 'test_module_cpu_openmp.json').open('w') as fd:
+        json.dump({**metadata_template, 'context': 'omp'}, fd)
+
+    from xsuite.prebuild_kernels import get_suitable_kernel
+
+    serial_info = get_suitable_kernel(
+        config={},
+        tracker_element_classes=[drift_tracker_class],
+        classes=[xt.Particles],
+        context=xo.ContextCpu(),
+    )
+    omp_info = get_suitable_kernel(
+        config={},
+        tracker_element_classes=[drift_tracker_class],
+        classes=[xt.Particles],
+        context=xo.ContextCpu(omp_num_threads='auto'),
+    )
+
+    assert serial_info['module_name'] == 'test_module_cpu_serial'
+    assert omp_info['module_name'] == 'test_module_cpu_openmp'
+
+
+def test_clear_kernels_preserves_other_context(tmp_path):
+
+    for filename in (
+        'test_module_cpu_serial.json',
+        'test_module_cpu_serial.c',
+        'test_module_cpu_serial.cpython-311-darwin.so',
+        'test_module_cpu_openmp.json',
+        'test_module_cpu_openmp.c',
+        'test_module_cpu_openmp.cpython-311-darwin.so',
+    ):
+        (tmp_path / filename).write_text('')
+
+    from xsuite.prebuild_kernels import clear_kernels
+
+    clear_kernels(location=tmp_path, context='omp')
+
+    assert (tmp_path / 'test_module_cpu_serial.json').exists()
+    assert (tmp_path / 'test_module_cpu_serial.c').exists()
+    assert (tmp_path / 'test_module_cpu_serial.cpython-311-darwin.so').exists()
+    assert not (tmp_path / 'test_module_cpu_openmp.json').exists()
+    assert not (tmp_path / 'test_module_cpu_openmp.c').exists()
+    assert not (tmp_path / 'test_module_cpu_openmp.cpython-311-darwin.so').exists()

--- a/xtrack/tracker.py
+++ b/xtrack/tracker.py
@@ -462,6 +462,7 @@ class Tracker:
                     config=self.config,
                     tracker_element_classes=self.line_element_classes,
                     classes=extra_classes,
+                    context=self._context,
                 )
 
             if kernel_info:
@@ -1557,6 +1558,7 @@ class Tracker:
             config=self.line.config,
             tracker_element_classes=self.line_element_classes,
             classes=[],
+            context=self._context,
             verbose=True
         )
 


### PR DESCRIPTION
## Description

Changes in Xtrack related to being able to prebuild OpenMP kernels.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
