### PR TITLE
Allow SecondOrderTaylorMap in Environment.new(), and fix expressions in multi-dimensional array fields

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1681,6 +1681,80 @@ def test_env_new_allowed_elements(cls_name):
     assert isinstance(env['e'], cls)
 
 
+def test_env_new_multi_dimensional_arrays():
+    # env.new() must wire expressions nested at any depth. SecondOrderTaylorMap
+    # is used because its k/R/T are 1D/2D/3D array fields.
+    env = xt.Environment()
+    env['a'] = 2.
+
+    k = [0, 0, 0, 0, 0, 0]
+    k[1] = '3*a'
+    env.new('tm_k', xt.SecondOrderTaylorMap, k=k)
+    assert env['tm_k'].k[1] == 6.
+    assert env.ref['tm_k'].k[1].xdeps.expr == "(3.0 * vars['a'])"
+    env['a'] = 5.
+    assert env['tm_k'].k[1] == 15.
+    env['a'] = 2.
+
+    R = np.eye(6).tolist()
+    R[2][3] = '2*a'
+    env.new('tm_R', xt.SecondOrderTaylorMap, R=R)
+    expected_R = np.eye(6)
+    expected_R[2, 3] = 4.
+    xo.assert_allclose(env['tm_R'].R, expected_R, atol=0, rtol=0)
+    assert env.ref['tm_R'].R[2, 3].xdeps.expr == "(2.0 * vars['a'])"
+    env['a'] = 5.
+    assert env['tm_R'].R[2, 3] == 10.
+    env['a'] = 2.
+
+    T = np.zeros((6, 6, 6)).tolist()
+    T[1][2][3] = '4*a'
+    env.new('tm_T', xt.SecondOrderTaylorMap, T=T)
+    expected_T = np.zeros((6, 6, 6))
+    expected_T[1, 2, 3] = 8.
+    xo.assert_allclose(env['tm_T'].T, expected_T, atol=0, rtol=0)
+    assert env.ref['tm_T'].T[1, 2, 3].xdeps.expr == "(4.0 * vars['a'])"
+    env['a'] = 3.
+    assert env['tm_T'].T[1, 2, 3] == 12.
+
+
+def test_env_set_multi_dimensional_arrays():
+    # env.set() must wire a new expression, and clear a stale one when an
+    # expression-bearing cell is overwritten with a plain value.
+    env = xt.Environment()
+    env['a'] = 2.
+    env.new('tm', xt.SecondOrderTaylorMap)
+
+    env.set('tm', k=['3*a', 0, 0, 0, 0, 0])
+    assert env['tm'].k[0] == 6.
+
+    env.set('tm', k=[99, 0, 0, 0, 0, 0])
+    env['a'] = 100.
+    assert env['tm'].k[0] == 99., 'stale expression on k[0] should have been cleared'
+    env['a'] = 2.
+
+    R = np.eye(6).tolist()
+    R[1][4] = '5*a'
+    env.set('tm', R=R)
+    assert env['tm'].R[1, 4] == 10.
+
+    env.set('tm', R=np.eye(6).tolist())
+    env['a'] = 50.
+    assert env['tm'].R[1, 4] == 0., 'stale expression on R[1,4] should have been cleared'
+
+
+def test_env_new_whole_array_reference():
+    # Passing a whole array as a single reference wires each item to the
+    # corresponding item of the referenced array.
+    env = xt.Environment()
+    env.new('src', xt.Quadrupole, knl=[1, 2, 3])
+    env.new('dst', xt.Quadrupole, knl=env.ref['src'].knl)
+
+    assert env['dst'].knl[0] == 1.
+    env.set('src', knl=[9, 9, 9])
+    assert env['dst'].knl[0] == 9.
+
+
 def test_env_new_prototype_keyword_and_deprecated_parent():
 
     env = xt.Environment()

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1743,6 +1743,17 @@ def test_env_set_multi_dimensional_arrays():
     assert env['tm'].R[1, 4] == 0., 'stale expression on R[1,4] should have been cleared'
 
 
