### PR TITLE
Release/0.107.9

### DIFF
--- a/examples/aperture_model/SPS_LDB/.gitignore
+++ b/examples/aperture_model/SPS_LDB/.gitignore
@@ -1,4 +1,5 @@
 SPS.pickle
 sps.json
 sps_aperture.json
+sps_env.json
 *.csv

--- a/examples/aperture_model/SPS_LDB/001_build_model.py
+++ b/examples/aperture_model/SPS_LDB/001_build_model.py
@@ -1,4 +1,5 @@
 import csv
+import re
 from itertools import repeat
 from typing import Literal
 
@@ -22,8 +23,7 @@ class LDBConverterWarning(UserWarning):
     pass
 
 
-PIPE_OVERLAP_TOL = 1e-3
-PIPE_OVERLAP_ASSEMBLY_FILTER: Literal['none', 'top', 'sub'] = 'top'
+PIPE_OVERLAP_TOL = 3.1e-2
 
 context = xo.ContextCpu(omp_num_threads='auto')
 
@@ -32,53 +32,6 @@ def _format_list(lst):
     if len(lst) < 3:
         return ", ".join(lst)
     return ", ".join(lst[:3]) + ", ..."
-
-
-def _pipe_position_ancestors(transformations, name):
-    ancestors = []
-    seen = {name}
-    current = name
-
-    while current in transformations:
-        parent = transformations[current].ref
-        if parent in seen:
-            break
-        if parent not in transformations:
-            break
-
-        ancestors.append(parent)
-        seen.add(parent)
-        current = parent
-
-    return ancestors
-
-
-def _pipe_positions_excluded_by_assembly_filter(pipe_position_names, transformations, assembly_filter):
-    if assembly_filter == 'none':
-        return set()
-    if assembly_filter not in {'top', 'sub'}:
-        raise ValueError(
-            f'Unknown pipe assembly overlap filter {assembly_filter!r}; expected one of '
-            f"'none', 'top', or 'sub'."
-        )
-
-    placed_names = set(pipe_position_names)
-    top_assemblies = set()
-    subassemblies = set()
-
-    for name in placed_names:
-        placed_ancestors = [
-            ancestor for ancestor in _pipe_position_ancestors(transformations, name)
-            if ancestor in placed_names
-        ]
-        if placed_ancestors:
-            subassemblies.add(name)
-            top_assemblies.update(placed_ancestors)
-
-    if assembly_filter == 'top':
-        return subassemblies
-    return top_assemblies
-
 
 def _write_pipe_overlap_report(pipe_table, line_length, filename, s_tol=1e-6, excluded_pipe_positions=()):
     intervals = []
@@ -210,13 +163,19 @@ LONGITUDINAL_PLACEMENT_PATCHES = {}
 
 TYPE_APERTURE_PLACEMENT_PATCHES = {}
 
+IGNORED_TRANSFORMS = re.compile(
+    r'^(MB|QF|QD|LS|LO|AC|MD|TCE|MP|QM|BPV\.33108|BTVE\.61798|AEPA\.33404|AERB\.31302|BCTDC\.41435|BPMBV\.51303'
+    r'|BTVE\.61831|BTVE\.61876|BPCN\.20902|VVGST\.61737|VCTSC\.61752|VVGST\.61752|VTTE\.62005|BGIHA\.51634'
+    r'|BGIVA\.51674)')
+
 ldb_model = layout.Machine.from_pickle("SPS.pickle")
 
 # Load the SPS with its nominal curved survey
 sps = xt.load('sps.json')
 
 # Check that they can twiss
-sps.twiss4d()
+sps.twiss_default['method'] = '4d'
+sps.twiss()
 
 sv = sps.survey()
 
@@ -330,32 +289,10 @@ for transform_name, transformation in ldb_model.transformations.items():
 
 pipes_loc = sorted(pipes_loc.items(), key=lambda x: x[1].z)
 
