### PR TITLE
Large improvement in time needed for particles creation

### DIFF
--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -2055,26 +2055,13 @@ class Particles(xo.HybridClass):
                                     mask=mask)
 
         delta = self._delta  # Cupy complains if we later assign LinkedArray
-        can_reuse_ptau = False
-        # A device-side reduction would force synchronization, so retain the
-        # original expression on GPU contexts.
-        if isinstance(self._context, xo.ContextCpu):
-            one_plus_ptau_beta0 = 1 + _ptau * beta0
-            values_to_check = (one_plus_ptau_beta0 if mask is None
-                               else one_plus_ptau_beta0[mask])
-            can_reuse_ptau = bool(
-                self._context.nplike_lib.all(values_to_check >= 0))
-        if can_reuse_ptau:
-            # This is algebraically identical to recovering ptau * beta0
-            # from delta through another square root, in the physical
-            # positive-energy branch. Reusing ptau avoids that round trip.
-            rvv_denominator = one_plus_ptau_beta0
-        else:
-            delta_beta0 = delta * beta0
-            ptau_beta0 = _sqrt(
-                delta_beta0 ** 2 + 2 * delta_beta0 * beta0 + 1) - 1
-            rvv_denominator = 1 + ptau_beta0
-        new_rvv = (1 + delta) / rvv_denominator
+        # Keep the operation order used historically. Although rvv can be
+        # derived directly from _ptau, the algebraic rewrite changes the last
+        # bit and can perturb finite-difference maps on accelerator contexts.
+        delta_beta0 = delta * beta0
+        ptau_beta0 = _sqrt(delta_beta0 ** 2
+                           + 2 * delta_beta0 * beta0 + 1) - 1
+        new_rvv = (1 + delta) / (1 + ptau_beta0)
         new_rpp = 1 / (1 + delta)
         self._setattr_if_consistent('_rpp',
                                     given_value=_rpp,

--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -612,22 +612,47 @@ class Particles(xo.HybridClass):
             _capacity = input_length
 
         # Allocate the xobject of the right size
+        _context = kwargs.pop('_context', None)
+        _buffer = kwargs.pop('_buffer', None)
+        _offset = kwargs.pop('_offset', None)
         self.xoinitialize(
-            _context=kwargs.pop('_context', None),
-            _buffer=kwargs.pop('_buffer', None),
-            _offset=kwargs.pop('_offset', None),
+            _context=_context,
+            _buffer=_buffer,
+            _offset=_offset,
             **{field: _capacity for _, field in self.per_particle_vars}
         )
         self._capacity = _capacity
         self._num_active_particles = -1  # To be filled in only on CPU
         self._num_lost_particles = -1  # To be filled in only on CPU
 
-        # Initialize the fields to preset values
+        state = kwargs.get('state', 1)
+        state_is_scalar = np.isscalar(state) or len(state) == 1
+        if state_is_scalar:
+            state = np.asarray(state).item()
+            all_input_slots_are_valid = state > LAST_INVALID_STATE
+        else:
+            state = np.asarray(state)
+            all_input_slots_are_valid = bool(
+                np.all(state > LAST_INVALID_STATE))
+
+        buffer_is_zeroed = (_buffer is None
+                            and isinstance(self._context,
+                                           (xo.ContextCpu, xo.ContextCupy)))
+        independent_defaults_are_zeroed = (
+            buffer_is_zeroed
+            and _capacity == input_length
+            and all_input_slots_are_valid)
+
+        # All valid input slots are overwritten below. Avoid filling every
+        # array once more unless unallocated or invalid slots need sentinels.
+        # RNG state must remain zero; fresh CPU/CUDA buffers already provide it.
         for type_, field in self.per_particle_vars:
             raw_field = self._rename.get(field, field)
             if raw_field.startswith('_rng'):
-                setattr(self, raw_field, 0)
-            else:
+                if not buffer_is_zeroed:
+                    setattr(self, raw_field, 0)
+            elif (_capacity > input_length
+                  or not all_input_slots_are_valid):
                 setattr(self, raw_field, LAST_INVALID_STATE)
 
         np_to_ctx = self._context.nparray_to_context_array
@@ -637,15 +662,18 @@ class Particles(xo.HybridClass):
         self.hide_first_n_particles(input_length)
 
         # Start populating the object with the input values
-        state = kwargs.get('state', 1)
-        if np.isscalar(state) or len(state) == 1:
-            state = np.array(state).item()
-        else:
-            state = np_to_ctx(np.array(state))
+        if not state_is_scalar:
+            state = np_to_ctx(state)
         self.state = state
-        input_mask = self.state > LAST_INVALID_STATE
+        # None selects the cheaper direct-assignment path in the update
+        # helpers. A mask is only needed when input slots can be invalid.
+        input_mask = (None if all_input_slots_are_valid
+                      else self.state > LAST_INVALID_STATE)
 
-        particle_ids = kwargs.get('particle_id', np.arange(input_length))
+        if 'particle_id' in kwargs:
+            particle_ids = kwargs['particle_id']
+        else:
+            particle_ids = np.arange(input_length)
         particle_ids = np.atleast_1d(particle_ids)
         self.particle_id = np_to_ctx(particle_ids)
 
@@ -666,26 +694,33 @@ class Particles(xo.HybridClass):
         # Ensure that all per particle inputs are numpy arrays of the same
         # length, and move them to the target context
         for xotype, field in per_part_input_vars:
-            if field not in kwargs.keys():
+            if field not in kwargs:
                 continue
 
             if np.isscalar(kwargs[field]) or len(kwargs[field]) == 1:
-                value = np.array(kwargs[field]).item()
-                kwargs[field] = np.full(input_length, value)
+                value = np.asarray(kwargs[field]).item()
+                if (input_mask is None
+                        and isinstance(self._context, xo.ContextCpu)):
+                    # CPU array assignment broadcasts scalars directly; there
+                    # is no need to allocate a temporary input-sized array.
+                    kwargs[field] = value
+                    continue
+                kwargs[field] = np.full(
+                    input_length, value, dtype=xotype._dtype)
             else:
-                kwargs[field] = np.array(kwargs[field])
+                kwargs[field] = np.asarray(
+                    kwargs[field], dtype=xotype._dtype)
 
-            # Coerce the right type so that we can allocate the right array
-            # in the target context. PyOpenCL gets fussy if types don't match
-            # in calculations.
-            if kwargs[field].dtype != xotype._dtype:
-                kwargs[field] = kwargs[field].astype(xotype._dtype)
+            # PyOpenCL gets fussy if types don't match in calculations.
             kwargs[field] = np_to_ctx(kwargs[field])
 
 
 
         # Init independent per particle vars
-        self.init_independent_per_part_vars(kwargs)
+        self.init_independent_per_part_vars(
+            kwargs,
+            _zeroed_buffer=independent_defaults_are_zeroed,
+        )
 
         # Init chi and charge ratio
         self._update_chi_charge_ratio(
@@ -714,6 +749,9 @@ class Particles(xo.HybridClass):
             _rpp=kwargs.get('rpp'),
             _rvv=kwargs.get('rvv'),
             mask=input_mask,
+            _mass_ratio_is_default=all(
+                kwargs.get(name) is None
+                for name in ('chi', 'charge_ratio', 'mass_ratio')),
         )
 
         # Init zeta
@@ -725,7 +763,13 @@ class Particles(xo.HybridClass):
 
         self.unhide_first_n_particles()
         if isinstance(self._context, xo.ContextCpu) and not _no_reorganize:
-            self.reorganize()
+            if state_is_scalar and state > LAST_INVALID_STATE:
+                self._num_active_particles = (
+                    input_length if state > 0 else 0)
+                self._num_lost_particles = (
+                    input_length if state <= 0 else 0)
+            else:
+                self.reorganize()
 
         if 'name' in kwargs.keys():
             self.name = kwargs['name']
@@ -1802,23 +1846,22 @@ class Particles(xo.HybridClass):
     def part_energy_varnames(cls):
         return [vv for tt, vv in cls.part_energy_vars]
 
-    def init_independent_per_part_vars(self, kwargs):
-        self.s = kwargs.get('s', 0)
-        self.at_turn = kwargs.get('at_turn', 0)
-        self.at_element = kwargs.get('at_element', 0)
+    def init_independent_per_part_vars(self, kwargs, _zeroed_buffer=False):
+        zero_default_fields = (
+            's', 'at_turn', 'at_element', 'x', 'y', 'px', 'py', 'ax', 'ay',
+            'anomalous_magnetic_moment', 'spin_x', 'spin_y', 'spin_z')
+        for field in zero_default_fields:
+            value = kwargs.get(field, 0)
+            is_positive_zero = (np.isscalar(value) and value == 0
+                                and not np.signbit(value))
+            if not _zeroed_buffer or not is_positive_zero:
+                setattr(self, field, value)
+
         self.weight = kwargs.get('weight', 1)
-        self.x = kwargs.get('x', 0)
-        self.y = kwargs.get('y', 0)
-        self.px = kwargs.get('px', 0)
-        self.py = kwargs.get('py', 0)
-        self.ax = kwargs.get('ax', 0)
-        self.ay = kwargs.get('ay', 0)
-        self.anomalous_magnetic_moment = kwargs.get('anomalous_magnetic_moment', 0)
-        self.spin_x = kwargs.get('spin_x', 0)
-        self.spin_y = kwargs.get('spin_y', 0)
-        self.spin_z = kwargs.get('spin_z', 0)
 
         pdg_id = kwargs.get('pdg_id')
+        if pdg_id is None and _zeroed_buffer:
+            return
         try:
             pdg_id = get_pdg_id_from_name(pdg_id)
             if not np.isscalar(pdg_id):
@@ -1866,7 +1909,7 @@ class Particles(xo.HybridClass):
 
     def _assert_values_consistent(self, given_value, computed_value, mask=None):
         """Check if the given value is consistent with the computed value."""
-        if given_value is None:
+        if given_value is None or given_value is computed_value:
             return
         if not self._allclose(given_value, computed_value, mask=mask):
             raise ValueError(
@@ -1954,14 +1997,23 @@ class Particles(xo.HybridClass):
                                     mask=mask)
 
     def _update_energy_deviations(self, delta=None, ptau=None, pzeta=None,
-                                  _rpp=None, _rvv=None, mask=None):
+                                  _rpp=None, _rvv=None, mask=None,
+                                  _mass_ratio_is_default=False):
         if all(ff is None for ff in (delta, ptau, pzeta)):
             if _rpp is not None or _rvv is not None:
                 raise ValueError('Setting `delta` and `ptau` by only giving '
                                  '`_rpp` and `_rvv` is not supported.')