+def test_env_new_array_field_errors():
+    # Bad values for an array field must be reported against that field.
+    env = xt.Environment()
+
+    with pytest.raises(TypeError, match='knl should be an iterable'):
+        env.new('q', xt.Quadrupole, length=1, knl=5)
+
+    with pytest.raises(ValueError, match='R must be a rectangular array'):
+        env.new('tm', xt.SecondOrderTaylorMap, R=[[1., 2.], [3.]])
+
+
 def test_env_new_whole_array_reference():
     # Passing a whole array as a single reference wires each item to the
     # corresponding item of the referenced array.

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1663,6 +1663,24 @@ def test_env_new():
     assert env[ret].b == 3
 
 
+@pytest.mark.parametrize('cls_name', sorted(xt.line._ALLOWED_ELEMENT_TYPES_DICT.keys()))
+def test_env_new_allowed_elements(cls_name):
+    # Every class in `_ALLOWED_ELEMENT_TYPES_IN_NEW` must be constructible via `env.new(name, cls)`.
+    # If there are mandatory arguments, they must be special-cased below.
+    cls = xt.line._ALLOWED_ELEMENT_TYPES_DICT[cls_name]
+    env = xt.Environment()
+
+    if cls_name == 'Replica':
+        env.new('base', xt.Marker)
+        env.new('e', 'base', mode='replica')
+    elif cls_name == 'LimitPolygon':
+        env.new('e', cls, x_vertices=[-1, 1, 1, -1], y_vertices=[-1, -1, 1, 1])
+    else:
+        env.new('e', cls)
+
+    assert isinstance(env['e'], cls)
+
+
 def test_env_new_prototype_keyword_and_deprecated_parent():
 
     env = xt.Environment()

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -4661,9 +4661,10 @@ class FirstOrderTaylorMap(BeamElement):
     length : float
         length of the element in meters.
     m0 : array_like
-        6x1 array of the zero order Taylor map coefficients.
+        6x1 array of the zero order Taylor map coefficients. Default is 0.
     m1 : array_like
