### PR TITLE
Correct issue in momentum dependence of dipole fringe field

### DIFF
--- a/tests/test_elements_thick.py
+++ b/tests/test_elements_thick.py
@@ -3079,3 +3079,43 @@ def test_api_bend():
     assert bend2.k0 == 0.
     assert bend2.h == 0.1
     assert bend2.k0_from_h == False
+
+
+def test_delta_dipole_fringe():
+    # Test momentum dependence of dipole fringe, as corrected with respect to the PTC implementation
+    
+    dd = np.linspace(-0.05, 0.05, 11)
+    p0 = xt.Particles(y=0.002, delta=dd)
+    p1 = p0.copy()
+
+    def fieldvalue(x,y,z):  
+        # Polynomial dipole fringe field between 0 and 0.05 with max b1=0.1
+        # b1 = -1600 z^3 + 120 z^2 converted to tesla
+        return [0, (-1600*z**3 + 120*z**2 - 120*y**2*(1 - 40*z))* p0.rigidity0[0], (1600*y**3 + y*(-4800*z**2 + 240*z))* p0.rigidity0[0]]
+
+    length = 0.05
+    b1 = 0.1
+    
+    # Backwards drift, fringe, backwards bend
+    drift = xt.Line(elements=[xt.Drift(length=length/2)])
+    bend = xt.Line(elements=[xt.Bend(k0=b1, length=length/2)])
+    exactfringe = xt.BorisSpatialIntegrator(fieldmap_callable=fieldvalue, s_start=0, s_end=length, n_steps=1000)
+
+    drift.track(p0, backtrack=True)
+    exactfringe.track(p0)
+    bend.track(p0, backtrack=True)
+    
+    # Xsuite fringe with same parameters
+    gap = 0.04
+    ss = np.linspace(0,length,100)
+    bvals = -1600 * ss**3 + 120 * ss**2
+    fint = np.trapezoid((b1 - bvals)*bvals / b1**2 / gap, ss)
+    PTCfringe = xt.Bend(length=0, k0=b1, edge_entry_model="full", edge_entry_fint=fint, edge_entry_hgap=gap/2, edge_exit_active=0)
+    
+    PTCfringe.track(p1)
+     
+    deg0 = np.polyfit(p0.delta, p0.py, 1)
+    deg1 = np.polyfit(p1.delta, p1.py, 1)
+    
+    # Slopes should be similar, original implementation had sign difference
+    assert np.isclose(deg0[0]/deg1[0], 1, rtol=1e-2)

--- a/tests/test_elements_thick.py
+++ b/tests/test_elements_thick.py
@@ -3088,14 +3088,14 @@ def test_delta_dipole_fringe():
     p0 = xt.Particles(y=0.002, delta=dd)
     p1 = p0.copy()
 
+    length = 0.05
+    b1 = 0.1
+    
     def fieldvalue(x,y,z):  
         # Polynomial dipole fringe field between 0 and 0.05 with max b1=0.1
         # b1 = -1600 z^3 + 120 z^2 converted to tesla
         return [0, (-1600*z**3 + 120*z**2 - 120*y**2*(1 - 40*z))* p0.rigidity0[0], (1600*y**3 + y*(-4800*z**2 + 240*z))* p0.rigidity0[0]]
 
-    length = 0.05
-    b1 = 0.1
-    
     # Backwards drift, fringe, backwards bend
     drift = xt.Line(elements=[xt.Drift(length=length/2)])
     bend = xt.Line(elements=[xt.Bend(k0=b1, length=length/2)])
@@ -3113,9 +3113,9 @@ def test_delta_dipole_fringe():
     PTCfringe = xt.Bend(length=0, k0=b1, edge_entry_model="full", edge_entry_fint=fint, edge_entry_hgap=gap/2, edge_exit_active=0)
     
     PTCfringe.track(p1)
-     
+    
+    # Slopes of py vs delta should be similar, original implementation had sign difference
     deg0 = np.polyfit(p0.delta, p0.py, 1)
     deg1 = np.polyfit(p1.delta, p1.py, 1)
     