-# excluded_pipe_positions = _pipe_positions_excluded_by_assembly_filter(
-#     [transform_name for transform_name, _ in pipes_loc],
-#     ldb_model.transformations,
-#     PIPE_OVERLAP_ASSEMBLY_FILTER,
-# )
-#
-# if excluded_pipe_positions:
-#     pipes_loc = [
-#         (transform_name, loc)
-#         for transform_name, loc in pipes_loc
-#         if transform_name not in excluded_pipe_positions
-#     ]
-#     for transform_name in excluded_pipe_positions:
-#         pipes_loc_middles.pop(transform_name, None)
-
-
 if ignored_transforms:
     warn(f'Ignored {len(ignored_transforms)} transforms without target types, whose target types are not valid '
          f'apertures, or which were excluded purposefully due to data errors: {_format_list(ignored_transforms)}',
          LDBConverterWarning)
-# if excluded_pipe_positions:
-#     warn(
-#         f'Excluded {len(excluded_pipe_positions)} pipe positions using assembly filter '
-#         f'{PIPE_OVERLAP_ASSEMBLY_FILTER!r}: {_format_list(sorted(excluded_pipe_positions))}',
-#         LDBConverterWarning,
-#     )
 
 
 # Refer pipe locations to survey elements
@@ -380,8 +317,8 @@ s_center_by_name = dict(zip(line_table.name, line_table.s_center))
 
 # Place pipes in the model
 for transform_name, mad_point in pipes_loc:
-    # if transform_name in excluded_pipe_positions:
-    #     continue
+    if re.match(IGNORED_TRANSFORMS, transform_name):
+        continue
 
     type_name = ldb_model.transformations[transform_name].target_type
     pipe_to_place = type_name
@@ -417,16 +354,8 @@ for transform_name, mad_point in pipes_loc:
     if pipe_to_place:
         builder.place_pipe(transform_name, pipe_to_place, transformation=from_ref_to_here, at=at)
 
-# Clip the pipe that crosses the ring boundary. This avoids placing the single-turn model
-# past _end_point until the aperture model supports wrapped pipe spans.
-# last_profile_hcvc1ib = builder._pipes['HCVC1IB'].positions[1]
-# old_hcvc1ib_last_shift_s = last_profile_hcvc1ib.shift_s
-# vc1ib_1l1_start = dict(pipes_loc)['VC1IB.1L1.X'].z
-# boundary_margin = 0.001
-# last_profile_hcvc1ib.shift_s = min(old_hcvc1ib_last_shift_s, b1.get_length() - vc1ib_1l1_start - boundary_margin)
-
 aperture_model = builder.build(context=context)