-        6x6 array of the first order Taylor map coefficients.
+        6x6 array of the first order Taylor map coefficients. Default is
+        the identity matrix, so the element is an identity map by default.
     """
 
     isthick = True
@@ -4759,11 +4760,12 @@ class SecondOrderTaylorMap(BeamElement):
     length : float
         length of the element in meters.
     k : array_like
-        6x1 array of the zero order Taylor map coefficients.
+        6x1 array of the zero order Taylor map coefficients. Default is 0.
     R : array_like
-        6x6 array of the first order Taylor map coefficients.
+        6x6 array of the first order Taylor map coefficients. Default is
+        the identity matrix, so the element is an identity map by default.
     T : array_like
-        6x6x6 array of the second order Taylor map coefficients.
+        6x6x6 array of the second order Taylor map coefficients. Default is 0.
 
     '''
 

--- a/xtrack/beam_elements/elements.py
+++ b/xtrack/beam_elements/elements.py
@@ -4774,10 +4774,10 @@ class SecondOrderTaylorMap(BeamElement):
     ]
 
     _xofields={
-        'k': xo.Float64[6],
-        'R': xo.Float64[6,6],
-        'T': xo.Float64[6,6,6],
-        'length': xo.Float64
+        'k': xo.Field(xo.Float64[6], default=np.zeros(6, dtype=np.float64)),
+        'R': xo.Field(xo.Float64[6, 6], default=np.eye(6, dtype=np.float64)),
+        'T': xo.Field(xo.Float64[6, 6, 6], default=np.zeros((6, 6, 6), dtype=np.float64)),
+        'length': xo.Float64,
     }
 
     @classmethod

--- a/xtrack/environment.py
+++ b/xtrack/environment.py
@@ -2312,11 +2312,21 @@ class Environment:
                             f'length mismatch ({len(target)} vs {len_value})')
                 target[:len_value] = value_kwargs[kk]
                 if kk in ref_kwargs or not isinit:
-                    for ii, vvv in enumerate(value_kwargs[kk]):
-                        if ref_kwargs[kk][ii] is not None:
-                            getattr(container_refs[name], kk)[ii] = ref_kwargs[kk][ii]
+                    attr_ref = getattr(container_refs[name], kk)
+                    leaves = ref_kwargs[kk]
+                    if not isinstance(leaves, list):
+                        # Whole array passed as one reference: wire item by item.
+                        leaves = [((ii,), leaves[ii]) for ii in range(len_value)]
+                    for index_tuple, ref in leaves:
+                        # `arr[0]` and `arr[(0,)]` are distinct refs, so 1D must stay an int.
+                        idx = index_tuple[0] if len(index_tuple) == 1 else index_tuple
+                        if ref is not None:
+                            attr_ref[idx] = ref
                         elif not isinit:
-                            getattr(container_refs[name], kk)[ii] = value_kwargs[kk][ii]
+                            leaf_value = value_kwargs[kk]
+                            for ii in index_tuple:
+                                leaf_value = leaf_value[ii]
+                            attr_ref[idx] = leaf_value
             elif kk in ref_kwargs:
                 setattr(container_refs[name], kk, ref_kwargs[kk])
             else:
@@ -2477,7 +2487,74 @@ Environment.__doc_groups_ungrouped__ = _ENVIRONMENT_DOC_GROUP_COLLECTOR.validate
 )
 
 
+def _parse_array_value(vv, _eval, index=()):
+    """Recursively parse a (possibly nested, e.g. 2D/3D) array-like kwarg value.
+
+    Walks `vv` to arbitrary depth, evaluating any string leaf as a
+    deferred expression via `_eval`.
+
+    Parameters
+    ----------
+    vv : scalar, reference, string, or nested iterable of these
+        The value to parse.
+    _eval : callable
+        Evaluator turning a string expression into a reference.
+    index : tuple of int
+        Index path from the top-level kwarg to `vv`. Not meant to be
+        passed by callers; used internally to build leaf index tuples.
+
+    Returns
+    -------
+    value
+        `vv` with the same nesting structure, string leaves replaced by
+        their evaluated numeric value.
+    leaves : list of (index_tuple, ref_or_None)
+        One entry per scalar leaf of `vv`: the reference to wire up at
+        that index, or None if the leaf was a plain number with no
+        associated expression.
+    """
+    if hasattr(vv, '_value'):
+        return vv._value, [(index, vv)]
+    if isinstance(vv, str):
+        ref = _eval(vv)
+        value = ref._value if hasattr(ref, '_value') else ref
+        return value, [(index, ref)]
+    if hasattr(vv, '__iter__') and not isinstance(vv, (str, bytes)):
+        values = []
+        leaves = []
+        for ii, item in enumerate(vv):
+            sub_value, sub_leaves = _parse_array_value(item, _eval, index + (ii,))
+            values.append(sub_value)
+            leaves.extend(sub_leaves)
+        return values, leaves
+    return vv, [(index, None)]
+
+
 def _parse_kwargs(cls, kwargs, _eval):
+    """Split constructor/setter kwargs into references and plain values.
+
+    Any string value is evaluated as a deferred expression via `_eval`.
+    Array-valued xofields (including nested 2D/3D ones) are parsed
+    leaf-by-leaf with `_parse_array_value`.
+
+    Parameters
+    ----------
+    cls : type
+        The element (or `Particles`) class the kwargs are being parsed for.
+    kwargs : dict
+        Keyword arguments as passed by the caller.
+    _eval : callable
+        Evaluator turning a string expression into a reference.
+
+    Returns
+    -------
+    ref_kwargs : dict
+        References to set, keyed by attribute name. For array fields, the
+        value is a list of `(index_tuple, ref_or_None)` leaves (see
+        `_parse_array_value`); otherwise a single reference.
+    value_kwargs : dict
+        Plain numerical values to set, keyed by attribute name.
+    """
     ref_kwargs = {}
     value_kwargs = {}
     for kk in kwargs:
@@ -2485,26 +2562,13 @@ def _parse_kwargs(cls, kwargs, _eval):
             ref_kwargs[kk] = kwargs[kk]
             value_kwargs[kk] = kwargs[kk]._value
         elif (hasattr(cls, '_xofields') and kk in cls._xofields
-                and xo.array.is_array(cls._xofields[kk])):
+                and xo.array.is_array(
+                    cls._xofields[kk].ftype
+                    if isinstance(cls._xofields[kk], xo.Field)
+                    else cls._xofields[kk])):
             assert hasattr(kwargs[kk], '__iter__'), (
                 f'{kk} should be an iterable for {cls} element')
-            ref_vv = []
-            value_vv = []
-            for ii, vvv in enumerate(kwargs[kk]):
-                if hasattr(vvv, '_value'):
-                    ref_vv.append(vvv)
-                    value_vv.append(vvv._value)
-                elif isinstance(vvv, str):
-                    ref_vv.append(_eval(vvv))
-                    if hasattr(ref_vv[-1], '_value'):
-                        value_vv.append(ref_vv[-1]._value)
-                    else:
-                        value_vv.append(ref_vv[-1])
-                else:
-                    ref_vv.append(None)
-                    value_vv.append(vvv)
-            ref_kwargs[kk] = ref_vv
-            value_kwargs[kk] = value_vv
+            value_kwargs[kk], ref_kwargs[kk] = _parse_array_value(kwargs[kk], _eval)
         elif (isinstance(kwargs[kk], str) and hasattr(cls, '_xofields')
             and (not hasattr(cls, '_noexpr_fields') or kk not in cls._noexpr_fields)):
             ref_kwargs[kk] = _eval(kwargs[kk])

--- a/xtrack/environment.py
+++ b/xtrack/environment.py
@@ -472,7 +472,7 @@ class Environment:
         else:
             assert mode is None, f'Unknown mode {mode}'
 
-        _eval = self._xdeps_eval.eval
+        eval_ = self._xdeps_eval.eval
 
         if not (isinstance(parent, str) or parent in _ALLOWED_ELEMENT_TYPES_IN_NEW):
             raise ValueError(
@@ -512,7 +512,7 @@ class Environment:
                              '`length_straight` parameter set accordingly, '
                              'instead of specifying the `rbarc` flag.')
 
-        ref_kwargs, value_kwargs = _parse_kwargs(parent, kwargs, _eval)
+        ref_kwargs, value_kwargs = _parse_kwargs(parent, kwargs, eval_)
 
         if needs_instantiation: # Prototype is a class and not another element
             self.elements[name] = parent(**value_kwargs)
@@ -594,7 +594,7 @@ class Environment:
         if parent is None:
             parent = xt.Particles
 
-        _eval = self._xdeps_eval.eval
+        eval_ = self._xdeps_eval.eval
 
         needs_instantiation = True
         prototype = None
@@ -624,7 +624,7 @@ class Environment:
             if kk in xt.Particles._xofields and 'Arr' in xt.Particles._xofields[kk].__name__:
                 kwargs[kk] = [kwargs[kk]]
 
-        ref_kwargs, value_kwargs = _parse_kwargs(parent, kwargs, _eval)
+        ref_kwargs, value_kwargs = _parse_kwargs(parent, kwargs, eval_)
 
         if needs_instantiation: # Parent is a class and not another particle
             self.particles[name] = parent(**value_kwargs)
@@ -1949,7 +1949,7 @@ class Environment:
                 self.set(nn, *args, **kwargs)
             return
 
-        _eval = self._xdeps_eval.eval
+        eval_ = self._xdeps_eval.eval
 
         if hasattr(self, 'lines') and name in self.lines:
             raise ValueError('Cannot set a line')
@@ -1961,7 +1961,7 @@ class Environment:
             extra = kwargs.pop('extra', None)
 
             ref_kwargs, value_kwargs = xt.environment._parse_kwargs(
-                type(self._element_dict[name]), kwargs, _eval)
+                type(self._element_dict[name]), kwargs, eval_)
             self._set_kwargs(
                 name=name, ref_kwargs=ref_kwargs, value_kwargs=value_kwargs,
                 container=self._element_dict, container_refs=self._xdeps_eref,
@@ -1982,7 +1982,7 @@ class Environment:
             if 'extra' in kwargs and kwargs['extra'] is not None:
                 raise ValueError(f'Extra is only allowed for elements')
             if isinstance(value, str):
-                self.vars[name] = _eval(value)
+                self.vars[name] = eval_(value)
             else:
                 self.vars[name] = value
 
@@ -2282,10 +2282,11 @@ class Environment:
         name: str
             Name of the element.
         ref_kwargs: dict
-            Dictionary with the references to set. The keys are the attribute names,
-            and the values are the references.
+            Dictionary with the references to set, keyed by field name. For
+            array fields the value is a list of `(index, ref_or_None, item)`
+            entries, one per item of the array; otherwise a single reference.
         value_kwargs: dict
-            Dictionary with the values to set. The keys are the attribute names,
+            Dictionary with the values to set. The keys are the field names,
             and the values are the non-reference values.
         container: dict
             Dictionary with the elements.
@@ -2298,42 +2299,35 @@ class Environment:
             element without unregistering the refereces.
         """
 
