### PR TITLE
Investigate spin tune discrepancy

### DIFF
--- a/examples/spin/005_rbend_check_spin.py
+++ b/examples/spin/005_rbend_check_spin.py
@@ -1,0 +1,12 @@
+import xtrack as xt
+import numpy as np
+env = xt.Environment()
+env.new('rb', 'RBend', length_straight=2., angle=0.1)
+
+line = env.new_line(components=['rb'])
+line.set_particle_ref('electron', energy0=5e9)
+line.configure_bend_model(edge='full')
+
+two = line.twiss4d(betx=1, bety=1, spin=True, spin_x=1)
+
+spin_angle = np.atan2(two.spin_z, two.spin_x)/(2*np.pi)

--- a/examples/spin/005_rbend_check_spin.py
+++ b/examples/spin/005_rbend_check_spin.py
@@ -1,15 +1,24 @@
 import xtrack as xt
+import xobjects as xo
 import numpy as np
+
 env = xt.Environment()
-env.new('rb', 'RBend', length_straight=2., angle=0.1)
+
+angle = 0.1
+env.new('rb', 'RBend', length_straight=2., angle=0.1,
+        edge_entry_model='full', edge_exit_model='full',
+        rbend_model='curved-body')
 
 anomalous_magnetic_moment = 1.15965218091e-3
 
 line = env.new_line(components=['rb'])
 line.set_particle_ref('electron', energy0=5e9,
                       anomalous_magnetic_moment=anomalous_magnetic_moment)
-line.configure_bend_model(edge='full')
+
 
 two = line.twiss4d(betx=1, bety=1, spin=True, spin_x=1)
 
-spin_angle = np.atan2(two.spin_z, two.spin_x)/(2*np.pi)
+spin_angle = np.atan2(two.spin_z, two.spin_x)
+expected_spin_angle = anomalous_magnetic_moment * line.particle_ref.gamma0[0] * angle
+
+xo.assert_allclose(spin_angle[-1], expected_spin_angle, rtol=1e-8)

--- a/examples/spin/005_rbend_check_spin.py
+++ b/examples/spin/005_rbend_check_spin.py
@@ -3,8 +3,11 @@ import numpy as np
 env = xt.Environment()
 env.new('rb', 'RBend', length_straight=2., angle=0.1)
 
+anomalous_magnetic_moment = 1.15965218091e-3
+
 line = env.new_line(components=['rb'])
-line.set_particle_ref('electron', energy0=5e9)
+line.set_particle_ref('electron', energy0=5e9,
+                      anomalous_magnetic_moment=anomalous_magnetic_moment)
 line.configure_bend_model(edge='full')
 
 two = line.twiss4d(betx=1, bety=1, spin=True, spin_x=1)

--- a/tests/test_spin.py
+++ b/tests/test_spin.py
@@ -339,6 +339,33 @@ def test_bend(case, atol):
     xo.assert_allclose(p.spin_z[0], ref['spin_z'], atol=atol, rtol=0)
 
 
+@pytest.mark.parametrize(
+    'edge_model', ['suppressed', 'linear', 'full', 'dipole-only'])
+@pytest.mark.parametrize(
+    'rbend_model', ['adaptive', 'curved-body', 'straight-body'])
+def test_spin_rbend_and_edge_models(edge_model, rbend_model):
+    env = xt.Environment()
+
+    angle = 0.1
+    env.new('rb', 'RBend', length_straight=2., angle=angle,
+            edge_entry_model=edge_model, edge_exit_model=edge_model,
+            rbend_model=rbend_model)
+
+    anomalous_magnetic_moment = 1.15965218091e-3
+
+    line = env.new_line(components=['rb'])
+    line.set_particle_ref('electron', energy0=5e9,
+                          anomalous_magnetic_moment=anomalous_magnetic_moment)
+
+    tw = line.twiss4d(betx=1, bety=1, spin=True, spin_x=1)
+
+    spin_angle = np.atan2(tw.spin_z, tw.spin_x)
+    expected_spin_angle = (
+        anomalous_magnetic_moment * line.particle_ref.gamma0[0] * angle)
+
+    xo.assert_allclose(spin_angle[-1], expected_spin_angle, rtol=1e-8)
+
+
 @pytest.mark.parametrize('h', [0.0, 0.1], ids=['straight', 'polar'])
 def test_spin_drift(h):
     bend = xt.Bend(

--- a/xtrack/beam_elements/elements_src/track_wedge.h
+++ b/xtrack/beam_elements/elements_src/track_wedge.h
@@ -55,6 +55,22 @@ void Wedge_single_particle(
     LocalParticle_add_to_y(part, delta_y);
     LocalParticle_set_px(part, new_px);
     LocalParticle_add_to_zeta(part, -delta_ell / rvv);
+
+    // For spin we impplement the effect of the reference frame rotation,
+    // but we do not yet implement the effect of the magnetic field on the spin.
+    #ifndef XTRACK_MULTIPOLE_NO_SYNRAD // Spin tracking is disabled by the synrad compile flag
+        double const sin_angle = -sin(theta);
+        double const cos_angle = cos(theta);
+        /* Rotate spin */
+        double const spin_x_0 = LocalParticle_get_spin_x(part);
+        double const spin_z_0 = LocalParticle_get_spin_z(part);
+        if ((spin_x_0 != 0) || (spin_z_0 != 0)){
+            double const spin_x_1 = cos_angle*spin_x_0 - sin_angle*spin_z_0;
+            double const spin_z_1 = sin_angle*spin_x_0 + cos_angle*spin_z_0;
+            LocalParticle_set_spin_x(part, spin_x_1);
+            LocalParticle_set_spin_z(part, spin_z_1);
+        }
+    #endif
 }
 
 GPUFUN

--- a/xtrack/beam_elements/elements_src/track_wedge.h
+++ b/xtrack/beam_elements/elements_src/track_wedge.h
@@ -56,7 +56,7 @@ void Wedge_single_particle(
     LocalParticle_set_px(part, new_px);
     LocalParticle_add_to_zeta(part, -delta_ell / rvv);
 
-    // For spin we impplement the effect of the reference frame rotation,
+    // For spin we implement the effect of the reference frame rotation,
     // but we do not yet implement the effect of the magnetic field on the spin.
     #ifndef XTRACK_MULTIPOLE_NO_SYNRAD // Spin tracking is disabled by the synrad compile flag
         double const sin_angle = -sin(theta);


### PR DESCRIPTION
**Change:**
 - Fix spin tracking inconsistency dipole edge (spin rotation applied in rotation map but not in wedge map). As before no spin precession from the edge fields is applied. 