### PR TITLE
Remove compilation warnings

### DIFF
--- a/xtrack/aperture/headers/cross_sections.h
+++ b/xtrack/aperture/headers/cross_sections.h
@@ -96,7 +96,6 @@ void build_profile_polygons(
 {
     const uint32_t num_profiles = ProfilePolygons_get_count(profile_polygons);
     const uint32_t num_cross_sections = ApertureBounds_get_count(aperture_bounds);
-    const uint32_t num_survey_entries = SurveyData_len_s(survey);
 
     /* First generate polygons for profiles */
     for (uint32_t idx = 0; idx < num_profiles; idx++)

--- a/xtrack/aperture/headers/segment3d.h
+++ b/xtrack/aperture/headers/segment3d.h
@@ -48,24 +48,25 @@ float_type segment_get_length(LineSegment3D segment) {
 }
 
 
-float_type segment3d_get_length(Segment3D segment) {
+static inline float_type segment3d_get_length(Segment3D segment) {
     switch (segment.type) {
         case SEGMENT3D_LINE:
             return segment_get_length(segment.line);
         case SEGMENT3D_ARC:
             return segment.arc.length;
     }
+    return NAN;
 }
 
 
-inline Point3D line_segment_point_at(const LineSegment3D segment, const float_type frac_length)
+static inline Point3D line_segment_point_at(const LineSegment3D segment, const float_type frac_length)
 {
     const Point3D direction = point3d_sub(segment.end, segment.start);
     return point3d_add_scaled(segment.start, direction, frac_length);
 }
 
 
-inline Point3D arc_segment_point_at(const ArcSegment3D segment, const float_type frac_length)
+static inline Point3D arc_segment_point_at(const ArcSegment3D segment, const float_type frac_length)
 {
     const float_type length = frac_length * segment.length;
     const float_type curvature = segment.curvature;
@@ -93,7 +94,7 @@ inline Point3D arc_segment_point_at(const ArcSegment3D segment, const float_type
 }
 
 
-inline Point3D segment_point_at(const Segment3D segment, const float_type frac_length)
+static inline Point3D segment_point_at(const Segment3D segment, const float_type frac_length)
 {
     switch (segment.type) {
         case SEGMENT3D_LINE:
@@ -104,7 +105,7 @@ inline Point3D segment_point_at(const Segment3D segment, const float_type frac_l
 }
 
 
-inline Point3D plane_initial_point(const Pose plane)
+static inline Point3D plane_initial_point(const Pose plane)
 /*
     Given a pose defining a plane (z = 0 in the local `plane` frame), return
     its initial point.
@@ -118,7 +119,7 @@ inline Point3D plane_initial_point(const Pose plane)
 }
 
 
-inline Point3D plane_normal_vector(const Pose plane)
+static inline Point3D plane_normal_vector(const Pose plane)
 /*
     Given a pose defining a plane (z = 0 in the local `plane` frame), return
     its normal point.
@@ -363,7 +364,7 @@ float_type arc_segment_plane_intersect(
 }
 
 
-inline float_type segment3d_plane_intersect(const Segment3D segment, const Point3D plane_point, const Point3D normal)
+static inline float_type segment3d_plane_intersect(const Segment3D segment, const Point3D plane_point, const Point3D normal)
 /*
     Given a `segment` (line or arc) and a plane defined with a point and a normal, get a parameter `t` along
     the length of the `segment` at which the plane intersects the segment. If `t` is not in [0, 1] the plane
@@ -376,10 +377,11 @@ inline float_type segment3d_plane_intersect(const Segment3D segment, const Point
         case SEGMENT3D_ARC:
             return arc_segment_plane_intersect(segment.arc, plane_point, normal);
     }
+    return NAN;
 }
 
 
-inline float_type closest_t_on_line_segment(const Point3D p, const LineSegment3D segment)
+static inline float_type closest_t_on_line_segment(const Point3D p, const LineSegment3D segment)
 /*
     Closest point parameter `t` on segment [a,b] to point p. Parameter `t` is unconstrained,
     if the point strictly on the segment is needed, clamp to [0, 1].
@@ -399,7 +401,7 @@ inline float_type closest_t_on_line_segment(const Point3D p, const LineSegment3D
 }
 
 
-inline float_type closest_t_on_arc_segment(const Point3D p, const ArcSegment3D segment)
+static inline float_type closest_t_on_arc_segment(const Point3D p, const ArcSegment3D segment)
 /*
     Closest point parameter t on an ArcSegment3D to point p.
 
@@ -450,7 +452,7 @@ inline float_type closest_t_on_arc_segment(const Point3D p, const ArcSegment3D s
 }
 
 
-inline float_type closest_t_on_segment(const Point3D p, const Segment3D segment)
+static inline float_type closest_t_on_segment(const Point3D p, const Segment3D segment)
 /*
     Get parameter `t` of the point along the `segment` closest to `p`.
 */
@@ -461,6 +463,7 @@ inline float_type closest_t_on_segment(const Point3D p, const Segment3D segment)
         case SEGMENT3D_ARC:
             return closest_t_on_arc_segment(p, segment.arc);
     }
+    return NAN;
 }
 
 #endif  /* XT_APERTURE_SEGMENT3D_H */

--- a/xtrack/aperture/headers/survey_tools.h
+++ b/xtrack/aperture/headers/survey_tools.h
@@ -14,7 +14,7 @@ typedef struct {
 } SurveyEntry_s;
 
 
-inline float_type get_survey_max_s(const SurveyData survey)
+static inline float_type get_survey_max_s(const SurveyData survey)
 /* Get the max s of the survey. */
 {
     // Rely on the fact that the last element is `_end_point` (length = 0).
@@ -24,7 +24,7 @@ inline float_type get_survey_max_s(const SurveyData survey)
 }
 
 
-inline Pose pose_matrix_from_survey(const SurveyData survey, const uint32_t idx) {
+static inline Pose pose_matrix_from_survey(const SurveyData survey, const uint32_t idx) {
     Pose m;
     for (int i = 0; i < 4; i++) {
         for (int j = 0; j < 4; j++) {
@@ -35,7 +35,7 @@ inline Pose pose_matrix_from_survey(const SurveyData survey, const uint32_t idx)
 }
 
 
-inline Point3D survey_point(SurveyData survey, uint32_t idx) {
+static inline Point3D survey_point(SurveyData survey, uint32_t idx) {
     Pose pose = pose_matrix_from_survey(survey, idx);
     return (Point3D) {
         .x = pose.mat[0][3],
@@ -45,7 +45,7 @@ inline Point3D survey_point(SurveyData survey, uint32_t idx) {
 }
 
 
-inline LineSegment3D survey_line_segment(SurveyData survey, uint32_t idx) {
+static inline LineSegment3D survey_line_segment(SurveyData survey, uint32_t idx) {
     const Point3D entry = survey_point(survey, idx);
     const Point3D exit = survey_point(survey, idx + 1);
     return (LineSegment3D) {
@@ -55,7 +55,7 @@ inline LineSegment3D survey_line_segment(SurveyData survey, uint32_t idx) {
 }
 
 
-inline ArcSegment3D survey_arc_segment(SurveyData survey, uint32_t idx) {
+static inline ArcSegment3D survey_arc_segment(SurveyData survey, uint32_t idx) {
     const Pose start = pose_matrix_from_survey(survey, idx);
     const float_type length = SurveyData_get_length(survey, idx);
     const float_type angle = SurveyData_get_angle(survey, idx);
@@ -70,7 +70,7 @@ inline ArcSegment3D survey_arc_segment(SurveyData survey, uint32_t idx) {
 }
 
 
-inline Segment3D survey_segment(SurveyData survey, uint32_t idx) {
+static inline Segment3D survey_segment(SurveyData survey, uint32_t idx) {
     const float_type angle = SurveyData_get_angle(survey, idx);
     const float_type length = SurveyData_get_length(survey, idx);
 

--- a/xtrack/beam_elements/elements_src/drift_slice_rbend.h
+++ b/xtrack/beam_elements/elements_src/drift_slice_rbend.h
@@ -22,7 +22,6 @@
 
             double weight = DriftSliceRBendData_get_weight(el);
             int64_t rbend_model = DriftSliceRBendData_get__parent_rbend_model(el);
-            double full_length;
             double length_drift;
             double ds_corr = 0;
             double full_length_curved = DriftSliceRBendData_get__parent_length(el);


### PR DESCRIPTION
## Description

Remove quite some compile warnings from Xtrack.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