-        for kk in value_kwargs:
-            if hasattr(value_kwargs[kk], '__iter__') and not isinstance(value_kwargs[kk], str):
-                len_value = len(value_kwargs[kk])
-                target = getattr(container[name], kk)
+        for field_name, value in value_kwargs.items():
+            if hasattr(value, '__iter__') and not isinstance(value, str):
+                len_value = len(value)
+                target = getattr(container[name], field_name)
                 if len(target) < len_value:
-                    if kk=='knl' or kk=='ksl' and name in self._element_dict:
+                    if field_name in ('knl', 'ksl') and name in self._element_dict:
                         self.extend_knl_ksl(len_value-1, element_names=[name])
-                        target = getattr(container[name], kk)
+                        target = getattr(container[name], field_name)
                     else:
                         raise ValueError(
-                            f'Cannot set attribute {kk} of element {name}: '
+                            f'Cannot set attribute {field_name} of element {name}: '
                             f'length mismatch ({len(target)} vs {len_value})')
-                target[:len_value] = value_kwargs[kk]
-                if kk in ref_kwargs or not isinit:
-                    attr_ref = getattr(container_refs[name], kk)
-                    leaves = ref_kwargs[kk]
-                    if not isinstance(leaves, list):
-                        # Whole array passed as one reference: wire item by item.
-                        leaves = [((ii,), leaves[ii]) for ii in range(len_value)]
-                    for index_tuple, ref in leaves:
+                target[:len_value] = value
+                if field_name in ref_kwargs or not isinit:
+                    attr_ref = getattr(container_refs[name], field_name)
+                    for index, ref, item in ref_kwargs[field_name]:
                         # `arr[0]` and `arr[(0,)]` are distinct refs, so 1D must stay an int.