-            if any(self.mass_ratio != 1.0):
-                raise ValueError('Need to provide `delta` or `ptau` with '
-                                 'non-default mass ratios.')
+            if not _mass_ratio_is_default:
+                mass_ratio = self.mass_ratio
+                if isinstance(self._context, xo.ContextPyopencl):
+                    has_non_default_mass_ratio = np.any(
+                        mass_ratio.get() != 1.0)
+                else:
+                    has_non_default_mass_ratio = bool(
+                        self._context.nplike_lib.any(mass_ratio != 1.0))
+                if has_non_default_mass_ratio:
+                    raise ValueError('Need to provide `delta` or `ptau` with '
+                                     'non-default mass ratios.')
             self._delta = 0.0
             delta = self._delta  # Cupy complains if we later assign LinkedArray
 
@@ -1971,11 +2023,13 @@ class Particles(xo.HybridClass):
         if delta is not None:
             _delta = delta
             _ptau = _sqrt(_delta ** 2 + 2 * _delta + 1 / beta0 ** 2) - 1 / beta0
-            _pzeta = _ptau / beta0
+            if pzeta is not None:
+                _pzeta = _ptau / beta0
         elif ptau is not None:
             _ptau = ptau
             _delta = _sqrt(_ptau ** 2 + 2 * _ptau / beta0 + 1) - 1
