### PR TITLE
Utilise inserting a list of xt.places for synctime installation

### DIFF
--- a/xtrack/synctime.py
+++ b/xtrack/synctime.py
@@ -79,27 +79,35 @@ def install_sync_time_at_collective_elements(
 
     ltab = line.get_table()
     tab_collective = ltab.rows[ltab.iscollective]
+
+    env = line.env
+    places = []
+
     for ii, nn in enumerate(tab_collective.name):
-        cc = SyncTime(circumference=circumference,
-                        frame_relative_length=frame_relative_length,
-                        id=COAST_STATE_RANGE_START + ii + 1)
-        line.insert(
-            obj=cc, what=f'synctime_{ii}', at=nn,
-            with_progress=with_progress)
+        name = f"synctime_{ii}"
+        env.elements[name] = SyncTime(
+            circumference=circumference,
+            frame_relative_length= frame_relative_length,
+            id=COAST_STATE_RANGE_START + ii + 1,
+        )
+        places.append(env.place(name=name, at=nn))
 
-    synctime_start = SyncTime(circumference=circumference,
-                        frame_relative_length=frame_relative_length,
-                        id=COAST_STATE_RANGE_START + len(tab_collective)+1,
-                        at_start=True)
-    synctime_end = SyncTime(circumference=circumference,
-                        frame_relative_length=frame_relative_length,
-                        id=COAST_STATE_RANGE_START + len(tab_collective)+2,
-                        at_end=True)
+    env.elements["synctime_start"] = SyncTime(circumference=circumference,
+        frame_relative_length=frame_relative_length,
+        id=COAST_STATE_RANGE_START + len(tab_collective)+1,
+        at_start=True,
+    )
+    places.append(env.place(name="synctime_start", at=0))
 
-    line.insert(
-        obj=synctime_start, what='synctime_start', at=0,
-        with_progress=with_progress)
-    line.append('synctime_end', obj=synctime_end)
+    env.elements["synctime_end"] = SyncTime(circumference=circumference,
+        frame_relative_length=frame_relative_length,
+        id=COAST_STATE_RANGE_START + len(tab_collective)+2,
+        at_end=True,
+    )
+    places.append(env.place(name="synctime_end", at=circumference))
+
+    line.insert(places, with_progress=with_progress)
+
 
 def prepare_particles_for_sync_time(particles, line):
     synctime_start = line['synctime_start']


### PR DESCRIPTION
## Description
When creating SyncTime elements and adding them to the line, it currently results in a long stream of slicing line readouts. It is cleaner to create all SyncTime elements, create the place objects and then insert them all in one go.

Note: This may be improved later by using env.new instead of env["element_name"] = ... when SyncTime is in _ALLOWED_ELEMENT_TYPES_IN_NEW in xt.environment.py

Unchanged functionality on user side.