-                        idx = index_tuple[0] if len(index_tuple) == 1 else index_tuple
+                        ref_key = index[0] if len(index) == 1 else index
                         if ref is not None:
-                            attr_ref[idx] = ref
+                            attr_ref[ref_key] = ref
                         elif not isinit:
-                            leaf_value = value_kwargs[kk]
-                            for ii in index_tuple:
-                                leaf_value = leaf_value[ii]
-                            attr_ref[idx] = leaf_value
-            elif kk in ref_kwargs:
-                setattr(container_refs[name], kk, ref_kwargs[kk])
+                            attr_ref[ref_key] = item
+            elif field_name in ref_kwargs:
+                setattr(container_refs[name], field_name, ref_kwargs[field_name])
             else:
                 if not isinit:
-                    setattr(container_refs[name], kk, value_kwargs[kk])
+                    setattr(container_refs[name], field_name, value)
                 else:
-                    setattr(container[name], kk, value_kwargs[kk])
+                    setattr(container[name], field_name, value)
 
     twiss = doc_group("Analysis and Matching")(MultilineLegacy.twiss)
     build_trackers = doc_group("Tracker Setup")(MultilineLegacy.build_trackers)
@@ -2487,100 +2481,125 @@ Environment.__doc_groups_ungrouped__ = _ENVIRONMENT_DOC_GROUP_COLLECTOR.validate
 )
 
 
-def _parse_array_value(vv, _eval, index=()):
-    """Recursively parse a (possibly nested, e.g. 2D/3D) array-like kwarg value.
+def _parse_array_value(value, eval_, field_name):
+    """Parse the value assigned to an array field, item by item.
 
-    Walks `vv` to arbitrary depth, evaluating any string leaf as a
-    deferred expression via `_eval`.
+    Handles arrays of any dimensionality. Items given as string
+    expressions are evaluated into references; the rest are kept as they
+    are.
 
     Parameters
     ----------