-aperture = Aperture(model=aperture_model, line=sps, s_tol=PIPE_OVERLAP_TOL, context=context, _skip_validity_check=True)
+aperture = Aperture(model=aperture_model, line=sps, s_tol=PIPE_OVERLAP_TOL, context=context)
 
 p_tab = aperture.get_pipe_table()
 pipe_overlap_rows = _write_pipe_overlap_report(
@@ -451,3 +380,8 @@ plt.plot(sv.Z, sv.X, color='blue', marker='o', linestyle='none')
 aperture.plot_floor_projection(ax=ax, aspect='equal')
 plt.title('SPS Aperture and Survey Floor Plot')
 plt.show()
+
+aperture.plot_extents(s_positions=aperture.s_around_transitions(resolution=0.1))
+plt.show()
+
+aperture.to_json('sps_aperture.json')

--- a/examples/aperture_model/SPS_LDB/002_put_limits.py
+++ b/examples/aperture_model/SPS_LDB/002_put_limits.py
@@ -1,0 +1,59 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import xtrack as xt
+
+S_TOL = 3.1e-2
+
+sps = xt.load('sps.json')
+sps.twiss_default['method'] = '4d'
+env = sps.env
+
+aperture = xt.Aperture.from_json('sps_aperture.json', line=sps, s_tol=S_TOL)
+
+sps_thin = sps.copy(shallow=True)
+sps_thin.slice_thick_elements(
+    slicing_strategies=[
+        xt.Strategy(slicing=xt.Teapot(1)),
+        xt.Strategy(element_type=xt.Quadrupole, slicing=xt.Teapot(4)),
+        xt.Strategy(element_type=xt.RBend, slicing=xt.Teapot(2)),
+    ]
+)
+tt = sps_thin.get_table()
+
+s_positions = aperture.s_around_transitions()
+limits_transitions = aperture.get_limit_elements(s_positions)
+insertions_transitions = []
+
+for ii, (s, limit) in enumerate(limits_transitions.items()):
+    name = f'aperture_{ii}'
+    env.elements[name] = limit
+    insertions_transitions.append(env.place(name=name, at=s))
+
+tt_active = tt.rows.match_not(element_type='Drift.*|Limit.*|Marker|')
+limits_up_downstream_active = aperture.get_limit_elements(np.unique(np.concatenate([tt_active.s_start, tt_active.s_end])))
+insertions_up_downstream = []
+
+for row in tt_active.rows:
+    name_upstream = f'aperture_start_{row.name}'
+    assert name_upstream not in env.elements
+    env.elements[name_upstream] = limits_up_downstream_active[row.s_start]
+
+    name_downstream = f'aperture_end_{row.name}'
+    assert name_downstream not in env.elements
+    env.elements[name_downstream] = limits_up_downstream_active[row.s_end]
+
+    insertions_up_downstream.append(env.place(name=name_upstream, at=0, from_=row.name, from_anchor='start'))
+    insertions_up_downstream.append(env.place(name=name_downstream, at=0, from_=row.name, from_anchor='end'))
+
+sps_with_limits = sps_thin.copy(shallow=True)
+sps_with_limits.insert(insertions_up_downstream)
+sps_with_limits.insert(insertions_transitions)
+
+
+aperture_from_limits = xt.Aperture.from_line_with_limits(sps_with_limits)
+aperture_from_limits.plot_extents(aperture_from_limits.s_around_transitions(resolution=10), include_aper_tols=True)
+plt.show()
+
+env.lines['sps_thin'] = sps_thin
+env.lines['sps_with_limits'] = sps_with_limits
+env.to_json('sps_env.json')

--- a/examples/aperture_model/SPS_LDB/003_compare_full_limits.py
+++ b/examples/aperture_model/SPS_LDB/003_compare_full_limits.py
@@ -1,0 +1,41 @@
+import matplotlib.pyplot as plt
+import xtrack as xt
+
+S_TOL = 3.1e-2
+
+sps = xt.load('sps.json')
+env = xt.load('sps_env.json')
+sps_with_limits = env.lines['sps_with_limits']
+
+aperture = xt.Aperture.from_json(
+    'sps_aperture.json',
+    line=sps,
+    s_tol=S_TOL,
+    _skip_validity_check=True,
+)
+
+aperture_from_limits = xt.Aperture.from_line_with_limits(sps_with_limits, s_tol=S_TOL)
+
+s_positions = aperture.s_around_transitions(resolution=0.1)
+sections_original = aperture.cross_sections_at_s(s_positions, extents=True, polygons=False)
+sections_recovered = aperture_from_limits.cross_sections_at_s(s_positions, extents=True, polygons=False)
+
+fig, (ax_x, ax_y) = plt.subplots(2, 1, sharex=True)
+
+ax_x.plot(s_positions, sections_original.min_x, color='C0', linestyle='-', label='original min')
+ax_x.plot(s_positions, sections_original.max_x, color='C0', linestyle='-', label='original max')
+ax_x.plot(s_positions, sections_recovered.min_x, color='C1', linestyle='--', label='from limits min')
+ax_x.plot(s_positions, sections_recovered.max_x, color='C1', linestyle='--', label='from limits max')
+ax_x.set_ylabel('x [m]')
+ax_x.legend()
+
+ax_y.plot(s_positions, sections_original.min_y, color='C0', linestyle='-', label='original min')
+ax_y.plot(s_positions, sections_original.max_y, color='C0', linestyle='-', label='original max')
+ax_y.plot(s_positions, sections_recovered.min_y, color='C1', linestyle='--', label='from limits min')
+ax_y.plot(s_positions, sections_recovered.max_y, color='C1', linestyle='--', label='from limits max')
+ax_y.set_ylabel('y [m]')
+ax_y.set_xlabel('s [m]')
+ax_y.legend()
+
+fig.suptitle('SPS aperture extents: original model vs recovered from limits')
+plt.show()

--- a/examples/aperture_model/SPS_LDB/004_track.py
+++ b/examples/aperture_model/SPS_LDB/004_track.py
@@ -1,0 +1,65 @@
+from time import perf_counter
+
+import numpy as np
+
+import xpart as xp
+import xtrack as xt
+
+NUM_PART = 10_000
+NUM_TURNS = 10
+NEMITT_SCAN = [2.5e-6, 25e-6, 100e-6, 500e-6]
+
+env = xt.load('sps_env.json')
+sps_thin = env.lines['sps_thin']
+sps_with_limits = env.lines['sps_with_limits']
+
+sps_with_no_inner_circ = sps_with_limits.copy(shallow=True)
+new_names = []
+for name in sps_with_no_inner_circ.element_names:
+    element = env.elements[name]
+    if not isinstance(element, xt.LimitPolygon):
+        new_names.append(name)
+        continue
+
+    sub_name = f'{name}_bis'
+    env.elements[sub_name] = env.elements[name].copy()
+    env.elements[sub_name].inner_radius_sq = 1e-32
+    new_names.append(sub_name)
+
+sps_with_no_inner_circ.element_names = new_names
+
+
+for nemitt in NEMITT_SCAN:
+    print(f'=> Testing nemitt = {nemitt}...')
+    x_norm, px_norm = xp.generate_2D_gaussian(NUM_PART)
+    y_norm, py_norm = xp.generate_2D_gaussian(NUM_PART)
+
+    p0 = sps_thin.build_particles(
+        x_norm=x_norm,
+        px_norm=px_norm,
+        y_norm=y_norm,
+        py_norm=py_norm,
+        nemitt_x=nemitt,
+        nemitt_y=nemitt,
+        zeta=0.0,
+        delta=0.0,
+    )
+
+    p_thin = p0.copy()
+    p_limits = p0.copy()
+    p_ellipses = p0.copy()
+
+    print('Tracking with no limits... ', end='')
+    t0 = perf_counter()
+    sps_thin.track(p_thin, num_turns=NUM_TURNS)
+    print(f'took {perf_counter() - t0:.3f} s')
+
+    print('Tracking with limits... ', end='')
+    t0 = perf_counter()
+    sps_with_limits.track(p_limits, num_turns=NUM_TURNS)
+    print(f'took {perf_counter() - t0:.3f} s, lost {np.sum(p_limits.state < 1)} particles')
+
+    print('Tracking with inner circle disabled... ', end='')
+    t0 = perf_counter()
+    sps_with_no_inner_circ.track(p_ellipses, num_turns=NUM_TURNS)
+    print(f'took {perf_counter() - t0:.3f} s, lost {np.sum(p_ellipses.state < 1)} particles')

--- a/examples/aperture_model/SPS_LDB/004_track.py
+++ b/examples/aperture_model/SPS_LDB/004_track.py
@@ -13,22 +13,6 @@ env = xt.load('sps_env.json')
 sps_thin = env.lines['sps_thin']
 sps_with_limits = env.lines['sps_with_limits']
 
-sps_with_no_inner_circ = sps_with_limits.copy(shallow=True)
-new_names = []
-for name in sps_with_no_inner_circ.element_names:
-    element = env.elements[name]
-    if not isinstance(element, xt.LimitPolygon):
-        new_names.append(name)
-        continue
-
-    sub_name = f'{name}_bis'
-    env.elements[sub_name] = env.elements[name].copy()
-    env.elements[sub_name].inner_radius_sq = 1e-32
-    new_names.append(sub_name)
-
-sps_with_no_inner_circ.element_names = new_names
-
-
 for nemitt in NEMITT_SCAN:
     print(f'=> Testing nemitt = {nemitt}...')
     x_norm, px_norm = xp.generate_2D_gaussian(NUM_PART)
@@ -47,7 +31,6 @@ for nemitt in NEMITT_SCAN:
 
     p_thin = p0.copy()
     p_limits = p0.copy()
-    p_ellipses = p0.copy()
 
     print('Tracking with no limits... ', end='')
     t0 = perf_counter()
@@ -58,8 +41,3 @@ for nemitt in NEMITT_SCAN:
     t0 = perf_counter()
     sps_with_limits.track(p_limits, num_turns=NUM_TURNS)
     print(f'took {perf_counter() - t0:.3f} s, lost {np.sum(p_limits.state < 1)} particles')
-
-    print('Tracking with inner circle disabled... ', end='')
-    t0 = perf_counter()
-    sps_with_no_inner_circ.track(p_ellipses, num_turns=NUM_TURNS)
-    print(f'took {perf_counter() - t0:.3f} s, lost {np.sum(p_ellipses.state < 1)} particles')

--- a/tests/test_aperture_model.py
+++ b/tests/test_aperture_model.py
@@ -482,6 +482,29 @@ def test_from_line_with_limits_type_bounds(test_context):
 
 
 @for_all_test_contexts(excluding=('ContextPyopencl', 'ContextCupy'))
+def test_from_line_with_limits_preserves_limit_polygon_geometry(test_context):
+    x_vertices = np.array([0.03, 0.0, -0.03, 0.0])
+    y_vertices = np.array([0.0, 0.02, 0.0, -0.02])
+    line = xt.Line(
+        elements=[xt.LimitPolygon(x_vertices=x_vertices, y_vertices=y_vertices)],
+        element_names=['aper'],
+    )
+
+    aperture_model = Aperture.from_line_with_limits(
+        line,
+        context=test_context,
+        _skip_validity_check=True,
+    )
+    section = aperture_model.cross_sections_at_s([0.0]).cross_section[0]
+
+    xo.assert_allclose(section[0], [x_vertices[0], y_vertices[0]], atol=1e-15, rtol=0)
+    assert np.min(section[:, 0]) < -0.02
+    assert np.max(section[:, 0]) > 0.02
+    assert np.min(section[:, 1]) < -0.01
+    assert np.max(section[:, 1]) > 0.01
+
+
+@for_all_test_contexts(excluding=('ContextPyopencl', 'ContextCupy'))
 def test_bounds_table_for_perfect_overlap_interval(test_context):
     env = xt.load(string=TOY_RING_SEQUENCE, format='madx', install_limits=False)
     env.set_particle_ref('proton', p0c=1.2e9)

--- a/tests/test_limit_polygon.py
+++ b/tests/test_limit_polygon.py
@@ -19,20 +19,6 @@ def _polygon_centroid(x, y):
     return np.array([cx, cy])
 
 
-def _distance_sq_point_to_segment(point, p0, p1):
-    delta = p1 - p0
-    seg_len_sq = np.dot(delta, delta)
-    if seg_len_sq == 0:
-        diff = point - p0
-        return np.dot(diff, diff)
-
-    t = np.dot(point - p0, delta) / seg_len_sq
-    t = np.clip(t, 0.0, 1.0)
-    projection = p0 + t * delta
-    diff = point - projection
-    return np.dot(diff, diff)
-
-
 def test_limitpolygon_area_signed():
     x_ccw = np.array([-2.0, 2.0, 2.0, -2.0]) * 1e-2
     y_ccw = np.array([-1.0, -1.0, 1.5, 1.5]) * 1e-2
@@ -131,50 +117,6 @@ def test_limitpolygon_impact_point_and_normal():
     assert np.all(i_found >= 0)
 
 
-def test_limitpolygon_inner_radius_is_derived():
-    x_vertices = np.array([2.0, -3.0, 1.5, -1.0]) * 1e-2
-    y_vertices = np.array([1.0, -2.5, 3.0, -1.5]) * 1e-2
-
-    aper = xt.LimitPolygon(
-        x_vertices=x_vertices,
-        y_vertices=y_vertices,
-    )
-
-    x_closed = np.concatenate([x_vertices, x_vertices[:1]])
-    y_closed = np.concatenate([y_vertices, y_vertices[:1]])
-    expected_inner_radius_sq = min(
-        _distance_sq_point_to_segment(
-            np.array([0.0, 0.0]),
-            np.array([x0, y0]),
-            np.array([x1, y1]),
-        )
-        for x0, y0, x1, y1 in zip(
-            x_closed[:-1], y_closed[:-1], x_closed[1:], y_closed[1:]
-        )
-    )
-
-    xo.assert_allclose(
-        aper.inner_radius_sq, expected_inner_radius_sq, atol=1e-15, rtol=0
-    )
-
-    aper_dict = aper.to_dict()
-    assert "inner_radius_sq" not in aper_dict
-
-    aper_roundtrip = xt.LimitPolygon.from_dict(aper_dict)
-    xo.assert_allclose(
-        aper_roundtrip.inner_radius_sq, aper.inner_radius_sq, atol=1e-15, rtol=0
-    )
-
-
-def test_limitpolygon_inner_radius_matches_rectangle():
-    x_vertices = np.array([-2.0, 2.0, 2.0, -2.0]) * 1e-2
-    y_vertices = np.array([-1.5, -1.5, 1.5, 1.5]) * 1e-2
-
-    aper = xt.LimitPolygon(x_vertices=x_vertices, y_vertices=y_vertices)
-
-    xo.assert_allclose(aper.inner_radius_sq, (1.5e-2) ** 2, atol=1e-15, rtol=0)
-
-
 def test_limitpolygon_inner_circle_particles_survive():
     x_vertices = np.array([-2.0, 2.0, 2.0, -2.0]) * 1e-2
     y_vertices = np.array([-1.5, -1.5, 1.5, 1.5]) * 1e-2
@@ -182,7 +124,7 @@ def test_limitpolygon_inner_circle_particles_survive():
     aper = xt.LimitPolygon(x_vertices=x_vertices, y_vertices=y_vertices)
 
     angles = np.linspace(0, 2 * np.pi, 16, endpoint=False)
-    radius = 0.99 * np.sqrt(aper.inner_radius_sq)
+    radius = 0.99 * 1.5e-2
     sample_x = radius * np.cos(angles)
     sample_y = radius * np.sin(angles)
 

--- a/xtrack/aperture/profile_converters.py
+++ b/xtrack/aperture/profile_converters.py
@@ -80,8 +80,8 @@ def _profile_from_limit_racetrack(element: apertures.LimitRacetrack) -> Tuple[Sh
 
 @profile_from_limit_element.register
 def _profile_from_limit_polygon(element: apertures.LimitPolygon) -> Tuple[ShapeTypes, float, float]:
-    xs = element.x_vertices + [element.x_vertices[0]]
-    ys = element.y_vertices + [element.y_vertices[0]]
+    xs = np.asarray(element.x_closed)
+    ys = np.asarray(element.y_closed)
     polygon = Polygon(vertices=np.column_stack([xs, ys]))
     return polygon, 0, 0
 

--- a/xtrack/beam_elements/apertures.py
+++ b/xtrack/beam_elements/apertures.py
@@ -14,30 +14,6 @@ from ..svgutils import svg_to_points
 
 UNLIMITED = 1e10  # could use np.inf but better safe than sorry
 
-def _compute_inner_radius_sq(x_vertices, y_vertices):
-    x0 = x_vertices
-    y0 = y_vertices
-    x1 = np.roll(x_vertices, -1)
-    y1 = np.roll(y_vertices, -1)
-
-    dx = x1 - x0
-    dy = y1 - y0
-    seg_len_sq = dx * dx + dy * dy
-
-    # Project the origin onto every edge at once and clamp to the segment.
-    with np.errstate(divide="ignore", invalid="ignore"):
-        t = -(x0 * dx + y0 * dy) / seg_len_sq
-    t = np.where(seg_len_sq > 0.0, np.clip(t, 0.0, 1.0), 0.0)
-
-    x_proj = x0 + t * dx
-    y_proj = y0 + t * dy
-    distances_sq = x_proj * x_proj + y_proj * y_proj
-
-    if np.any(seg_len_sq == 0.0):
-        distances_sq = np.where(seg_len_sq == 0.0, x0 * x0 + y0 * y0, distances_sq)
-
-    return float(np.min(distances_sq))
-
 
 class LimitRect(BeamElement):
     """
@@ -251,7 +227,6 @@ class LimitPolygon(BeamElement):
         "y_vertices": xo.Float64[:],
         "x_normal": xo.Float64[:],
         "y_normal": xo.Float64[:],
-        "inner_radius_sq": xo.Float64,
         "resc_fac": xo.Float64,
     }
 
@@ -309,17 +284,11 @@ class LimitPolygon(BeamElement):
             if context is not None and isinstance(y_vertices, context.nplike_array_type):
                 y_vertices = context.nparray_from_context_array(y_vertices)
 
-            x_vertices_np = np.asarray(x_vertices, dtype=np.float64)
-            y_vertices_np = np.asarray(y_vertices, dtype=np.float64)
-
             if "x_normal" not in kwargs.keys():
                 kwargs["x_normal"] = len(x_vertices)
 
             if "y_normal" not in kwargs.keys():
                 kwargs["y_normal"] = len(x_vertices)
-
-            if "inner_radius_sq" not in kwargs.keys():
-                kwargs["inner_radius_sq"] = _compute_inner_radius_sq(x_vertices_np, y_vertices_np)
 
             if "resc_fac" not in kwargs.keys():
                 kwargs["resc_fac"] = 1.0
@@ -355,8 +324,6 @@ class LimitPolygon(BeamElement):
 
     def to_dict(self, **kwargs):
         out= super().to_dict(**kwargs)
-        for kk in ("inner_radius_sq",):
-            out.pop(kk, None)
         out["svg"]=self.svg
         return out
 
@@ -366,7 +333,6 @@ class LimitPolygon(BeamElement):
         for kk in (
             "min_x", "max_x", "min_y", "max_y",
             "inner_min_x", "inner_max_x", "inner_min_y", "inner_max_y",
-            "inner_radius_sq",
         ):
             d.pop(kk, None)
         if 'svg' in d.keys() and d['svg'] is not None:

--- a/xtrack/beam_elements/apertures_src/limitpolygon.h
+++ b/xtrack/beam_elements/apertures_src/limitpolygon.h
@@ -20,7 +20,45 @@ void LimitPolygon_track_local_particle(LimitPolygonData el,
     }
 
     int64_t N_edg = LimitPolygonData_len_x_vertices(el);
-    double const inner_radius_sq = LimitPolygonData_get_inner_radius_sq(el);
+
+    // On CPU this will be used to short-circuit a positive check using
+    // an inscribed circle:
+    double inner_radius_sq = 0.0;
+
+    #ifdef XO_CONTEXT_CPU
+        // Compute `inner_radius_sq`
+        for (int64_t ii = 0; ii < N_edg; ii++) {
+            int64_t const jj = (ii + 1) % N_edg;
+            double const x0 = LimitPolygonData_get_x_vertices(el, ii);
+            double const y0 = LimitPolygonData_get_y_vertices(el, ii);
+            double const x1 = LimitPolygonData_get_x_vertices(el, jj);
+            double const y1 = LimitPolygonData_get_y_vertices(el, jj);
+            double const dx = x1 - x0;
+        double const dy = y1 - y0;
+        double const seg_len_sq = dx * dx + dy * dy;
+        double dist_sq;
+
+        // Distance from the origin to this edge segment. Project the origin
+        // onto the edge line, then clamp the projection to the finite segment.
+        if (seg_len_sq > 0.0) {
+            double t = -(x0 * dx + y0 * dy) / seg_len_sq;
+            if (t < 0.0) {
+                    t = 0.0;
+                } else if (t > 1.0) {
+                    t = 1.0;
+                }
+                double const x_proj = x0 + t * dx;
+                double const y_proj = y0 + t * dy;
+                dist_sq = x_proj * x_proj + y_proj * y_proj;
+            } else {
+                dist_sq = x0 * x0 + y0 * y0;
+            }
+
+            if (ii == 0 || dist_sq < inner_radius_sq) {
+                inner_radius_sq = dist_sq;
+            }
+        }
+    #endif
 
     START_PER_PARTICLE_BLOCK(part0, part);
         double const x = LocalParticle_get_x(part);


### PR DESCRIPTION
**Changes:**

- Add a complete example for the SPS aperture model imported from LDB
- Remove the `inner_radius_sq` field from `LimitPolygon` and instead do the calculation in C directly, but only on the CPU contexts (no benefit on GPU)
- Fix bug in the generation in `Aperture.get_limit_elements`.