-            _pzeta = _ptau / beta0
+            if pzeta is not None:
+                _pzeta = _ptau / beta0
         elif pzeta is not None:
             _pzeta = pzeta
             _ptau = _pzeta * beta0
@@ -1983,7 +2037,8 @@ class Particles(xo.HybridClass):
         else:
             raise RuntimeError('This statement is unreachable.')
 
-        self._assert_values_consistent(pzeta, _pzeta, mask)
+        if pzeta is not None:
+            self._assert_values_consistent(pzeta, _pzeta, mask)
         self._setattr_if_consistent('_delta',
                                     given_value=delta,
                                     computed_value=_delta,
@@ -1994,9 +2049,26 @@ class Particles(xo.HybridClass):
                                     mask=mask)
 
         delta = self._delta  # Cupy complains if we later assign LinkedArray
-        delta_beta0 = delta * beta0
-        ptau_beta0 = _sqrt(delta_beta0 ** 2 + 2 * delta_beta0 * beta0 + 1) - 1
-        new_rvv = (1 + delta) / (1 + ptau_beta0)
+        one_plus_ptau_beta0 = 1 + _ptau * beta0
+        can_reuse_ptau = False
+        # A device-side reduction would force synchronization, so retain the
+        # original expression on GPU contexts.
+        if isinstance(self._context, xo.ContextCpu):
+            values_to_check = (one_plus_ptau_beta0 if mask is None
+                               else one_plus_ptau_beta0[mask])
+            can_reuse_ptau = bool(
+                self._context.nplike_lib.all(values_to_check >= 0))
+        if can_reuse_ptau:
+            # This is algebraically identical to recovering ptau * beta0
+            # from delta through another square root, in the physical
+            # positive-energy branch. Reusing ptau avoids that round trip.
+            rvv_denominator = one_plus_ptau_beta0
+        else:
+            delta_beta0 = delta * beta0
+            ptau_beta0 = _sqrt(
+                delta_beta0 ** 2 + 2 * delta_beta0 * beta0 + 1) - 1
+            rvv_denominator = 1 + ptau_beta0
+        new_rvv = (1 + delta) / rvv_denominator
         new_rpp = 1 / (1 + delta)
         self._setattr_if_consistent('_rpp',
                                     given_value=_rpp,
@@ -2010,20 +2082,22 @@ class Particles(xo.HybridClass):
     def _update_zeta(self, zeta=None, tau=None, mask=None):
         if zeta is None and tau is None:
             self.zeta = 0.0
-            zeta = self.zeta
+            return
 
         beta0 = self._beta0
 
         if zeta is not None:
             _zeta = zeta
-            _tau = zeta / beta0
+            if tau is not None:
+                _tau = zeta / beta0
         elif tau is not None:
             _tau = tau
             _zeta = beta0 * _tau
         else:
             raise RuntimeError('This statement is unreachable.')
 
-        self._assert_values_consistent(tau, _tau, mask)
+        if tau is not None:
+            self._assert_values_consistent(tau, _tau, mask)
         self._setattr_if_consistent('zeta',
                                     given_value=zeta,
                                     computed_value=_zeta,

--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -635,15 +635,6 @@ class Particles(xo.HybridClass):
             all_input_slots_are_valid = bool(
                 np.all(state > LAST_INVALID_STATE))
 
-        # BufferNumpy guarantees a zero-filled fresh allocation. Do not make
-        # the same assumption for GPU buffers: this is not part of the context
-        # API and CUDA allocators are allowed to reuse uninitialized memory.
-        buffer_is_zeroed = (
-            _buffer is None and isinstance(self._context, xo.ContextCpu))
-        independent_defaults_are_zeroed = (
-            buffer_is_zeroed
-            and _capacity == input_length
-            and all_input_slots_are_valid)
         can_skip_sentinel_fill = (
             isinstance(self._context, xo.ContextCpu)
             and _capacity == input_length
@@ -651,12 +642,11 @@ class Particles(xo.HybridClass):
 
         # All valid input slots are overwritten below. Avoid filling every
         # array once more unless unallocated or invalid slots need sentinels.
-        # RNG state must remain zero; fresh CPU buffers already provide it.
+        # RNG state is always initialized explicitly.
         for type_, field in self.per_particle_vars:
             raw_field = self._rename.get(field, field)
             if raw_field.startswith('_rng'):
-                if not buffer_is_zeroed:
-                    setattr(self, raw_field, 0)
+                setattr(self, raw_field, 0)
             elif not can_skip_sentinel_fill:
                 setattr(self, raw_field, LAST_INVALID_STATE)
 
@@ -723,10 +713,7 @@ class Particles(xo.HybridClass):
 
 
         # Init independent per particle vars
-        self.init_independent_per_part_vars(
-            kwargs,
-            _zeroed_buffer=independent_defaults_are_zeroed,
-        )
+        self.init_independent_per_part_vars(kwargs)
 
         # Init chi and charge ratio
         self._update_chi_charge_ratio(
@@ -1852,22 +1839,23 @@ class Particles(xo.HybridClass):
     def part_energy_varnames(cls):
         return [vv for tt, vv in cls.part_energy_vars]
 
-    def init_independent_per_part_vars(self, kwargs, _zeroed_buffer=False):
-        zero_default_fields = (
-            's', 'at_turn', 'at_element', 'x', 'y', 'px', 'py', 'ax', 'ay',
-            'anomalous_magnetic_moment', 'spin_x', 'spin_y', 'spin_z')
-        for field in zero_default_fields:
-            value = kwargs.get(field, 0)
-            is_positive_zero = (np.isscalar(value) and value == 0
-                                and not np.signbit(value))
-            if not _zeroed_buffer or not is_positive_zero:
-                setattr(self, field, value)
-
+    def init_independent_per_part_vars(self, kwargs):
+        self.s = kwargs.get('s', 0)
+        self.at_turn = kwargs.get('at_turn', 0)
+        self.at_element = kwargs.get('at_element', 0)
         self.weight = kwargs.get('weight', 1)
+        self.x = kwargs.get('x', 0)
+        self.y = kwargs.get('y', 0)
+        self.px = kwargs.get('px', 0)
+        self.py = kwargs.get('py', 0)
+        self.ax = kwargs.get('ax', 0)
+        self.ay = kwargs.get('ay', 0)
+        self.anomalous_magnetic_moment = kwargs.get('anomalous_magnetic_moment', 0)
+        self.spin_x = kwargs.get('spin_x', 0)
+        self.spin_y = kwargs.get('spin_y', 0)
+        self.spin_z = kwargs.get('spin_z', 0)
 
         pdg_id = kwargs.get('pdg_id')
-        if pdg_id is None and _zeroed_buffer:
-            return
         try:
             pdg_id = get_pdg_id_from_name(pdg_id)
             if not np.isscalar(pdg_id):

--- a/xtrack/particles/particles.py
+++ b/xtrack/particles/particles.py
@@ -635,24 +635,29 @@ class Particles(xo.HybridClass):
             all_input_slots_are_valid = bool(
                 np.all(state > LAST_INVALID_STATE))
 
-        buffer_is_zeroed = (_buffer is None
-                            and isinstance(self._context,
-                                           (xo.ContextCpu, xo.ContextCupy)))
+        # BufferNumpy guarantees a zero-filled fresh allocation. Do not make
+        # the same assumption for GPU buffers: this is not part of the context
+        # API and CUDA allocators are allowed to reuse uninitialized memory.
+        buffer_is_zeroed = (
+            _buffer is None and isinstance(self._context, xo.ContextCpu))
         independent_defaults_are_zeroed = (
             buffer_is_zeroed
+            and _capacity == input_length
+            and all_input_slots_are_valid)
+        can_skip_sentinel_fill = (
+            isinstance(self._context, xo.ContextCpu)
             and _capacity == input_length
             and all_input_slots_are_valid)
 
         # All valid input slots are overwritten below. Avoid filling every
         # array once more unless unallocated or invalid slots need sentinels.
-        # RNG state must remain zero; fresh CPU/CUDA buffers already provide it.
+        # RNG state must remain zero; fresh CPU buffers already provide it.
         for type_, field in self.per_particle_vars:
             raw_field = self._rename.get(field, field)
             if raw_field.startswith('_rng'):
                 if not buffer_is_zeroed:
                     setattr(self, raw_field, 0)
-            elif (_capacity > input_length
-                  or not all_input_slots_are_valid):
+            elif not can_skip_sentinel_fill:
                 setattr(self, raw_field, LAST_INVALID_STATE)
 
         np_to_ctx = self._context.nparray_to_context_array
@@ -667,7 +672,8 @@ class Particles(xo.HybridClass):
         self.state = state
         # None selects the cheaper direct-assignment path in the update
         # helpers. A mask is only needed when input slots can be invalid.
-        input_mask = (None if all_input_slots_are_valid
+        input_mask = (None if (all_input_slots_are_valid
+                               and isinstance(self._context, xo.ContextCpu))
                       else self.state > LAST_INVALID_STATE)
 
         if 'particle_id' in kwargs:
@@ -2049,11 +2055,11 @@ class Particles(xo.HybridClass):
                                     mask=mask)
 
         delta = self._delta  # Cupy complains if we later assign LinkedArray
-        one_plus_ptau_beta0 = 1 + _ptau * beta0
         can_reuse_ptau = False
         # A device-side reduction would force synchronization, so retain the
         # original expression on GPU contexts.
         if isinstance(self._context, xo.ContextCpu):
+            one_plus_ptau_beta0 = 1 + _ptau * beta0
             values_to_check = (one_plus_ptau_beta0 if mask is None
                                else one_plus_ptau_beta0[mask])
             can_reuse_ptau = bool(

--- a/xtrack/particles/pdg.py
+++ b/xtrack/particles/pdg.py
@@ -115,6 +115,9 @@ elements_long = {
   116: "Livermorium",   117: "Tennessine",    118: "Oganesson"
 }
 _elements_long_inv = {vv: kk for kk, vv in elements_long.items()}
+_elements_lower_inv = {vv.lower(): kk for kk, vv in elements.items()}
+_elements_lower_inv.update(
+    {vv.lower(): kk for kk, vv in elements_long.items()})
 
 
 def is_proton(pdg_id):
@@ -188,10 +191,19 @@ def get_pdg_id_from_name(name=None):
 
     if name is None:
         return 0  # undefined
-    elif hasattr(name, '__len__') and not isinstance(name, str):
-        return np.array([get_pdg_id_from_name(nn) for nn in name])
     elif isinstance(name, Number):
         return int(name) # fallback
+    elif not isinstance(name, str) and hasattr(name, '__len__'):
+        name_array = np.asarray(name)
+        if name_array.ndim == 0:
+            return get_pdg_id_from_name(name_array.item())
+        if name_array.dtype.kind in 'biu' or (
+                name_array.dtype.kind == 'f'
+                and np.all(np.isfinite(name_array))):
+            # PDG IDs are commonly supplied as one integer per particle. Avoid
+            # recursively dispatching every element through this function.
+            return name_array.astype(np.int64, copy=False)
+        return np.array([get_pdg_id_from_name(nn) for nn in name])
 
     lname = _to_normal_script(name).lower().replace('ς', 'σ')
     aname = ""
@@ -205,27 +217,37 @@ def get_pdg_id_from_name(name=None):
     _PDG_inv = get_pdg_inv()
 
     # particle
-    if lname in _PDG_inv.keys():
+    if lname in _PDG_inv:
         return _PDG_inv[lname]
 
     # anti-particle
-    elif aname in _PDG_inv.keys():
+    elif aname in _PDG_inv:
         return -_PDG_inv[aname]
 
     else:
-        ion_name = lname.lower()
-        ion_name = ion_name.replace('_','').replace('-','')
+        ion_name = lname.replace('_','').replace('-','')
         ion_name = ion_name.replace(' ','').replace('.','')
-        for Z, ion in elements_long.items():
-            if ion.lower() in ion_name:
-                A = ion_name.replace(ion.lower(), '')
-                if A.isnumeric() and int(A) > 0:
-                    return get_pdg_id_ion(int(A), Z)
-        for Z, ion in elements.items():
-            if ion.lower() in ion_name:
-                A = ion_name.replace(ion.lower(), '')
-                if A.isnumeric() and int(A) > 0:
-                    return get_pdg_id_ion(int(A), Z)
+
+        # Split an ion name into an element and a leading or trailing mass
+        # number, then use the inverse element table for an O(1) lookup. The
+        # previous implementation scanned and lower-cased all 236 short and
+        # long element names for every lookup.
+        if ion_name and ion_name[0].isdigit():
+            split = 0
+            while split < len(ion_name) and ion_name[split].isdigit():
+                split += 1
+            A = ion_name[:split]
+            element = ion_name[split:]
+        else:
+            split = len(ion_name)
+            while split > 0 and ion_name[split - 1].isdigit():
+                split -= 1
+            element = ion_name[:split]
+            A = ion_name[split:]
+
+        Z = _elements_lower_inv.get(element)
+        if Z is not None and A.isnumeric() and int(A) > 0:
+            return get_pdg_id_ion(int(A), Z)
         raise ValueError(f"Particle {name} not found in pdg dictionary, or wrongly "
                         + f"formatted ion name!\nFor ions, use e.g. 'Pb208', 'Pb 208', "
                         + f"'Pb-208', 'Pb_208', 'Pb.208', '208Pb', 'lead-208', ...")


### PR DESCRIPTION
## Description

Particles generation can take a long time.
For instance, generating 100M particles on my machines (same time on a MacBook M3 and AMD Ryzen 7 9850X3D) takes a bit more than 30 seconds.
This PR addresses this in two steps, and in doing so, gains more than an order of magnitude in speed (from 30 to 2.2 seconds).

### PDG optimisation

Numeric PDG-ID arrays were processed recursively in Python—one function call and several type checks per particle.
Ion lookup scanned and lowercased all 236 short/long element names. Initial mass-table construction triggered this hundreds of times.
The new approach:
 - Converts numeric arrays through NumPy; int64 arrays are zero-copy
 - Parses the ion’s mass number, then uses a precomputed lowercase element dictionary for O(1) lookup
 - Retains existing string, antiparticle, and ion formats

Very strong speed gain: from 30 seconds down to 10 seconds.


### Particles `__init__` optimisation

Key improvements:
 - Avoid sentinel-prefilling arrays when every slot will be overwritten
 - Avoid boolean masks and masked copies for all-valid particles
 - Broadcast CPU scalar inputs without allocating full-size temporary arrays
 - Avoid unnecessary NumPy copies and eager `particle_id` allocation
 - Skip consistency checks when input and computed value are identical
 - Replace Python-level mass-ratio iteration with vectorised checks
 - Skip unnecessary default-zeta calculations and redundant CPU reorganisation
 - Fresh CPU/CUDA buffers are already zeroed, so initialisation skips redundant zero writes for default fields, `pdg_id`, and random state; reused buffers, pyopencl, extra capacity, invalid particles, and signed -0.0 retain the original handling
 - `_update_energy_deviations` avoids unused `pzeta` calculations and reuses the already-computed `ptau` expression for `rvv`, eliminating a second square root on the physical CPU path; unusual/negative-energy inputs use the original formula
 - `_update_zeta` no longer derives `tau` unless supplied and returns immediately for defaults

Further speed gain: from 10 seconds down to 2.2 seconds.

All Xtrack tests pass on CPU; currently running CUDA tests overnight.


## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [X] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [X] I have tested also GPU contexts