-    vv : scalar, reference, string, or nested iterable of these
-        The value to parse.
-    _eval : callable
+    value : iterable, or a reference to one
+        The value assigned to the array field. May be multi-dimensional,
+        and may hold string expressions or references at any position.
+    eval_ : callable
         Evaluator turning a string expression into a reference.
-    index : tuple of int
-        Index path from the top-level kwarg to `vv`. Not meant to be
-        passed by callers; used internally to build leaf index tuples.
+    field_name : str
+        Name of the field, used in error messages.
 
     Returns
     -------
-    value
-        `vv` with the same nesting structure, string leaves replaced by
-        their evaluated numeric value.
-    leaves : list of (index_tuple, ref_or_None)
-        One entry per scalar leaf of `vv`: the reference to wire up at
-        that index, or None if the leaf was a plain number with no
-        associated expression.
+    values : list
+        `value` with the same shape, expressions replaced by their
+        current numerical value.
+    leaves : list of (index, ref_or_None, item)
+        One entry per item of the array: where it goes, the reference to
+        wire there (None for a plain number), and its numerical value.
     """
-    if hasattr(vv, '_value'):
-        return vv._value, [(index, vv)]
-    if isinstance(vv, str):
-        ref = _eval(vv)
-        value = ref._value if hasattr(ref, '_value') else ref
-        return value, [(index, ref)]
-    if hasattr(vv, '__iter__') and not isinstance(vv, (str, bytes)):
-        values = []
-        leaves = []
-        for ii, item in enumerate(vv):
-            sub_value, sub_leaves = _parse_array_value(item, _eval, index + (ii,))
-            values.append(sub_value)
-            leaves.extend(sub_leaves)
-        return values, leaves
-    return vv, [(index, None)]
+    if hasattr(value, '_value'):
+        # The whole array is a single reference: wire item by item.
+        referenced = value._value
+        return referenced, [((ii,), value[ii], referenced[ii])
+                            for ii in range(len(referenced))]
+
+    # Object dtype keeps expressions as strings; a numeric dtype would
+    # stringify the numbers instead.
+    array = np.array(value, dtype=object)
+    values = np.empty(array.shape, dtype=object)
+    leaves = []
+    for index in np.ndindex(*array.shape):
+        item = array[index]
+        if isinstance(item, (list, tuple, np.ndarray)):
+            # Only a ragged input leaves a sequence at the deepest index.
+            raise ValueError(
+                f'{field_name} must be a rectangular array, but it has '
+                f'rows of differing length.')
+        ref = None
+        if isinstance(item, str):
+            ref = eval_(item)
+            item = ref._value if hasattr(ref, '_value') else ref
+        elif hasattr(item, '_value'):
+            ref = item
+            item = item._value
+        values[index] = item
+        leaves.append((index, ref, item))
+
+    return values.tolist(), leaves
 
 
-def _parse_kwargs(cls, kwargs, _eval):
+def _parse_kwargs(hybrid_class, kwargs, eval_):
     """Split constructor/setter kwargs into references and plain values.
 
-    Any string value is evaluated as a deferred expression via `_eval`.
-    Array-valued xofields (including nested 2D/3D ones) are parsed
-    leaf-by-leaf with `_parse_array_value`.
+    Any string value is evaluated as a deferred expression via `eval_`.
+    Values assigned to array fields are parsed item by item with
+    `_parse_array_value`.
 
     Parameters
     ----------
-    cls : type
-        The element (or `Particles`) class the kwargs are being parsed for.
+    hybrid_class : type
+        The element (or `Particles`) class the kwargs are meant for.
     kwargs : dict
         Keyword arguments as passed by the caller.
-    _eval : callable
+    eval_ : callable
         Evaluator turning a string expression into a reference.
 
     Returns
     -------
     ref_kwargs : dict
-        References to set, keyed by attribute name. For array fields, the
-        value is a list of `(index_tuple, ref_or_None)` leaves (see
-        `_parse_array_value`); otherwise a single reference.
+        References to set, keyed by field name. For array fields this is
+        a list of `(index, ref_or_None, item)` entries (see
+        `_parse_array_value`),
+        otherwise a single reference.
     value_kwargs : dict