-    # Slopes should be similar, original implementation had sign difference
-    assert np.isclose(deg0[0]/deg1[0], 1, rtol=1e-2)
+    assert np.allclose(deg0/deg1, 1, rtol=1e-2)

--- a/xtrack/beam_elements/elements_src/track_dipole_fringe.h
+++ b/xtrack/beam_elements/elements_src/track_dipole_fringe.h
@@ -11,6 +11,7 @@
 
 // MAD-NG implementation
 // https://github.com/MethodicalAcceleratorDesign/MAD/blob/d3cabd9cdebde62ebedb51bab61ac033b9159489/src/madl_dynmap.mad#L1864
+// Generating function changed to contain 1/pz instead of pz
 
 GPUFUN
 void DipoleFringe_single_particle(
@@ -89,6 +90,7 @@ void DipoleFringe_single_particle(
 #ifdef XTRACK_FRINGE_FROM_PTC
 // The following is ported from PTC:
 //https://github.com/MethodicalAcceleratorDesign/MAD-X/blob/master/libs/ptc/src/Sh_def_kind.f90#L4936
+// Generating function changed to contain 1/pz instead of pz
 
 GPUFUN
 void DipoleFringe_single_particle(
@@ -135,13 +137,13 @@ void DipoleFringe_single_particle(
     const double D_2_3 = -time_fac * yp / (pz * pz);
     const double D_3_3 =  time_fac / pz;
 
-    double fi0 = atan((xp / (1.0 + yp * yp)))-b * fint * hgap * 2.0 * ( 1.0 + xp * xp *(2.0 + yp * yp)) * pz;
+    double fi0 = atan((xp / (1.0 + yp * yp)))-b * fint * hgap * 2.0 * ( 1.0 + xp * xp *(2.0 + yp * yp)) * _pz;
     const double co2 = b / cos(fi0) / cos(fi0);
     const double co1 = co2 / (1.0 + POW2(xp / POW2(1.0 + yp * yp)));
 
-    const double fi_1 = co1 / (1.0 + yp*yp) - co2 * b * fint * hgap * 2.0*(2.0 * xp * (2.0 + yp * yp) * pz);
-    const double fi_2 = -co1 * 2.0 * xp * yp / POW2(1.0 + yp * yp) - co2 * b * fint * hgap * 2.0 * (2.0 * xp* xp * yp) * pz;
-    const double fi_3 = -co2 * b * fint * hgap * 2.0 * (1.0 + xp * xp * (2.0 + yp*yp));
+    const double fi_1 = co1 / (1.0 + yp*yp) - co2 * b * fint * hgap * 2.0*(2.0 * xp * (2.0 + yp * yp) * _pz);
+    const double fi_2 = -co1 * 2.0 * xp * yp / POW2(1.0 + yp * yp) - co2 * b * fint * hgap * 2.0 * (2.0 * xp* xp * yp) * _pz;
+    const double fi_3 = co2 * b * fint * hgap * 2.0 * (1.0 + xp * xp * (2.0 + yp*yp)) * POW2(_pz);
 
     fi0 = b * tan(fi0);
 

--- a/xtrack/beam_elements/elements_src/track_dipole_fringe.h
+++ b/xtrack/beam_elements/elements_src/track_dipole_fringe.h
@@ -137,13 +137,13 @@ void DipoleFringe_single_particle(
     const double D_2_3 = -time_fac * yp / (pz * pz);
     const double D_3_3 =  time_fac / pz;
 
-    double fi0 = atan((xp / (1.0 + yp * yp)))-b * fint * hgap * 2.0 * ( 1.0 + xp * xp *(2.0 + yp * yp)) * _pz;
+    double fi0 = atan((xp / (1.0 + yp * yp)))-b * fint * hgap * 2.0 * ( 1.0 + xp * xp *(2.0 + yp * yp)) / pz;
     const double co2 = b / cos(fi0) / cos(fi0);
     const double co1 = co2 / (1.0 + POW2(xp / POW2(1.0 + yp * yp)));
 
-    const double fi_1 = co1 / (1.0 + yp*yp) - co2 * b * fint * hgap * 2.0*(2.0 * xp * (2.0 + yp * yp) * _pz);
-    const double fi_2 = -co1 * 2.0 * xp * yp / POW2(1.0 + yp * yp) - co2 * b * fint * hgap * 2.0 * (2.0 * xp* xp * yp) * _pz;
-    const double fi_3 = co2 * b * fint * hgap * 2.0 * (1.0 + xp * xp * (2.0 + yp*yp)) * POW2(_pz);
+    const double fi_1 = co1 / (1.0 + yp*yp) - co2 * b * fint * hgap * 2.0*(2.0 * xp * (2.0 + yp * yp) / pz);
+    const double fi_2 = -co1 * 2.0 * xp * yp / POW2(1.0 + yp * yp) - co2 * b * fint * hgap * 2.0 * (2.0 * xp* xp * yp) / pz;
+    const double fi_3 = co2 * b * fint * hgap * 2.0 * (1.0 + xp * xp * (2.0 + yp*yp)) / POW2(pz);
 
     fi0 = b * tan(fi0);
 

--- a/xtrack/beam_elements/elements_src/track_dipole_fringe.h
+++ b/xtrack/beam_elements/elements_src/track_dipole_fringe.h
@@ -57,14 +57,14 @@ void DipoleFringe_single_particle(
     const double xp2 = POW2(xp);
     const double _yp2 = 1./yp2;
 
-    const double fi0 = atan((xp*_yp2)) - c2*(1 + xp2*(1+yp2))*pz;
+    const double fi0 = atan((xp*_yp2)) - c2*(1 + xp2*(1+yp2))*_pz;
     const double co2 = b0/POW2(cos(fi0));
     const double co1 = co2/(1 + POW2(xp*_yp2))*_yp2;
     const double co3 = co2*c2;
 
-    const double fi1 =    co1          - co3*2*xp*(1+yp2)*pz;
-    const double fi2 = -2*co1*xyp*_yp2 - co3*2*xp*xyp    *pz;
-    const double fi3 =                 - co3*(1 + xp2*(1+yp2));
+    const double fi1 =    co1          - co3*2*xp*(1+yp2)*_pz;
+    const double fi2 = -2*co1*xyp*_yp2 - co3*2*xp*xyp    *_pz;
+    const double fi3 =                 + co3*(1 + xp2*(1+yp2))*POW2(_pz);
 
     const double kx = fi1*(1+xp2)*_pz   + fi2*xyp*_pz       - fi3*xp;
     const double ky = fi1*xyp*_pz       + fi2*yp2*_pz       - fi3*yp;


### PR DESCRIPTION
## Description

Corrected the momentum dependence of dipole fringe field map derived in [Fringe Effects in MAD PART I, Second Order Fringe in MAD-X for the Module PTC, E. Forest](https://inspirehep.net/literature/2654316). The generating function in (37) should contain 1/pz in the last term instead of pz to be consistent with (34) in lowest order. Both the MAD-NG and PTC implementations of the map were modified. 

The difference between the old Xsuite fringe and the fringe field in SAD or an exact thin fringe field using a numerical integrator (inverse drift, exact fringe, inverse bend), made by @JPTS2, can be seen below

<img width="234" height="234" alt="image(3)" src="https://github.com/user-attachments/assets/fef5a448-1fb8-483d-8d1d-81a243802996" />
<img width="234" height="162" alt="image(2)" src="https://github.com/user-attachments/assets/bbe1c991-8b51-42b2-8a79-86e9f456a8c0" />

while after the described correction the agreement is much better.

<img width="234" height="234" alt="image" src="https://github.com/user-attachments/assets/62aa0754-02ce-4a7c-8da6-13f8d2b7501e" />
<img width="234" height="162" alt="image(1)" src="https://github.com/user-attachments/assets/c1d37dc7-662f-4139-bf09-182190d92b57" />

I included a test for this momentum dependence using a comparison against a Boris thin fringe. 
The tests have not yet been run.
See https://github.com/xsuite/xsuite/pull/878 for documentation update

## Checklist

Mandatory: 

- [X] I have added tests to cover my changes
- [X] All the [tests](https://github.com/xsuite/xsuite/actions/runs/29558848183/job/87817516133) are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [X] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [X] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