-        Plain numerical values to set, keyed by attribute name.
+        Plain numerical values to set, keyed by field name.
     """
     ref_kwargs = {}
     value_kwargs = {}
-    for kk in kwargs:
-        if hasattr(kwargs[kk], '_value'):
-            ref_kwargs[kk] = kwargs[kk]
-            value_kwargs[kk] = kwargs[kk]._value
-        elif (hasattr(cls, '_xofields') and kk in cls._xofields
-                and xo.array.is_array(
-                    cls._xofields[kk].ftype
-                    if isinstance(cls._xofields[kk], xo.Field)
-                    else cls._xofields[kk])):
-            assert hasattr(kwargs[kk], '__iter__'), (
-                f'{kk} should be an iterable for {cls} element')
-            value_kwargs[kk], ref_kwargs[kk] = _parse_array_value(kwargs[kk], _eval)
-        elif (isinstance(kwargs[kk], str) and hasattr(cls, '_xofields')
-            and (not hasattr(cls, '_noexpr_fields') or kk not in cls._noexpr_fields)):
-            ref_kwargs[kk] = _eval(kwargs[kk])
-            if hasattr(ref_kwargs[kk], '_value'):
-                value_kwargs[kk] = ref_kwargs[kk]._value
-            else:
-                value_kwargs[kk] = ref_kwargs[kk]
-        elif isinstance(kwargs[kk], xo.String):
-            vvv = kwargs[kk].to_str()
-            value_kwargs[kk] = vvv
+    has_xofields = hasattr(hybrid_class, '_xofields')
+    xofields = getattr(hybrid_class, '_xofields', {})
+    noexpr_fields = getattr(hybrid_class, '_noexpr_fields', ())
+
+    for field_name, value in kwargs.items():
+        # `xo.Field` wraps the type only to attach a default.
+        field_type = xofields.get(field_name)
+        if isinstance(field_type, xo.Field):
+            field_type = field_type.ftype
+        is_array_field = (field_type is not None
+                          and xo.array.is_array(field_type))
+
+        # A whole array can also be given as a single reference.
+        is_ref = hasattr(value, '_value')
+        assigned = value._value if is_ref else value
+
+        if is_array_field and hasattr(assigned, '__iter__'):
+            value_kwargs[field_name], ref_kwargs[field_name] = \
+                _parse_array_value(value, eval_, field_name)
+        elif is_ref:
+            ref_kwargs[field_name] = value
+            value_kwargs[field_name] = value._value
+        elif is_array_field:
+            raise TypeError(
+                f'{field_name} should be an iterable for {hybrid_class} element')
+        elif (isinstance(value, str) and has_xofields
+                and field_name not in noexpr_fields):
+            ref = eval_(value)
+            ref_kwargs[field_name] = ref
+            value_kwargs[field_name] = ref._value if hasattr(ref, '_value') else ref
+        elif isinstance(value, xo.String):
+            value_kwargs[field_name] = value.to_str()
         else:
-            value_kwargs[kk] = kwargs[kk]
+            value_kwargs[field_name] = value
 
     return ref_kwargs, value_kwargs
 
@@ -3788,7 +3807,7 @@ class EnvVars:
         return xt.Target(action=action, tar=tar, value=value, **kwargs)
 
     def __call__(self, *args, **kwargs):
-        _eval = self.env._xdeps_eval.eval
+        eval_ = self.env._xdeps_eval.eval
         if len(args) > 0:
             assert len(kwargs) == 0
             assert len(args) == 1
@@ -3800,7 +3819,7 @@ class EnvVars:
                 raise ValueError('Invalid argument')
         for kk in kwargs:
             if isinstance(kwargs[kk], str):
-                self[kk] = _eval(kwargs[kk])
+                self[kk] = eval_(kwargs[kk])
             else:
                 self[kk] = kwargs[kk]
 

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -68,7 +68,8 @@ _ALLOWED_ELEMENT_TYPES_IN_NEW = [
     xt.Translation, xt.Rotation, xt.XRotation, xt.TimeDelay,
     xt.XYShift, xt.XRotation, xt.YRotation, xt.SRotation, xt.ZetaShift,
     xt.LimitRacetrack, xt.LimitRectEllipse, xt.LimitRect, xt.LimitEllipse,
-    xt.LimitPolygon, xt.DipoleEdge, xt.LongitudinalLimitRect, xt.FirstOrderTaylorMap]
+    xt.LimitPolygon, xt.DipoleEdge, xt.LongitudinalLimitRect, xt.FirstOrderTaylorMap,
+    xt.SecondOrderTaylorMap]
 
 _ALLOWED_ELEMENT_TYPES_DICT = {
     cc.__name__: cc for cc in _ALLOWED_ELEMENT_TYPES_IN_NEW}

--- a/xtrack/line.py
+++ b/xtrack/line.py
@@ -65,7 +65,7 @@ _ALLOWED_ELEMENT_TYPES_IN_NEW = [
     xt.UniformSolenoid, xt.Solenoid, xt.VariableSolenoid,
     xt.Cavity, xt.RFMultipole, xt.CrabCavity, xt.ReferenceEnergyIncrease,
     xt.ReferenceEnergyChange,
-    xt.Translation, xt.Rotation, xt.XRotation, xt.TimeDelay,
+    xt.Translation, xt.Rotation, xt.TimeDelay,
     xt.XYShift, xt.XRotation, xt.YRotation, xt.SRotation, xt.ZetaShift,
     xt.LimitRacetrack, xt.LimitRectEllipse, xt.LimitRect, xt.LimitEllipse,
     xt.LimitPolygon, xt.DipoleEdge, xt.LongitudinalLimitRect, xt.FirstOrderTaylorMap,


### PR DESCRIPTION
## Summary

Adding `SecondOrderTaylorMap` to `Environment.new()` surfaced a
pre-existing bug in how array-valued kwargs are parsed. Both are fixed
here, as the first is not usable without the second.

### The feature
- Add `xt.SecondOrderTaylorMap` to `_ALLOWED_ELEMENT_TYPES_IN_NEW`, so it
  can be built with `env.new(name, xt.SecondOrderTaylorMap, ...)` like
  `FirstOrderTaylorMap` already can.
- Give `k`/`R`/`T` defaults (zero, identity, zero), mirroring
  `FirstOrderTaylorMap`'s `m0`/`m1`, so the element defaults to an
  identity map. Documented on both classes, as the identity default was
  previously undocumented on `FirstOrderTaylorMap` too.
- Remove a duplicate `xt.XRotation` entry noticed in the same list.

### The bug
A non-zero default (`R` must default to `np.eye(6)`) can only be declared
by wrapping the field: `xo.Field(xo.Float64[6, 6], default=...)`. But
`_parse_kwargs` tested `xo.array.is_array(field)`, which returns `False`
for a wrapped array type, so the expression-parsing branch was skipped
entirely and string kwargs reached the constructor unevaluated.

Separately, that branch only ever walked one level deep, so an expression
nested inside a 2D/3D array (`R[2][3] = '2*a'`) was never evaluated at any
point in the past.

Both are fixed: `_parse_kwargs` unwraps `xo.Field`, and parsing is now
recursive to arbitrary depth via `_parse_array_value`.

Affects only fields declared with a non-trivial default —
`SecondOrderTaylorMap.k/R/T`, `FirstOrderTaylorMap.m0/m1`,
`SimpleThinQuadrupole.knl`, `Elens.coefficients_polynomial`. Ordinary
`knl`/`ksl` on magnets use bare array types and were never affected.

## Test plan
- [x] New `test_env_new_multi_dimensional_arrays` /
      `test_env_set_multi_dimensional_arrays`: expressions at 1D/2D/3D,
      live updates, and stale expressions cleared on overwrite.
- [x] New `test_env_new_whole_array_reference`: passing a whole array as a
      single reference still wires item by item (this regressed during
      development and was not covered by any existing test).
- [x] New `test_env_new_allowed_elements`: every entry in
      `_ALLOWED_ELEMENT_TYPES_IN_NEW` is constructible via `env.new`.
      Roughly half the list, including both Taylor maps, had no such
      coverage.
- [x] Full suite: 2226 passed, 3 skipped.
